### PR TITLE
gennscar97/tes-26 subtrees creation and management

### DIFF
--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -170,6 +170,15 @@ test.describe('Behavior Tree panel', () => {
 
     await expect(page.getByTestId('bt-menu-button')).toBeVisible();
     await expect(page.getByTestId('bt-palette-toggle')).toBeVisible();
+    await expect(page.getByTestId('bt-select-mode')).toBeVisible();
+    await expect(page.getByTestId('bt-pan-mode')).toBeVisible();
+    await expect(page.getByTestId('bt-redo')).toBeDisabled();
+    await expect(page.getByTestId('bt-pan-mode')).toHaveAttribute('aria-pressed', 'true');
+
+    await page.getByTestId('bt-select-mode').click();
+    await expect(page.getByTestId('bt-select-mode')).toHaveAttribute('aria-pressed', 'true');
+    await page.getByTestId('bt-pan-mode').click();
+    await expect(page.getByTestId('bt-pan-mode')).toHaveAttribute('aria-pressed', 'true');
 
     await openNodePalette(page);
     await expect(page.getByTestId('bt-node-palette')).toBeVisible();
@@ -328,7 +337,88 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.locator('.react-flow__edge')).toHaveCount(2);
   });
 
-  test('highlights a clicked connection and its child node', async ({ page }) => {
+  test('highlights all ctrl-selected nodes and clears them with one pane click', async ({ page }) => {
+    await openBehaviorTree(page);
+    await seedOrderedSequenceTree(page);
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.locator('.bt-menu-tree-row').filter({ hasText: 'Ordered Sequence' }).click();
+
+    const firstAction = page.locator('.react-flow__node').filter({ hasText: 'First Action' });
+    const secondAction = page.locator('.react-flow__node').filter({ hasText: 'Second Action' });
+
+    await firstAction.click();
+    await page.keyboard.down('Control');
+    await secondAction.click();
+    await page.keyboard.up('Control');
+
+    await expect(page.locator('.bt-node.clicked')).toHaveCount(2);
+    await expect(firstAction.locator('.bt-node')).toHaveClass(/clicked/);
+    await expect(secondAction.locator('.bt-node')).toHaveClass(/clicked/);
+
+    await page.getByTestId('bt-canvas').click({ position: { x: 24, y: 24 } });
+
+    await expect(page.locator('.bt-node.clicked')).toHaveCount(0);
+    await expect(page.locator('.react-flow__node.selected')).toHaveCount(0);
+  });
+
+  test('wraps and explodes from the contextual selection actions', async ({ page }) => {
+    await openBehaviorTree(page);
+    await seedOrderedSequenceTree(page);
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.locator('.bt-menu-tree-row').filter({ hasText: 'Ordered Sequence' }).click();
+
+    const firstAction = page.locator('.react-flow__node').filter({ hasText: 'First Action' });
+    const secondAction = page.locator('.react-flow__node').filter({ hasText: 'Second Action' });
+
+    await firstAction.click();
+    await page.keyboard.down('Control');
+    await secondAction.click();
+    await page.keyboard.up('Control');
+
+    await expect(page.getByTestId('bt-selection-actions')).toBeVisible();
+    await expect(page.getByTestId('bt-context-wrap')).toBeVisible();
+    await page.getByTestId('bt-context-wrap').click();
+
+    const subtreeNode = page.locator('.react-flow__node').filter({ hasText: 'Subtree' });
+    await expect(subtreeNode).toHaveCount(1);
+    await expect(page.getByTestId('bt-undo')).toBeEnabled();
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Z' : 'Control+Z');
+
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(0);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'First Action' })).toHaveCount(1);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Second Action' })).toHaveCount(1);
+    await expect(page.getByTestId('bt-redo')).toBeEnabled();
+
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+Z' : 'Control+Shift+Z');
+
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(1);
+    await expect(page.getByTestId('bt-redo')).toBeDisabled();
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Z' : 'Control+Z');
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(0);
+
+    await firstAction.click();
+    await page.keyboard.down('Control');
+    await secondAction.click();
+    await page.keyboard.up('Control');
+    await page.getByTestId('bt-context-wrap').click();
+
+    await expect(subtreeNode).toHaveCount(1);
+    await expect(page.getByTestId('bt-context-open-subtree')).toBeVisible();
+    await expect(page.getByTestId('bt-context-save-subtree')).toBeVisible();
+    await expect(page.getByTestId('bt-context-explode')).toBeVisible();
+    await page.getByTestId('bt-context-explode').click();
+
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(0);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'First Action' })).toHaveCount(1);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Second Action' })).toHaveCount(1);
+    await expect(page.locator('.react-flow__edge-text').filter({ hasText: '1' })).toHaveCount(1);
+    await expect(page.locator('.react-flow__edge-text').filter({ hasText: '2' })).toHaveCount(1);
+  });
+
+  test('selects a clicked connection without keeping stale node highlights', async ({ page }) => {
     await openBehaviorTree(page);
     await seedSavedTree(page);
 
@@ -354,8 +444,42 @@ test.describe('Behavior Tree panel', () => {
     await expect(edge).toHaveClass(/selected/);
     await expect(edge.locator('.react-flow__edge-path')).toHaveCSS('stroke', 'rgb(255, 179, 0)');
     await expect(edge.locator('.react-flow__edge-path')).toHaveCSS('stroke-width', '5px');
-    await expect(child).toHaveClass(/selected/);
+    await expect(child).not.toHaveClass(/selected/);
     await expect(parent).not.toHaveClass(/selected/);
+  });
+
+  test('ctrl-selects multiple links without selecting nodes', async ({ page }) => {
+    await openBehaviorTree(page);
+    await seedOrderedSequenceTree(page);
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.locator('.bt-menu-tree-row').filter({ hasText: 'Ordered Sequence' }).click();
+
+    const sequence = page.locator('.react-flow__node').filter({ hasText: 'Sequence' });
+    const firstAction = page.locator('.react-flow__node').filter({ hasText: 'First Action' });
+    const secondAction = page.locator('.react-flow__node').filter({ hasText: 'Second Action' });
+    const sequenceBox = await sequence.boundingBox();
+    const firstBox = await firstAction.boundingBox();
+    const secondBox = await secondAction.boundingBox();
+
+    expect(sequenceBox).not.toBeNull();
+    expect(firstBox).not.toBeNull();
+    expect(secondBox).not.toBeNull();
+
+    await page.mouse.click(
+      ((sequenceBox?.x ?? 0) + (sequenceBox?.width ?? 0) / 2 + (firstBox?.x ?? 0) + (firstBox?.width ?? 0) / 2) / 2,
+      ((sequenceBox?.y ?? 0) + (sequenceBox?.height ?? 0) / 2 + (firstBox?.y ?? 0) + (firstBox?.height ?? 0) / 2) / 2
+    );
+    await page.keyboard.down('Control');
+    await page.mouse.click(
+      ((sequenceBox?.x ?? 0) + (sequenceBox?.width ?? 0) / 2 + (secondBox?.x ?? 0) + (secondBox?.width ?? 0) / 2) / 2,
+      ((sequenceBox?.y ?? 0) + (sequenceBox?.height ?? 0) / 2 + (secondBox?.y ?? 0) + (secondBox?.height ?? 0) / 2) / 2
+    );
+    await page.keyboard.up('Control');
+
+    await expect(page.locator('.react-flow__edge.selected')).toHaveCount(2);
+    await expect(page.locator('.react-flow__node.selected')).toHaveCount(0);
+    await expect(page.locator('.bt-node.clicked')).toHaveCount(0);
   });
 
   test('stacks mobile toolbar groups vertically without overlap', async ({ page }) => {
@@ -372,18 +496,16 @@ test.describe('Behavior Tree panel', () => {
     const menuButton = page.getByTestId('bt-menu-button');
     const paletteButton = page.getByTestId('bt-palette-toggle');
     const arrangeButton = page.getByTestId('bt-arrange-tree');
-    const renameButton = page.getByTestId('bt-rename-selected');
-    const duplicateButton = page.getByTestId('bt-duplicate-selected');
+    const selectionActions = page.getByTestId('bt-selection-actions');
     await expect(page.getByTestId('bt-rename-selected')).toBeVisible();
     await expect(page.getByTestId('bt-duplicate-selected')).toBeVisible();
+    await expect(selectionActions).toBeVisible();
 
     const leftBox = await leftTools.boundingBox();
     const rightBox = await rightTools.boundingBox();
     const menuBox = await menuButton.boundingBox();
     const paletteBox = await paletteButton.boundingBox();
     const arrangeBox = await arrangeButton.boundingBox();
-    const renameBox = await renameButton.boundingBox();
-    const duplicateBox = await duplicateButton.boundingBox();
 
     expect(leftBox).not.toBeNull();
     expect(rightBox).not.toBeNull();
@@ -392,8 +514,6 @@ test.describe('Behavior Tree panel', () => {
     expect(paletteBox?.x).toBe(arrangeBox?.x);
     expect(menuBox?.y ?? 0).toBeLessThan(paletteBox?.y ?? 0);
     expect(paletteBox?.y ?? 0).toBeLessThan(arrangeBox?.y ?? 0);
-    expect(renameBox?.x).toBe(duplicateBox?.x);
-    expect(renameBox?.y ?? 0).toBeLessThan(duplicateBox?.y ?? 0);
   });
 
   test('shows sequence child order and reorders children', async ({ page }) => {

--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -183,13 +183,19 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.getByTestId('bt-palette-toggle')).toBeVisible();
     await expect(page.getByTestId('bt-select-mode')).toBeVisible();
     await expect(page.getByTestId('bt-pan-mode')).toBeVisible();
+    await expect(page.getByTestId('bt-follow-mode')).toBeVisible();
     await expect(page.getByTestId('bt-redo')).toBeDisabled();
     await expect(page.getByTestId('bt-pan-mode')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('bt-follow-mode')).toHaveAttribute('aria-pressed', 'false');
 
     await page.getByTestId('bt-select-mode').click();
     await expect(page.getByTestId('bt-select-mode')).toHaveAttribute('aria-pressed', 'true');
     await page.getByTestId('bt-pan-mode').click();
     await expect(page.getByTestId('bt-pan-mode')).toHaveAttribute('aria-pressed', 'true');
+    await page.getByTestId('bt-follow-mode').click();
+    await expect(page.getByTestId('bt-follow-mode')).toHaveAttribute('aria-pressed', 'true');
+    await page.getByTestId('bt-follow-mode').click();
+    await expect(page.getByTestId('bt-follow-mode')).toHaveAttribute('aria-pressed', 'false');
 
     await openNodePalette(page);
     await expect(page.getByTestId('bt-node-palette')).toBeVisible();
@@ -524,6 +530,92 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(0);
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Selector' })).toHaveCount(1);
+  });
+
+  test('opens a saved tree as root when selected from inside a subtree', async ({ page }) => {
+    await openBehaviorTree(page);
+    await page.evaluate(() => {
+      const now = Date.now();
+      const subtreeSource = {
+        id: 'e2e-subtree-load-source',
+        name: 'Subtree Load Source',
+        nodes: [
+          {
+            id: 'node-a',
+            type: 'action',
+            position: { x: 0, y: 0 },
+            data: {
+              label: 'Source A',
+              actionName: '/source_a',
+              actionType: 'example_msgs/action/SourceA',
+              parameters: {},
+            },
+          },
+          {
+            id: 'node-b',
+            type: 'action',
+            position: { x: 260, y: 0 },
+            data: {
+              label: 'Source B',
+              actionName: '/source_b',
+              actionType: 'example_msgs/action/SourceB',
+              parameters: {},
+            },
+          },
+        ],
+        edges: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      const freshRoot = {
+        id: 'e2e-fresh-root-tree',
+        name: 'Fresh Root Tree',
+        nodes: [
+          {
+            id: 'node-root',
+            type: 'action',
+            position: { x: 0, y: 0 },
+            data: {
+              label: 'Fresh Root Action',
+              actionName: '/fresh_root',
+              actionType: 'example_msgs/action/FreshRoot',
+              parameters: {},
+            },
+          },
+        ],
+        edges: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      localStorage.setItem(
+        'robo-boy-behavior-trees',
+        JSON.stringify([
+          { tree: subtreeSource, version: '1.0.0' },
+          { tree: freshRoot, version: '1.0.0' },
+        ])
+      );
+    });
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.locator('.bt-menu-tree-row').filter({ hasText: 'Subtree Load Source' }).click();
+
+    const sourceA = page.locator('.react-flow__node').filter({ hasText: 'Source A' });
+    const sourceB = page.locator('.react-flow__node').filter({ hasText: 'Source B' });
+    await sourceA.click();
+    await page.keyboard.down('Control');
+    await sourceB.click();
+    await page.keyboard.up('Control');
+    await page.getByTestId('bt-context-wrap').click();
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(1);
+    await page.getByTestId('bt-context-open-subtree').click();
+    await expect(page.getByTestId('bt-subtree-parent')).toBeVisible();
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.locator('.bt-menu-tree-row').filter({ hasText: 'Fresh Root Tree' }).click();
+
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Fresh Root Action' })).toHaveCount(1);
+    await expect(page.getByTestId('bt-subtree-parent')).toHaveCount(0);
   });
 
   test('adds retry and repeat nodes and edits their iteration counts', async ({ page }) => {

--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -411,7 +411,7 @@ test.describe('Behavior Tree panel', () => {
     await expect(firstAction.locator('.bt-node')).toHaveClass(/clicked/);
     await expect(secondAction.locator('.bt-node')).toHaveClass(/clicked/);
 
-    await page.getByTestId('bt-canvas').click({ position: { x: 24, y: 24 } });
+    await page.getByTestId('bt-canvas').click({ position: { x: 24, y: 260 } });
 
     await expect(page.locator('.bt-node.clicked')).toHaveCount(0);
     await expect(page.locator('.react-flow__node.selected')).toHaveCount(0);

--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -361,6 +361,7 @@ test.describe('Behavior Tree panel', () => {
 
     await sequence.click();
     await multiSelectClick(selector);
+    await expect(page.locator('.bt-node.clicked')).toHaveCount(2);
 
     await expect(page.getByTestId('bt-duplicate-selected')).toBeVisible();
     await page.getByTestId('bt-duplicate-selected').click();
@@ -639,13 +640,13 @@ test.describe('Behavior Tree panel', () => {
     await expect(repeatNode).toHaveCount(1);
     await expect(repeatNode).toContainText('3 repeats');
 
-    await retryNode.click();
+    await retryNode.click({ force: true });
     await page.getByTestId('bt-configure-iteration').click();
     await page.getByLabel('Attempts').fill('-1');
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(retryNode).toContainText('Infinite');
 
-    await repeatNode.click();
+    await repeatNode.click({ force: true });
     await page.getByTestId('bt-configure-iteration').click();
     await page.getByLabel('Repeats').fill('5');
     await page.getByRole('button', { name: 'Save' }).click();

--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -1,6 +1,10 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 import { Buffer } from 'node:buffer';
 import { installRosMock } from './helpers/rosMock';
+
+const MULTI_SELECT_MODIFIER = (process.platform === 'darwin' ? 'Meta' : 'Control') as
+  | 'Meta'
+  | 'Control';
 
 async function connectWithMockRos(page: Page) {
   await installRosMock(page);
@@ -34,6 +38,20 @@ async function openNodePalette(page: Page) {
 
   await toggle.click();
   await expect(palette).toBeVisible();
+}
+
+async function closeNodePalette(page: Page) {
+  const palette = page.getByTestId('bt-node-palette');
+  if ((await palette.count()) === 0 || !(await palette.first().isVisible())) {
+    return;
+  }
+
+  await page.getByTestId('bt-palette-toggle').click();
+  await expect(palette).toHaveCount(0);
+}
+
+async function multiSelectClick(locator: Locator) {
+  await locator.click({ modifiers: [MULTI_SELECT_MODIFIER] });
 }
 
 async function seedSavedTree(page: Page) {
@@ -216,7 +234,7 @@ test.describe('Behavior Tree panel', () => {
 
     await page.getByTestId('bt-menu-button').click();
     await expect(page.getByTestId('bt-menu-panel')).toBeVisible();
-    await expect(page.getByText('Saved Trees', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('bt-menu-panel').getByText('Saved Trees', { exact: true })).toBeVisible();
   });
 
   test('renames and saves a tree into localStorage', async ({ page }) => {
@@ -342,9 +360,7 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.locator('.react-flow__edge')).toHaveCount(1);
 
     await sequence.click();
-    await page.keyboard.down('Control');
-    await selector.click();
-    await page.keyboard.up('Control');
+    await multiSelectClick(selector);
 
     await expect(page.getByTestId('bt-duplicate-selected')).toBeVisible();
     await page.getByTestId('bt-duplicate-selected').click();
@@ -365,9 +381,7 @@ test.describe('Behavior Tree panel', () => {
     const secondAction = page.locator('.react-flow__node').filter({ hasText: 'Second Action' });
 
     await firstAction.click();
-    await page.keyboard.down('Control');
-    await secondAction.click();
-    await page.keyboard.up('Control');
+    await multiSelectClick(secondAction);
 
     await expect(page.locator('.bt-node.clicked')).toHaveCount(2);
     await expect(firstAction.locator('.bt-node')).toHaveClass(/clicked/);
@@ -427,9 +441,7 @@ test.describe('Behavior Tree panel', () => {
     const secondAction = page.locator('.react-flow__node').filter({ hasText: 'Second Action' });
 
     await firstAction.click();
-    await page.keyboard.down('Control');
-    await secondAction.click();
-    await page.keyboard.up('Control');
+    await multiSelectClick(secondAction);
 
     await expect(page.getByTestId('bt-selection-actions')).toBeVisible();
     await expect(page.getByTestId('bt-context-wrap')).toBeVisible();
@@ -453,9 +465,7 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(0);
 
     await firstAction.click();
-    await page.keyboard.down('Control');
-    await secondAction.click();
-    await page.keyboard.up('Control');
+    await multiSelectClick(secondAction);
     await page.getByTestId('bt-context-wrap').click();
 
     await expect(subtreeNode).toHaveCount(1);
@@ -518,9 +528,7 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
 
     await page.locator('.react-flow__node').filter({ hasText: 'Sequence' }).click();
-    await page.keyboard.down('Control');
-    await page.locator('.react-flow__node').filter({ hasText: 'Selector' }).click();
-    await page.keyboard.up('Control');
+    await multiSelectClick(page.locator('.react-flow__node').filter({ hasText: 'Selector' }));
     await page.getByTestId('bt-context-wrap').click();
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(1);
     await page.getByTestId('bt-context-open-subtree').click();
@@ -603,9 +611,7 @@ test.describe('Behavior Tree panel', () => {
     const sourceA = page.locator('.react-flow__node').filter({ hasText: 'Source A' });
     const sourceB = page.locator('.react-flow__node').filter({ hasText: 'Source B' });
     await sourceA.click();
-    await page.keyboard.down('Control');
-    await sourceB.click();
-    await page.keyboard.up('Control');
+    await multiSelectClick(sourceB);
     await page.getByTestId('bt-context-wrap').click();
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(1);
     await page.getByTestId('bt-context-open-subtree').click();
@@ -624,6 +630,7 @@ test.describe('Behavior Tree panel', () => {
 
     await page.getByTestId('bt-node-palette').getByText('Retry').click();
     await page.getByTestId('bt-node-palette').getByText('Repeat').click();
+    await closeNodePalette(page);
 
     const retryNode = page.locator('.react-flow__node').filter({ hasText: 'Retry' });
     const repeatNode = page.locator('.react-flow__node').filter({ hasText: 'Repeat' });

--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -51,7 +51,30 @@ async function closeNodePalette(page: Page) {
 }
 
 async function multiSelectClick(locator: Locator) {
-  await locator.click({ modifiers: [MULTI_SELECT_MODIFIER] });
+  await locator.evaluate((element, modifier) => {
+    const isMeta = modifier === 'Meta';
+    element.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        pointerId: 1,
+        pointerType: 'mouse',
+        button: 0,
+        buttons: 1,
+        ctrlKey: !isMeta,
+        metaKey: isMeta,
+      })
+    );
+    element.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        ctrlKey: !isMeta,
+        metaKey: isMeta,
+      })
+    );
+  }, MULTI_SELECT_MODIFIER);
 }
 
 async function seedSavedTree(page: Page) {
@@ -646,7 +669,7 @@ test.describe('Behavior Tree panel', () => {
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(retryNode).toContainText('Infinite');
 
-    await repeatNode.click({ force: true });
+    await repeatNode.click({ position: { x: 16, y: 16 } });
     await page.getByTestId('bt-configure-iteration').click();
     await page.getByLabel('Repeats').fill('5');
     await page.getByRole('button', { name: 'Save' }).click();

--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { Buffer } from 'node:buffer';
 import { installRosMock } from './helpers/rosMock';
 
 async function connectWithMockRos(page: Page) {
@@ -156,6 +157,16 @@ async function seedOrderedSequenceTree(page: Page) {
       'robo-boy-behavior-trees',
       JSON.stringify([{ tree, version: '1.0.0' }])
     );
+  });
+}
+
+async function importTreeFromMenu(page: Page, tree: Record<string, unknown>) {
+  await page.getByTestId('bt-menu-button').click();
+  const input = page.locator('input[type="file"]');
+  await input.setInputFiles({
+    name: 'imported-tree.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify({ tree, version: '1.0.0' })),
   });
 }
 
@@ -362,6 +373,43 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.locator('.react-flow__node.selected')).toHaveCount(0);
   });
 
+  test('box-select stays active while dragging across nodes', async ({ page }) => {
+    await openBehaviorTree(page);
+    await seedOrderedSequenceTree(page);
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.locator('.bt-menu-tree-row').filter({ hasText: 'Ordered Sequence' }).click();
+
+    const firstAction = page.locator('.react-flow__node').filter({ hasText: 'First Action' });
+    const secondAction = page.locator('.react-flow__node').filter({ hasText: 'Second Action' });
+    const firstBox = await firstAction.boundingBox();
+    const secondBox = await secondAction.boundingBox();
+    const canvasBox = await page.getByTestId('bt-canvas').boundingBox();
+    expect(firstBox).not.toBeNull();
+    expect(secondBox).not.toBeNull();
+    expect(canvasBox).not.toBeNull();
+
+    const startX = Math.max((canvasBox?.x ?? 0) + 72, Math.min(firstBox?.x ?? 0, secondBox?.x ?? 0) - 36);
+    const startY = Math.max((canvasBox?.y ?? 0) + 72, Math.min(firstBox?.y ?? 0, secondBox?.y ?? 0) - 36);
+    const firstCenterX = (firstBox?.x ?? 0) + (firstBox?.width ?? 0) / 2;
+    const firstCenterY = (firstBox?.y ?? 0) + (firstBox?.height ?? 0) / 2;
+    const endX = Math.max((firstBox?.x ?? 0) + (firstBox?.width ?? 0), (secondBox?.x ?? 0) + (secondBox?.width ?? 0)) + 36;
+    const endY = Math.max((firstBox?.y ?? 0) + (firstBox?.height ?? 0), (secondBox?.y ?? 0) + (secondBox?.height ?? 0)) + 36;
+
+    await page.getByTestId('bt-select-mode').click();
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(firstCenterX, firstCenterY, { steps: 5 });
+    await expect(firstAction.locator('.bt-node')).toHaveClass(/clicked/);
+    await page.mouse.move(endX, endY, { steps: 8 });
+    await page.mouse.up();
+
+    await expect(page.locator('.bt-node.clicked')).toHaveCount(2);
+    await expect(firstAction.locator('.bt-node')).toHaveClass(/clicked/);
+    await expect(secondAction.locator('.bt-node')).toHaveClass(/clicked/);
+    await expect(page.getByTestId('bt-selection-actions')).toBeVisible();
+  });
+
   test('wraps and explodes from the contextual selection actions', async ({ page }) => {
     await openBehaviorTree(page);
     await seedOrderedSequenceTree(page);
@@ -416,6 +464,93 @@ test.describe('Behavior Tree panel', () => {
     await expect(page.locator('.react-flow__node').filter({ hasText: 'Second Action' })).toHaveCount(1);
     await expect(page.locator('.react-flow__edge-text').filter({ hasText: '1' })).toHaveCount(1);
     await expect(page.locator('.react-flow__edge-text').filter({ hasText: '2' })).toHaveCount(1);
+  });
+
+  test('undoes loading, creating, importing, and subtree-path changes safely', async ({ page }) => {
+    await openBehaviorTree(page);
+    await seedSavedTree(page);
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.locator('.bt-menu-tree-row').filter({ hasText: 'Duplicate Source' }).click();
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
+
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Z' : 'Control+Z');
+    await expect(page.locator('.react-flow__node')).toHaveCount(0);
+    await expect(page.getByTestId('bt-redo')).toBeEnabled();
+
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+Z' : 'Control+Shift+Z');
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
+
+    await page.getByTestId('bt-menu-button').click();
+    await page.getByRole('button', { name: 'New' }).click();
+    await expect(page.locator('.react-flow__node')).toHaveCount(0);
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Z' : 'Control+Z');
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
+
+    const now = Date.now();
+    await importTreeFromMenu(page, {
+      id: 'e2e-imported-tree',
+      name: 'Imported Tree',
+      nodes: [
+        {
+          id: 'node-imported',
+          type: 'action',
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Imported Action',
+            actionName: '/imported',
+            actionType: 'example_msgs/action/Imported',
+          },
+        },
+      ],
+      edges: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Imported Action' })).toHaveCount(1);
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Z' : 'Control+Z');
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
+
+    await page.locator('.react-flow__node').filter({ hasText: 'Sequence' }).click();
+    await page.keyboard.down('Control');
+    await page.locator('.react-flow__node').filter({ hasText: 'Selector' }).click();
+    await page.keyboard.up('Control');
+    await page.getByTestId('bt-context-wrap').click();
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(1);
+    await page.getByTestId('bt-context-open-subtree').click();
+    await expect(page.getByTestId('bt-subtree-parent')).toBeVisible();
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Z' : 'Control+Z');
+    await expect(page.getByTestId('bt-subtree-parent')).toHaveCount(0);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Subtree' })).toHaveCount(0);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Sequence' })).toHaveCount(1);
+    await expect(page.locator('.react-flow__node').filter({ hasText: 'Selector' })).toHaveCount(1);
+  });
+
+  test('adds retry and repeat nodes and edits their iteration counts', async ({ page }) => {
+    await openBehaviorTree(page);
+    await openNodePalette(page);
+
+    await page.getByTestId('bt-node-palette').getByText('Retry').click();
+    await page.getByTestId('bt-node-palette').getByText('Repeat').click();
+
+    const retryNode = page.locator('.react-flow__node').filter({ hasText: 'Retry' });
+    const repeatNode = page.locator('.react-flow__node').filter({ hasText: 'Repeat' });
+    await expect(retryNode).toHaveCount(1);
+    await expect(retryNode).toContainText('3 attempts');
+    await expect(repeatNode).toHaveCount(1);
+    await expect(repeatNode).toContainText('3 repeats');
+
+    await retryNode.click();
+    await page.getByTestId('bt-configure-iteration').click();
+    await page.getByLabel('Attempts').fill('-1');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(retryNode).toContainText('Infinite');
+
+    await repeatNode.click();
+    await page.getByTestId('bt-configure-iteration').click();
+    await page.getByLabel('Repeats').fill('5');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(repeatNode).toContainText('5 repeats');
   });
 
   test('selects a clicked connection without keeping stale node highlights', async ({ page }) => {

--- a/src/features/behaviorTree/components/BehaviorTreePanel.css
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.css
@@ -440,6 +440,15 @@
   border: 1px solid var(--primary-color, #4285f4);
 }
 
+.bt-custom-selection {
+  position: absolute;
+  z-index: 18;
+  box-sizing: border-box;
+  background: rgba(66, 133, 244, 0.08);
+  border: 1px solid var(--primary-color, #4285f4);
+  pointer-events: none;
+}
+
 .react-flow__nodesselection-rect {
   display: none;
 }
@@ -505,6 +514,42 @@
   color: #ffffff;
 }
 
+.bt-subtree-parent-action {
+  position: absolute;
+  z-index: 24;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 12px;
+  border: 1px solid color-mix(in srgb, var(--primary-color, #4285f4) 34%, var(--border-color, #e0e0e0));
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--card-bg, #ffffff) 95%, transparent);
+  color: var(--primary-color, #4285f4);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.13);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  backdrop-filter: blur(10px);
+  transition: background 0.16s ease, color 0.16s ease, transform 0.16s ease;
+}
+
+.bt-subtree-parent-action svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.bt-subtree-parent-action:hover,
+.bt-subtree-parent-action:focus-visible {
+  background: var(--primary-color, #4285f4);
+  color: #ffffff;
+  outline: none;
+  transform: translateY(-1px);
+}
+
 /* Panel placeholder when empty */
 .bt-empty-state {
   position: absolute;
@@ -529,6 +574,35 @@
   padding: 16px;
   box-sizing: border-box;
   background: rgba(0, 0, 0, 0.24);
+}
+
+.bt-iteration-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.24);
+}
+
+.bt-iteration-dialog {
+  width: min(380px, 100%);
+  padding: 20px;
+  box-sizing: border-box;
+  background: var(--card-bg, #ffffff);
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 12px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.2);
+}
+
+.bt-iteration-help {
+  margin: 8px 0 22px;
+  color: var(--text-color-secondary, #777777);
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .bt-node-name-dialog {

--- a/src/features/behaviorTree/components/BehaviorTreePanel.css
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.css
@@ -517,28 +517,29 @@
 .bt-subtree-parent-action {
   position: absolute;
   z-index: 24;
-  height: 36px;
+  min-width: 108px;
+  height: 42px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
-  padding: 0 12px;
+  gap: 8px;
+  padding: 0 14px;
   border: 1px solid color-mix(in srgb, var(--primary-color, #4285f4) 34%, var(--border-color, #e0e0e0));
-  border-radius: 18px;
+  border-radius: 21px;
   background: color-mix(in srgb, var(--card-bg, #ffffff) 95%, transparent);
   color: var(--primary-color, #4285f4);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.13);
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 800;
   backdrop-filter: blur(10px);
   transition: background 0.16s ease, color 0.16s ease, transform 0.16s ease;
 }
 
 .bt-subtree-parent-action svg {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
 }
 

--- a/src/features/behaviorTree/components/BehaviorTreePanel.css
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.css
@@ -440,6 +440,71 @@
   border: 1px solid var(--primary-color, #4285f4);
 }
 
+.react-flow__nodesselection-rect {
+  display: none;
+}
+
+.bt-selection-actions {
+  position: absolute;
+  z-index: 25;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 5px;
+  max-width: min(360px, calc(100% - 16px));
+  padding: 6px;
+  border: 1px solid color-mix(in srgb, var(--success-color, #4caf50) 34%, var(--border-color, #e0e0e0));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--card-bg, #ffffff) 94%, transparent);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+  backdrop-filter: blur(10px);
+}
+
+.bt-selection-action {
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 11px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-color, #333333);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  transition: background 0.16s ease, color 0.16s ease, transform 0.16s ease;
+}
+
+.bt-selection-action svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.bt-selection-action:hover,
+.bt-selection-action:focus-visible {
+  background: var(--success-color, #4caf50);
+  color: #ffffff;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.bt-selection-action.danger {
+  color: var(--error-color, #f44336);
+}
+
+.bt-selection-action.danger:hover,
+.bt-selection-action.danger:focus-visible {
+  background: var(--error-color, #f44336);
+  color: #ffffff;
+}
+
 /* Panel placeholder when empty */
 .bt-empty-state {
   position: absolute;

--- a/src/features/behaviorTree/components/BehaviorTreePanel.css
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.css
@@ -517,29 +517,28 @@
 .bt-subtree-parent-action {
   position: absolute;
   z-index: 24;
-  min-width: 108px;
-  height: 42px;
+  height: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 0 14px;
+  gap: 7px;
+  padding: 0 12px;
   border: 1px solid color-mix(in srgb, var(--primary-color, #4285f4) 34%, var(--border-color, #e0e0e0));
-  border-radius: 21px;
+  border-radius: 18px;
   background: color-mix(in srgb, var(--card-bg, #ffffff) 95%, transparent);
   color: var(--primary-color, #4285f4);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.13);
   cursor: pointer;
   font: inherit;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 800;
   backdrop-filter: blur(10px);
   transition: background 0.16s ease, color 0.16s ease, transform 0.16s ease;
 }
 
 .bt-subtree-parent-action svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
 }
 

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -7,8 +7,7 @@ const reactFlowMock = vi.hoisted(() => ({
   render: vi.fn(),
   nodes: [] as Array<Record<string, unknown>>,
   edges: [] as Array<Record<string, unknown>>,
-  setNodes: vi.fn(),
-  setEdges: vi.fn(),
+  setCenter: vi.fn(),
 }));
 
 vi.mock('reactflow', () => ({
@@ -23,12 +22,13 @@ vi.mock('reactflow', () => ({
   BackgroundVariant: { Dots: 'dots' },
   ConnectionMode: { Loose: 'loose' },
   addEdge: vi.fn((_edge, edges) => edges),
-  useNodesState: () => [reactFlowMock.nodes, reactFlowMock.setNodes, vi.fn()],
-  useEdgesState: () => [reactFlowMock.edges, reactFlowMock.setEdges, vi.fn()],
+  applyNodeChanges: vi.fn((_changes, nodes) => nodes),
+  applyEdgeChanges: vi.fn((_changes, edges) => edges),
   useReactFlow: () => ({
     screenToFlowPosition: (position: { x: number; y: number }) => position,
-    deleteElements: vi.fn(),
     fitView: vi.fn(),
+    getZoom: () => 1,
+    setCenter: reactFlowMock.setCenter,
   }),
 }));
 
@@ -37,8 +37,7 @@ describe('BehaviorTreePanel', () => {
     reactFlowMock.render.mockClear();
     reactFlowMock.nodes = [];
     reactFlowMock.edges = [];
-    reactFlowMock.setNodes.mockReset();
-    reactFlowMock.setEdges.mockReset();
+    reactFlowMock.setCenter.mockReset();
   });
 
   it('does not open the node palette until the user toggles it', () => {
@@ -65,7 +64,7 @@ describe('BehaviorTreePanel', () => {
     expect(screen.getByRole('button', { name: 'Arrange tree' })).toBeInTheDocument();
   });
 
-  it('selects a clicked edge and the child node it points to', () => {
+  it('handles an edge click without crashing', () => {
     reactFlowMock.nodes = [
       { id: 'parent', position: { x: 0, y: 0 }, data: {}, selected: true },
       { id: 'child', position: { x: 0, y: 100 }, data: {}, selected: false },
@@ -83,16 +82,6 @@ describe('BehaviorTreePanel', () => {
     act(() => {
       props.onEdgeClick({} as React.MouseEvent, reactFlowMock.edges[0]);
     });
-
-    const updateNodes = reactFlowMock.setNodes.mock.calls[0][0];
-    const updateEdges = reactFlowMock.setEdges.mock.calls[0][0];
-    expect(updateNodes(reactFlowMock.nodes)).toEqual([
-      expect.objectContaining({ id: 'parent', selected: false }),
-      expect.objectContaining({ id: 'child', selected: true }),
-    ]);
-    expect(updateEdges(reactFlowMock.edges)).toEqual([
-      expect.objectContaining({ id: 'edge-1', selected: true }),
-      expect.objectContaining({ id: 'edge-2', selected: false }),
-    ]);
+    expect(reactFlowMock.render).toHaveBeenCalled();
   });
 });

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -36,13 +36,25 @@ const createRect = (x: number, y: number, width: number, height: number): DOMRec
 
 vi.mock('../engine/executor', () => ({
   BehaviorTreeExecutor: vi.fn().mockImplementation(
-    (_tree: unknown, _ros: unknown, callback: (event: Record<string, unknown>) => void) => {
+    function MockBehaviorTreeExecutor(
+      this: {
+        start: ReturnType<typeof vi.fn>;
+        stop: ReturnType<typeof vi.fn>;
+        callback: (event: Record<string, unknown>) => void;
+      },
+      _tree: unknown,
+      _ros: unknown,
+      callback: (event: Record<string, unknown>) => void
+    ) {
       const instance = {
         start: vi.fn(),
         stop: vi.fn(),
         callback,
       };
       executorMock.instances.push(instance);
+      this.start = instance.start;
+      this.stop = instance.stop;
+      this.callback = instance.callback;
       return instance;
     }
   ),
@@ -1573,10 +1585,19 @@ describe('BehaviorTreePanel', () => {
 
     render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
     fireEvent.click(screen.getByTestId('bt-select-mode'));
+    await waitFor(() => expect(screen.getByTestId('bt-select-mode')).toHaveAttribute('aria-pressed', 'true'));
     fireEvent.click(screen.getByTestId('bt-menu-button'));
     fireEvent.click(screen.getByText('Early End Tree'));
 
     await screen.findByTestId('rf-node-node-a');
+    await waitFor(() => {
+      expect(reactFlowMock.render.mock.lastCall?.[0]).toEqual(
+        expect.objectContaining({
+          panOnDrag: false,
+          selectionOnDrag: false,
+        })
+      );
+    });
     const flow = screen.getByTestId('mock-react-flow');
     fireEvent.pointerDown(flow, {
       pointerId: 1,

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -43,7 +43,7 @@ vi.mock('reactflow', () => ({
   }) => {
     reactFlowMock.render(props);
     return (
-      <div data-testid="mock-react-flow">
+      <div data-testid="mock-react-flow" className="react-flow react-flow__pane">
         {props.nodes?.map((node) => (
           <button
             key={node.id}
@@ -219,7 +219,7 @@ describe('BehaviorTreePanel', () => {
     expect(reactFlowMock.render.mock.lastCall?.[0]).toEqual(
       expect.objectContaining({
         panOnDrag: false,
-        selectionOnDrag: true,
+        selectionOnDrag: false,
       })
     );
     expect(screen.getByTestId('bt-select-mode')).toHaveAttribute('aria-pressed', 'true');
@@ -483,6 +483,226 @@ describe('BehaviorTreePanel', () => {
       expect(latestProps.nodes.some((node) => node.type === 'subtree')).toBe(true);
       expect(screen.getByTestId('bt-redo')).toBeDisabled();
     });
+  });
+
+  it('restores the previous root tree after loading a saved tree and undoing', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'loaded-tree',
+            name: 'Loaded Tree',
+            nodes: [
+              {
+                id: 'node-loaded',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Loaded Action', actionName: '/loaded', actionType: 'example/Loaded' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Loaded Tree'));
+
+    await screen.findByTestId('rf-node-node-loaded');
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes).toHaveLength(0);
+    });
+    expect(screen.getByTestId('bt-redo')).toBeEnabled();
+  });
+
+  it('restores the previous tree after creating a new tree and undoing', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'new-undo-source',
+            name: 'New Undo Source',
+            nodes: [
+              {
+                id: 'node-existing',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Existing Action', actionName: '/existing', actionType: 'example/Existing' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('New Undo Source'));
+    await screen.findByTestId('rf-node-node-existing');
+
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('New'));
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes).toHaveLength(0);
+    });
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.map((node) => node.id)).toContain('node-existing');
+    });
+  });
+
+  it('undoes a newly created subtree from inside that subtree without leaving a broken path', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'subtree-path-undo',
+            name: 'Subtree Path Undo',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Subtree Path Undo'));
+
+    const nodeA = await screen.findByTestId('rf-node-node-a');
+    const nodeB = await screen.findByTestId('rf-node-node-b');
+    fireEvent.click(nodeA);
+    fireEvent.click(nodeB, { ctrlKey: true });
+
+    await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-wrap'));
+    await waitFor(() => expect(screen.getByTestId('bt-context-open-subtree')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-open-subtree'));
+    await waitFor(() => expect(screen.getByTestId('bt-subtree-parent')).toBeInTheDocument());
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.map((node) => node.id)).toEqual(expect.arrayContaining(['node-a', 'node-b']));
+      expect(latestProps.nodes.some((node) => node.type === 'subtree')).toBe(false);
+    });
+    expect(screen.queryByTestId('bt-subtree-parent')).not.toBeInTheDocument();
+  });
+
+  it('keeps the active subtree path when undoing an edit made inside the subtree', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'subtree-edit-undo',
+            name: 'Subtree Edit Undo',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Subtree Edit Undo'));
+
+    const nodeA = await screen.findByTestId('rf-node-node-a');
+    const nodeB = await screen.findByTestId('rf-node-node-b');
+    fireEvent.click(nodeA);
+    fireEvent.click(nodeB, { ctrlKey: true });
+    await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-wrap'));
+    await waitFor(() => expect(screen.getByTestId('bt-context-open-subtree')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-open-subtree'));
+    await waitFor(() => expect(screen.getByTestId('bt-subtree-parent')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('bt-palette-toggle'));
+    fireEvent.click(screen.getByText('Retry'));
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.some((node) => node.type === 'retry')).toBe(true);
+    });
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.map((node) => node.id)).toEqual(expect.arrayContaining(['node-a', 'node-b']));
+      expect(latestProps.nodes).toHaveLength(2);
+      expect(latestProps.nodes.some((node) => node.type === 'retry')).toBe(false);
+    });
+    expect(screen.getByTestId('bt-subtree-parent')).toBeInTheDocument();
   });
 
   it('does not keep a box-selected edge unless both endpoint nodes are selected', async () => {
@@ -1077,5 +1297,142 @@ describe('BehaviorTreePanel', () => {
 
     expect(screen.queryByTestId('bt-duplicate-selected')).not.toBeInTheDocument();
     await waitFor(() => expect(nodeA).toHaveAttribute('data-highlighted', 'false'));
+  });
+
+  it('keeps custom box selection alive while dragging across nodes', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'early-end-tree',
+            name: 'Early End Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+    reactFlowMock.nodeRects = {
+      'node-a': createRect(30, 30, 100, 70),
+      'node-b': createRect(210, 45, 100, 70),
+    };
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-select-mode'));
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Early End Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const flow = screen.getByTestId('mock-react-flow');
+    fireEvent.pointerDown(flow, {
+      pointerId: 1,
+      pointerType: 'mouse',
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(flow, {
+      pointerId: 1,
+      pointerType: 'mouse',
+      clientX: 95,
+      clientY: 80,
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.find((node) => node.id === 'node-a')?.data?.isHighlighted).toBe(true);
+      expect(latestProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).not.toBe(true);
+    });
+    expect(screen.getByTestId('bt-custom-selection')).toBeInTheDocument();
+
+    fireEvent.pointerMove(flow, {
+      pointerId: 1,
+      pointerType: 'mouse',
+      clientX: 340,
+      clientY: 140,
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.find((node) => node.id === 'node-a')?.data?.isHighlighted).toBe(true);
+      expect(latestProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).toBe(true);
+    });
+
+    fireEvent.pointerUp(flow, {
+      pointerId: 1,
+      pointerType: 'mouse',
+      clientX: 340,
+      clientY: 140,
+    });
+    await waitFor(() => expect(screen.getByTestId('bt-selection-actions')).toBeInTheDocument());
+    expect(screen.queryByTestId('bt-custom-selection')).not.toBeInTheDocument();
+  });
+
+  it('edits retry and repeat counts from the contextual action', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'iteration-tree',
+            name: 'Iteration Tree',
+            nodes: [
+              {
+                id: 'node-retry',
+                type: 'retry',
+                position: { x: 0, y: 0 },
+                data: { label: 'Retry', type: 'retry', iterationLimit: 3 },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Iteration Tree'));
+
+    const retryNode = await screen.findByTestId('rf-node-node-retry');
+    fireEvent.click(retryNode);
+
+    await waitFor(() => expect(screen.getByTestId('bt-configure-iteration')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-configure-iteration'));
+    fireEvent.change(screen.getByLabelText('Attempts'), { target: { value: '-1' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.find((node) => node.id === 'node-retry')?.data?.iterationLimit).toBe(-1);
+    });
   });
 });

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -34,6 +34,38 @@ const createRect = (x: number, y: number, width: number, height: number): DOMRec
   toJSON: () => ({}),
 } as DOMRect);
 
+const firePointerEvent = (
+  element: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+  init: {
+    pointerId?: number;
+    pointerType?: string;
+    button?: number;
+    buttons?: number;
+    clientX: number;
+    clientY: number;
+  }
+) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const eventInit = {
+    pointerId: 1,
+    pointerType: 'mouse',
+    button: 0,
+    buttons: type === 'pointerup' || type === 'pointercancel' ? 0 : 1,
+    ...init,
+  };
+
+  Object.entries(eventInit).forEach(([key, value]) => {
+    Object.defineProperty(event, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+    });
+  });
+
+  fireEvent(element, event);
+};
+
 vi.mock('../engine/executor', () => ({
   BehaviorTreeExecutor: vi.fn().mockImplementation(
     function MockBehaviorTreeExecutor(
@@ -694,7 +726,8 @@ describe('BehaviorTreePanel', () => {
     fireEvent.click(screen.getByText('Loaded Tree'));
 
     await screen.findByTestId('rf-node-node-loaded');
-    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    await waitFor(() => expect(screen.getByTestId('bt-undo')).not.toBeDisabled());
+    fireEvent.click(screen.getByTestId('bt-undo'));
 
     await waitFor(() => {
       const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
@@ -870,7 +903,8 @@ describe('BehaviorTreePanel', () => {
       expect(latestProps.nodes.some((node) => node.type === 'retry')).toBe(true);
     });
 
-    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    await waitFor(() => expect(screen.getByTestId('bt-undo')).not.toBeDisabled());
+    fireEvent.click(screen.getByTestId('bt-undo'));
 
     await waitFor(() => {
       const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
@@ -1600,16 +1634,11 @@ describe('BehaviorTreePanel', () => {
       );
     });
     const flow = screen.getByTestId('mock-react-flow');
-    fireEvent.pointerDown(flow, {
-      pointerId: 1,
-      pointerType: 'mouse',
-      button: 0,
+    firePointerEvent(flow, 'pointerdown', {
       clientX: 40,
       clientY: 40,
     });
-    fireEvent.pointerMove(flow, {
-      pointerId: 1,
-      pointerType: 'mouse',
+    firePointerEvent(flow, 'pointermove', {
       clientX: 190,
       clientY: 160,
     });
@@ -1623,9 +1652,7 @@ describe('BehaviorTreePanel', () => {
     });
     expect(screen.getByTestId('bt-custom-selection')).toBeInTheDocument();
 
-    fireEvent.pointerMove(flow, {
-      pointerId: 1,
-      pointerType: 'mouse',
+    firePointerEvent(flow, 'pointermove', {
       clientX: 390,
       clientY: 190,
     });
@@ -1638,9 +1665,7 @@ describe('BehaviorTreePanel', () => {
       expect(latestProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).toBe(true);
     });
 
-    fireEvent.pointerUp(flow, {
-      pointerId: 1,
-      pointerType: 'mouse',
+    firePointerEvent(flow, 'pointerup', {
       clientX: 390,
       clientY: 190,
     });

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import BehaviorTreePanel from './BehaviorTreePanel';
 
@@ -7,13 +7,123 @@ const reactFlowMock = vi.hoisted(() => ({
   render: vi.fn(),
   nodes: [] as Array<Record<string, unknown>>,
   edges: [] as Array<Record<string, unknown>>,
+  nodeRects: {} as Record<string, DOMRect>,
+  edgeRects: {} as Record<string, DOMRect>,
+  selectionRect: null as DOMRect | null,
   setCenter: vi.fn(),
+  fitView: vi.fn(),
 }));
 
+const createRect = (x: number, y: number, width: number, height: number): DOMRect => ({
+  x,
+  y,
+  width,
+  height,
+  left: x,
+  top: y,
+  right: x + width,
+  bottom: y + height,
+  toJSON: () => ({}),
+} as DOMRect);
+
 vi.mock('reactflow', () => ({
-  default: (props: { children?: React.ReactNode }) => {
+  default: (props: {
+    children?: React.ReactNode;
+    nodes?: Array<Record<string, any>>;
+    edges?: Array<Record<string, any>>;
+    onNodeClick?: (event: React.MouseEvent, node: Record<string, any>) => void;
+    onNodesChange?: (changes: Array<Record<string, any>>) => void;
+    onEdgesChange?: (changes: Array<Record<string, any>>) => void;
+    onSelectionStart?: () => void;
+    onSelectionEnd?: () => void;
+    onSelectionChange?: (selection: {
+      nodes: Array<Record<string, any>>;
+      edges: Array<Record<string, any>>;
+    }) => void;
+  }) => {
     reactFlowMock.render(props);
-    return <div data-testid="mock-react-flow">{props.children}</div>;
+    return (
+      <div data-testid="mock-react-flow">
+        {props.nodes?.map((node) => (
+          <button
+            key={node.id}
+            type="button"
+            data-testid={`rf-node-${node.id}`}
+            data-id={node.id}
+            data-highlighted={node.data?.isHighlighted ? 'true' : 'false'}
+            data-selected={node.selected ? 'true' : 'false'}
+            className={`react-flow__node${node.selected ? ' selected' : ''}`}
+            ref={(element) => {
+              const rect = reactFlowMock.nodeRects[node.id];
+              if (element && rect) element.getBoundingClientRect = () => rect;
+            }}
+            onClick={(event) => {
+              const isMultiSelect = event.ctrlKey || event.metaKey;
+              const selectedNodeIds = new Set<string>();
+
+              if (isMultiSelect) {
+                props.nodes?.forEach((candidate) => {
+                  if (candidate.selected) selectedNodeIds.add(candidate.id);
+                });
+                if (node.selected) {
+                  selectedNodeIds.delete(node.id);
+                } else {
+                  selectedNodeIds.add(node.id);
+                }
+                props.onNodesChange?.([
+                  { id: node.id, type: 'select', selected: !node.selected },
+                ]);
+              } else {
+                selectedNodeIds.add(node.id);
+                props.onNodesChange?.(
+                  props.nodes?.map((candidate) => ({
+                    id: candidate.id,
+                    type: 'select',
+                    selected: candidate.id === node.id,
+                  })) ?? []
+                );
+                props.onEdgesChange?.(
+                  props.edges
+                    ?.filter((edge) => edge.selected)
+                    .map((edge) => ({ id: edge.id, type: 'select', selected: false })) ?? []
+                );
+              }
+
+              props.onNodeClick?.(event, node);
+              props.onSelectionChange?.({
+                nodes: props.nodes?.filter((candidate) => selectedNodeIds.has(candidate.id)) ?? [],
+                edges: [],
+              });
+            }}
+          >
+            {node.data?.label ?? node.id}
+          </button>
+        ))}
+        {props.edges?.map((edge) => (
+          <div
+            key={edge.id}
+            data-testid={`rf__edge-${edge.id}`}
+            data-id={edge.id}
+            className={`react-flow__edge${edge.selected ? ' selected' : ''}`}
+            ref={(element) => {
+              const rect = reactFlowMock.edgeRects[edge.id];
+              if (element && rect) element.getBoundingClientRect = () => rect;
+            }}
+          />
+        ))}
+        {reactFlowMock.selectionRect && (
+          <div
+            className="react-flow__selection"
+            ref={(element) => {
+              if (element && reactFlowMock.selectionRect) {
+                element.getBoundingClientRect = () => reactFlowMock.selectionRect as DOMRect;
+              }
+            }}
+          />
+        )}
+        {props.children}
+      </div>
+    );
   },
   ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Background: () => null,
@@ -21,12 +131,31 @@ vi.mock('reactflow', () => ({
   MiniMap: () => null,
   BackgroundVariant: { Dots: 'dots' },
   ConnectionMode: { Loose: 'loose' },
+  SelectionMode: { Partial: 'partial' },
   addEdge: vi.fn((_edge, edges) => edges),
-  applyNodeChanges: vi.fn((_changes, nodes) => nodes),
-  applyEdgeChanges: vi.fn((_changes, edges) => edges),
+  applyNodeChanges: vi.fn((changes, nodes) =>
+    nodes.map((node: Record<string, any>) => {
+      const selectChange = changes.find(
+        (change: Record<string, any>) => change.type === 'select' && change.id === node.id
+      );
+      return selectChange
+        ? { ...node, selected: selectChange.selected }
+        : node;
+    })
+  ),
+  applyEdgeChanges: vi.fn((changes, edges) =>
+    edges.map((edge: Record<string, any>) => {
+      const selectChange = changes.find(
+        (change: Record<string, any>) => change.type === 'select' && change.id === edge.id
+      );
+      return selectChange
+        ? { ...edge, selected: selectChange.selected }
+        : edge;
+    })
+  ),
   useReactFlow: () => ({
     screenToFlowPosition: (position: { x: number; y: number }) => position,
-    fitView: vi.fn(),
+    fitView: reactFlowMock.fitView,
     getZoom: () => 1,
     setCenter: reactFlowMock.setCenter,
   }),
@@ -37,7 +166,12 @@ describe('BehaviorTreePanel', () => {
     reactFlowMock.render.mockClear();
     reactFlowMock.nodes = [];
     reactFlowMock.edges = [];
+    reactFlowMock.nodeRects = {};
+    reactFlowMock.edgeRects = {};
+    reactFlowMock.selectionRect = null;
     reactFlowMock.setCenter.mockReset();
+    reactFlowMock.fitView.mockReset();
+    localStorage.clear();
   });
 
   it('does not open the node palette until the user toggles it', () => {
@@ -54,7 +188,13 @@ describe('BehaviorTreePanel', () => {
     render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
 
     expect(reactFlowMock.render).toHaveBeenCalledWith(
-      expect.objectContaining({ connectionRadius: 48 })
+      expect.objectContaining({
+        connectionRadius: 48,
+        selectionMode: 'partial',
+        multiSelectionKeyCode: ['Control', 'Meta'],
+        panOnDrag: true,
+        selectionOnDrag: false,
+      })
     );
   });
 
@@ -62,6 +202,37 @@ describe('BehaviorTreePanel', () => {
     render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
 
     expect(screen.getByRole('button', { name: 'Arrange tree' })).toBeInTheDocument();
+  });
+
+  it('switches between pan and box-select canvas modes', () => {
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+
+    expect(reactFlowMock.render.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        panOnDrag: true,
+        selectionOnDrag: false,
+      })
+    );
+
+    fireEvent.click(screen.getByTestId('bt-select-mode'));
+
+    expect(reactFlowMock.render.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        panOnDrag: false,
+        selectionOnDrag: true,
+      })
+    );
+    expect(screen.getByTestId('bt-select-mode')).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByTestId('bt-pan-mode'));
+
+    expect(reactFlowMock.render.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        panOnDrag: true,
+        selectionOnDrag: false,
+      })
+    );
+    expect(screen.getByTestId('bt-pan-mode')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('handles an edge click without crashing', () => {
@@ -83,5 +254,828 @@ describe('BehaviorTreePanel', () => {
       props.onEdgeClick({} as React.MouseEvent, reactFlowMock.edges[0]);
     });
     expect(reactFlowMock.render).toHaveBeenCalled();
+  });
+
+  it('keeps multiple nodes highlighted after Ctrl-click selection', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'ctrl-selection-tree',
+            name: 'Ctrl Selection Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Ctrl Selection Tree'));
+
+    const nodeA = await screen.findByTestId('rf-node-node-a');
+    const nodeB = await screen.findByTestId('rf-node-node-b');
+
+    fireEvent.click(nodeA);
+    await waitFor(() => expect(nodeA).toHaveAttribute('data-highlighted', 'true'));
+
+    fireEvent.click(nodeB, { ctrlKey: true });
+
+    await waitFor(() => {
+      expect(nodeA).toHaveAttribute('data-highlighted', 'true');
+      expect(nodeB).toHaveAttribute('data-highlighted', 'true');
+    });
+  });
+
+  it('centers a saved tree after opening it', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'center-tree',
+            name: 'Center Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 840, y: 620 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Center Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    await waitFor(() => {
+      expect(reactFlowMock.fitView).toHaveBeenCalledWith(
+        expect.objectContaining({ padding: 0.22, maxZoom: 1.1 })
+      );
+    });
+  });
+
+  it('keeps the selected node layout inside a wrapped subtree', async () => {
+    const now = Date.now();
+    const nodeAPosition = { x: 37, y: 123 };
+    const nodeBPosition = { x: 312, y: -48 };
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'wrap-layout-tree',
+            name: 'Wrap Layout Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: nodeAPosition,
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: nodeBPosition,
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Wrap Layout Tree'));
+
+    const nodeA = await screen.findByTestId('rf-node-node-a');
+    const nodeB = await screen.findByTestId('rf-node-node-b');
+    fireEvent.click(nodeA);
+    fireEvent.click(nodeB, { ctrlKey: true });
+
+    await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-wrap'));
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      const subtreeNode = latestProps.nodes.find((node) => node.type === 'subtree');
+      expect(subtreeNode).toBeTruthy();
+      const embeddedNodes = subtreeNode?.data?.tree?.nodes as Array<Record<string, any>>;
+      const anchor = {
+        x: (nodeAPosition.x + nodeBPosition.x) / 2,
+        y: (nodeAPosition.y + nodeBPosition.y) / 2,
+      };
+      expect(embeddedNodes.find((node) => node.id === 'node-a')?.position).toEqual({
+        x: nodeAPosition.x - anchor.x,
+        y: nodeAPosition.y - anchor.y,
+      });
+      expect(embeddedNodes.find((node) => node.id === 'node-b')?.position).toEqual({
+        x: nodeBPosition.x - anchor.x,
+        y: nodeBPosition.y - anchor.y,
+      });
+    });
+  });
+
+  it('undoes and redoes subtree wrapping with keyboard shortcuts', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'redo-wrap-tree',
+            name: 'Redo Wrap Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    expect(screen.getByTestId('bt-redo')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Redo Wrap Tree'));
+
+    const nodeA = await screen.findByTestId('rf-node-node-a');
+    const nodeB = await screen.findByTestId('rf-node-node-b');
+    fireEvent.click(nodeA);
+    fireEvent.click(nodeB, { ctrlKey: true });
+
+    await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-wrap'));
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.some((node) => node.type === 'subtree')).toBe(true);
+    });
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.some((node) => node.type === 'subtree')).toBe(false);
+      expect(screen.getByTestId('bt-redo')).toBeEnabled();
+    });
+
+    fireEvent.keyDown(window, { key: 'Z', ctrlKey: true, shiftKey: true });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.some((node) => node.type === 'subtree')).toBe(true);
+      expect(screen.getByTestId('bt-redo')).toBeDisabled();
+    });
+  });
+
+  it('does not keep a box-selected edge unless both endpoint nodes are selected', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'partial-edge-tree',
+            name: 'Partial Edge Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'sequence',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', type: 'sequence' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [{ id: 'edge-a-b', source: 'node-a', target: 'node-b', animated: true }],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Partial Edge Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      nodes: Array<Record<string, any>>;
+      edges: Array<Record<string, any>>;
+      onSelectionStart: () => void;
+      onSelectionChange: (selection: {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      }) => void;
+    };
+    const nodeA = props.nodes.find((node) => node.id === 'node-a');
+    const edge = props.edges.find((candidate) => candidate.id === 'edge-a-b');
+    expect(nodeA).toBeTruthy();
+    expect(edge).toBeTruthy();
+
+    act(() => {
+      props.onSelectionStart();
+      props.onSelectionChange({ nodes: [nodeA as Record<string, any>], edges: [edge as Record<string, any>] });
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        edges: Array<Record<string, any>>;
+      };
+      expect(latestProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).not.toBe(true);
+    });
+  });
+
+  it('keeps only geometrically enclosed links when the selection box is measurable', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'geometry-edge-tree',
+            name: 'Geometry Edge Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'sequence',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', type: 'sequence' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+              {
+                id: 'node-c',
+                type: 'action',
+                position: { x: 440, y: 0 },
+                data: { label: 'Node C', actionName: '/c', actionType: 'example/C' },
+              },
+            ],
+            edges: [
+              { id: 'edge-a-b', source: 'node-a', target: 'node-b', animated: true },
+              { id: 'edge-a-c', source: 'node-a', target: 'node-c', animated: true },
+            ],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+    reactFlowMock.selectionRect = createRect(0, 0, 100, 100);
+    reactFlowMock.edgeRects = {
+      'edge-a-b': createRect(20, 20, 40, 30),
+      'edge-a-c': createRect(20, 20, 160, 30),
+    };
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Geometry Edge Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      nodes: Array<Record<string, any>>;
+      edges: Array<Record<string, any>>;
+      onSelectionStart: () => void;
+      onSelectionChange: (selection: {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      }) => void;
+    };
+
+    act(() => {
+      props.onSelectionStart();
+      props.onSelectionChange({ nodes: props.nodes, edges: props.edges });
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        edges: Array<Record<string, any>>;
+      };
+      expect(latestProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).toBe(true);
+      expect(latestProps.edges.find((candidate) => candidate.id === 'edge-a-c')?.selected).not.toBe(true);
+    });
+  });
+
+  it('uses selection geometry when React Flow misses partially covered nodes', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'partial-node-geometry-tree',
+            name: 'Partial Node Geometry Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+    reactFlowMock.selectionRect = createRect(95, 0, 80, 100);
+    reactFlowMock.nodeRects = {
+      'node-a': createRect(10, 10, 100, 70),
+      'node-b': createRect(130, 10, 100, 70),
+    };
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Partial Node Geometry Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      nodes: Array<Record<string, any>>;
+      onSelectionStart: () => void;
+      onSelectionChange: (selection: {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      }) => void;
+    };
+    const nodeA = props.nodes.find((node) => node.id === 'node-a');
+    expect(nodeA).toBeTruthy();
+
+    act(() => {
+      props.onSelectionStart();
+      props.onSelectionChange({ nodes: [nodeA as Record<string, any>], edges: [] });
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.find((node) => node.id === 'node-a')?.data?.isHighlighted).toBe(true);
+      expect(latestProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).toBe(true);
+    });
+  });
+
+  it('keeps an enclosed link selected when the selection box is gone at release', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'release-link-tree',
+            name: 'Release Link Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'sequence',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', type: 'sequence' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [{ id: 'edge-a-b', source: 'node-a', target: 'node-b', animated: true }],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+    reactFlowMock.selectionRect = createRect(0, 0, 120, 120);
+    reactFlowMock.edgeRects = {
+      'edge-a-b': createRect(20, 20, 40, 30),
+    };
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Release Link Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      onSelectionStart: () => void;
+      onSelectionEnd: () => void;
+      onSelectionChange: (selection: {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      }) => void;
+    };
+
+    act(() => {
+      props.onSelectionStart();
+      props.onSelectionChange({ nodes: [], edges: [] });
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        edges: Array<Record<string, any>>;
+      };
+      expect(latestProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).toBe(true);
+    });
+
+    const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+      onSelectionEnd: () => void;
+    };
+    act(() => {
+      reactFlowMock.selectionRect = null;
+      latestProps.onSelectionEnd();
+    });
+
+    await waitFor(() => {
+      const finalProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        edges: Array<Record<string, any>>;
+      };
+      expect(finalProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).toBe(true);
+    });
+  });
+
+  it('ignores the stale empty selection event that can follow box release', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'late-clear-tree',
+            name: 'Late Clear Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Late Clear Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      nodes: Array<Record<string, any>>;
+      onPaneClick: () => void;
+      onSelectionStart: () => void;
+      onSelectionEnd: () => void;
+      onSelectionChange: (selection: {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      }) => void;
+    };
+    const nodeA = props.nodes.find((node) => node.id === 'node-a');
+    const nodeB = props.nodes.find((node) => node.id === 'node-b');
+    expect(nodeA).toBeTruthy();
+    expect(nodeB).toBeTruthy();
+
+    act(() => {
+      props.onSelectionStart();
+      props.onSelectionChange({
+        nodes: [nodeA as Record<string, any>, nodeB as Record<string, any>],
+        edges: [],
+      });
+      props.onSelectionEnd();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('bt-selection-actions')).toBeInTheDocument());
+
+    const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+      onPaneClick: () => void;
+      onSelectionChange: (selection: {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      }) => void;
+    };
+    act(() => {
+      latestProps.onSelectionChange({ nodes: [], edges: [] });
+      latestProps.onPaneClick();
+    });
+
+    await waitFor(() => {
+      const finalProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(finalProps.nodes.find((node) => node.id === 'node-a')?.data?.isHighlighted).toBe(true);
+      expect(finalProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).toBe(true);
+    });
+    expect(screen.getByTestId('bt-selection-actions')).toBeInTheDocument();
+  });
+
+  it('keeps box-selected nodes and enclosed links highlighted after release updates', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'box-selection-tree',
+            name: 'Box Selection Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'sequence',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', type: 'sequence' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [{ id: 'edge-a-b', source: 'node-a', target: 'node-b', animated: true }],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Box Selection Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      nodes: Array<Record<string, any>>;
+      edges: Array<Record<string, any>>;
+      onNodesChange: (changes: Array<Record<string, any>>) => void;
+      onEdgesChange: (changes: Array<Record<string, any>>) => void;
+      onSelectionStart: () => void;
+      onSelectionEnd: () => void;
+      onSelectionChange: (selection: {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      }) => void;
+    };
+    const nodeA = props.nodes.find((node) => node.id === 'node-a');
+    const nodeB = props.nodes.find((node) => node.id === 'node-b');
+    const edge = props.edges.find((candidate) => candidate.id === 'edge-a-b');
+    expect(nodeA).toBeTruthy();
+    expect(nodeB).toBeTruthy();
+    expect(edge).toBeTruthy();
+
+    act(() => {
+      props.onSelectionStart();
+      props.onSelectionChange({
+        nodes: [nodeA as Record<string, any>, nodeB as Record<string, any>],
+        edges: [edge as Record<string, any>],
+      });
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.find((node) => node.id === 'node-a')?.data?.isHighlighted).toBe(true);
+      expect(latestProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).toBe(true);
+      expect(latestProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).toBe(true);
+    });
+
+    const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+      onNodesChange: (changes: Array<Record<string, any>>) => void;
+      onEdgesChange: (changes: Array<Record<string, any>>) => void;
+      onSelectionEnd: () => void;
+    };
+
+    act(() => {
+      latestProps.onNodesChange([
+        { id: 'node-a', type: 'select', selected: true },
+        { id: 'node-b', type: 'select', selected: true },
+      ]);
+      latestProps.onEdgesChange([{ id: 'edge-a-b', type: 'select', selected: false }]);
+      latestProps.onSelectionEnd();
+    });
+
+    await waitFor(() => {
+      const finalProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      };
+      expect(finalProps.nodes.find((node) => node.id === 'node-a')?.data?.isHighlighted).toBe(true);
+      expect(finalProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).toBe(true);
+      expect(finalProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).toBe(true);
+    });
+  });
+
+  it('selects an enclosed link when a box drag adds the second endpoint without another edge event', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'box-edge-count-tree',
+            name: 'Box Edge Count Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'sequence',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', type: 'sequence' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [{ id: 'edge-a-b', source: 'node-a', target: 'node-b', animated: true }],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Box Edge Count Tree'));
+
+    await screen.findByTestId('rf-node-node-a');
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      onNodesChange: (changes: Array<Record<string, any>>) => void;
+      onEdgesChange: (changes: Array<Record<string, any>>) => void;
+      onSelectionStart: () => void;
+    };
+
+    act(() => {
+      props.onSelectionStart();
+      props.onNodesChange([{ id: 'node-a', type: 'select', selected: true }]);
+      props.onEdgesChange([{ id: 'edge-a-b', type: 'select', selected: true }]);
+    });
+
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        edges: Array<Record<string, any>>;
+      };
+      expect(latestProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).not.toBe(true);
+    });
+
+    const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+      onNodesChange: (changes: Array<Record<string, any>>) => void;
+    };
+
+    act(() => {
+      latestProps.onNodesChange([
+        { id: 'node-a', type: 'select', selected: true },
+        { id: 'node-b', type: 'select', selected: true },
+      ]);
+    });
+
+    await waitFor(() => {
+      const finalProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      };
+      expect(finalProps.nodes.find((node) => node.id === 'node-a')?.data?.isHighlighted).toBe(true);
+      expect(finalProps.nodes.find((node) => node.id === 'node-b')?.data?.isHighlighted).toBe(true);
+      expect(finalProps.edges.find((candidate) => candidate.id === 'edge-a-b')?.selected).toBe(true);
+    });
+  });
+
+  it('hides contextual selection actions immediately when a new area selection starts', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'context-actions-tree',
+            name: 'Context Actions Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Context Actions Tree'));
+
+    const nodeA = await screen.findByTestId('rf-node-node-a');
+    fireEvent.click(nodeA);
+
+    await waitFor(() => expect(screen.getByTestId('bt-duplicate-selected')).toBeInTheDocument());
+
+    const props = reactFlowMock.render.mock.lastCall?.[0] as {
+      onSelectionStart: () => void;
+    };
+
+    act(() => {
+      props.onSelectionStart();
+    });
+
+    expect(screen.queryByTestId('bt-duplicate-selected')).not.toBeInTheDocument();
+    await waitFor(() => expect(nodeA).toHaveAttribute('data-highlighted', 'false'));
   });
 });

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -14,6 +14,14 @@ const reactFlowMock = vi.hoisted(() => ({
   fitView: vi.fn(),
 }));
 
+const executorMock = vi.hoisted(() => ({
+  instances: [] as Array<{
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    callback: (event: Record<string, unknown>) => void;
+  }>,
+}));
+
 const createRect = (x: number, y: number, width: number, height: number): DOMRect => ({
   x,
   y,
@@ -26,12 +34,27 @@ const createRect = (x: number, y: number, width: number, height: number): DOMRec
   toJSON: () => ({}),
 } as DOMRect);
 
+vi.mock('../engine/executor', () => ({
+  BehaviorTreeExecutor: vi.fn().mockImplementation(
+    (_tree: unknown, _ros: unknown, callback: (event: Record<string, unknown>) => void) => {
+      const instance = {
+        start: vi.fn(),
+        stop: vi.fn(),
+        callback,
+      };
+      executorMock.instances.push(instance);
+      return instance;
+    }
+  ),
+}));
+
 vi.mock('reactflow', () => ({
   default: (props: {
     children?: React.ReactNode;
     nodes?: Array<Record<string, any>>;
     edges?: Array<Record<string, any>>;
     onNodeClick?: (event: React.MouseEvent, node: Record<string, any>) => void;
+    onEdgeClick?: (event: React.MouseEvent, edge: Record<string, any>) => void;
     onNodesChange?: (changes: Array<Record<string, any>>) => void;
     onEdgesChange?: (changes: Array<Record<string, any>>) => void;
     onSelectionStart?: () => void;
@@ -109,6 +132,13 @@ vi.mock('reactflow', () => ({
               const rect = reactFlowMock.edgeRects[edge.id];
               if (element && rect) element.getBoundingClientRect = () => rect;
             }}
+            onClick={(event) => {
+              props.onEdgeClick?.(event, edge);
+              props.onSelectionChange?.({
+                nodes: [],
+                edges: props.edges?.filter((candidate) => candidate.id === edge.id) ?? [],
+              });
+            }}
           />
         ))}
         {reactFlowMock.selectionRect && (
@@ -171,6 +201,7 @@ describe('BehaviorTreePanel', () => {
     reactFlowMock.selectionRect = null;
     reactFlowMock.setCenter.mockReset();
     reactFlowMock.fitView.mockReset();
+    executorMock.instances = [];
     localStorage.clear();
   });
 
@@ -235,6 +266,63 @@ describe('BehaviorTreePanel', () => {
     expect(screen.getByTestId('bt-pan-mode')).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('toggles follow mode and centers the running node while executing', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'follow-tree',
+            name: 'Follow Tree',
+            nodes: [
+              {
+                id: 'node-follow',
+                type: 'action',
+                position: { x: 480, y: 360 },
+                width: 180,
+                height: 70,
+                data: { label: 'Follow Action', actionName: '/follow', actionType: 'example/Follow' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={{} as any} isConnected isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Follow Tree'));
+    await screen.findByTestId('rf-node-node-follow');
+
+    fireEvent.click(screen.getByTestId('bt-follow-mode'));
+    expect(screen.getByTestId('bt-follow-mode')).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(executorMock.instances).toHaveLength(1);
+
+    act(() => {
+      executorMock.instances[0].callback({
+        type: 'nodeRunning',
+        nodeId: 'node-follow',
+        timestamp: Date.now(),
+        data: { status: 'running', treePath: [] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(reactFlowMock.setCenter).toHaveBeenCalledWith(
+        570,
+        395,
+        expect.objectContaining({ zoom: 1, duration: 360 })
+      );
+    });
+  });
+
   it('handles an edge click without crashing', () => {
     reactFlowMock.nodes = [
       { id: 'parent', position: { x: 0, y: 0 }, data: {}, selected: true },
@@ -251,9 +339,86 @@ describe('BehaviorTreePanel', () => {
     };
 
     act(() => {
-      props.onEdgeClick({} as React.MouseEvent, reactFlowMock.edges[0]);
+      props.onEdgeClick(
+        {
+          ctrlKey: false,
+          metaKey: false,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+        } as unknown as React.MouseEvent,
+        reactFlowMock.edges[0]
+      );
     });
     expect(reactFlowMock.render).toHaveBeenCalled();
+  });
+
+  it('keeps multiple links selected after Ctrl-clicking edges', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'ctrl-edge-tree',
+            name: 'Ctrl Edge Tree',
+            nodes: [
+              {
+                id: 'root',
+                type: 'sequence',
+                position: { x: 0, y: 0 },
+                data: { label: 'Root', type: 'sequence' },
+              },
+              {
+                id: 'child-a',
+                type: 'action',
+                position: { x: 0, y: 120 },
+                data: { label: 'Child A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'child-b',
+                type: 'action',
+                position: { x: 220, y: 120 },
+                data: { label: 'Child B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [
+              { id: 'edge-root-a', source: 'root', target: 'child-a', animated: true },
+              { id: 'edge-root-b', source: 'root', target: 'child-b', animated: true },
+            ],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Ctrl Edge Tree'));
+
+    const edgeA = await screen.findByTestId('rf__edge-edge-root-a');
+    const edgeB = await screen.findByTestId('rf__edge-edge-root-b');
+
+    fireEvent.click(edgeA);
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        edges: Array<Record<string, any>>;
+      };
+      expect(latestProps.edges.find((edge) => edge.id === 'edge-root-a')?.selected).toBe(true);
+      expect(latestProps.edges.find((edge) => edge.id === 'edge-root-b')?.selected).not.toBe(true);
+    });
+
+    fireEvent.click(edgeB, { ctrlKey: true });
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+        edges: Array<Record<string, any>>;
+      };
+      expect(latestProps.edges.find((edge) => edge.id === 'edge-root-a')?.selected).toBe(true);
+      expect(latestProps.edges.find((edge) => edge.id === 'edge-root-b')?.selected).toBe(true);
+      expect(latestProps.nodes.some((node) => node.selected)).toBe(false);
+    });
   });
 
   it('keeps multiple nodes highlighted after Ctrl-click selection', async () => {
@@ -703,6 +868,77 @@ describe('BehaviorTreePanel', () => {
       expect(latestProps.nodes.some((node) => node.type === 'retry')).toBe(false);
     });
     expect(screen.getByTestId('bt-subtree-parent')).toBeInTheDocument();
+  });
+
+  it('opens a saved tree as a root tree when currently inside a subtree', async () => {
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'subtree-load-source',
+            name: 'Subtree Load Source',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+              {
+                id: 'node-b',
+                type: 'action',
+                position: { x: 220, y: 0 },
+                data: { label: 'Node B', actionName: '/b', actionType: 'example/B' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'fresh-root-tree',
+            name: 'Fresh Root Tree',
+            nodes: [
+              {
+                id: 'node-root',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Fresh Root Action', actionName: '/root', actionType: 'example/Root' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Subtree Load Source'));
+
+    const nodeA = await screen.findByTestId('rf-node-node-a');
+    const nodeB = await screen.findByTestId('rf-node-node-b');
+    fireEvent.click(nodeA);
+    fireEvent.click(nodeB, { ctrlKey: true });
+    await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-wrap'));
+    await waitFor(() => expect(screen.getByTestId('bt-context-open-subtree')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('bt-context-open-subtree'));
+    await waitFor(() => expect(screen.getByTestId('bt-subtree-parent')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Fresh Root Tree'));
+
+    await screen.findByTestId('rf-node-node-root');
+    expect(screen.queryByTestId('bt-subtree-parent')).not.toBeInTheDocument();
   });
 
   it('does not keep a box-selected edge unless both endpoint nodes are selected', async () => {

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -42,6 +42,8 @@ const firePointerEvent = (
     pointerType?: string;
     button?: number;
     buttons?: number;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
     clientX: number;
     clientY: number;
   }
@@ -62,8 +64,16 @@ const firePointerEvent = (
       value,
     });
   });
-
   fireEvent(element, event);
+};
+
+const ctrlClickNode = (element: Element) => {
+  firePointerEvent(element, 'pointerdown', {
+    clientX: 0,
+    clientY: 0,
+    ctrlKey: true,
+  });
+  fireEvent.click(element, { ctrlKey: true });
 };
 
 vi.mock('../engine/executor', () => ({
@@ -508,7 +518,7 @@ describe('BehaviorTreePanel', () => {
     fireEvent.click(nodeA);
     await waitFor(() => expect(nodeA).toHaveAttribute('data-highlighted', 'true'));
 
-    fireEvent.click(nodeB, { ctrlKey: true });
+    ctrlClickNode(nodeB);
 
     await waitFor(() => {
       expect(nodeA).toHaveAttribute('data-highlighted', 'true');
@@ -595,7 +605,7 @@ describe('BehaviorTreePanel', () => {
     const nodeA = await screen.findByTestId('rf-node-node-a');
     const nodeB = await screen.findByTestId('rf-node-node-b');
     fireEvent.click(nodeA);
-    fireEvent.click(nodeB, { ctrlKey: true });
+    ctrlClickNode(nodeB);
 
     await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('bt-context-wrap'));
@@ -662,7 +672,7 @@ describe('BehaviorTreePanel', () => {
     const nodeA = await screen.findByTestId('rf-node-node-a');
     const nodeB = await screen.findByTestId('rf-node-node-b');
     fireEvent.click(nodeA);
-    fireEvent.click(nodeB, { ctrlKey: true });
+    ctrlClickNode(nodeB);
 
     await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('bt-context-wrap'));
@@ -828,7 +838,7 @@ describe('BehaviorTreePanel', () => {
     const nodeA = await screen.findByTestId('rf-node-node-a');
     const nodeB = await screen.findByTestId('rf-node-node-b');
     fireEvent.click(nodeA);
-    fireEvent.click(nodeB, { ctrlKey: true });
+    ctrlClickNode(nodeB);
 
     await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('bt-context-wrap'));
@@ -887,7 +897,7 @@ describe('BehaviorTreePanel', () => {
     const nodeA = await screen.findByTestId('rf-node-node-a');
     const nodeB = await screen.findByTestId('rf-node-node-b');
     fireEvent.click(nodeA);
-    fireEvent.click(nodeB, { ctrlKey: true });
+    ctrlClickNode(nodeB);
     await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('bt-context-wrap'));
     await waitFor(() => expect(screen.getByTestId('bt-context-open-subtree')).toBeInTheDocument());
@@ -984,7 +994,7 @@ describe('BehaviorTreePanel', () => {
     const nodeA = await screen.findByTestId('rf-node-node-a');
     const nodeB = await screen.findByTestId('rf-node-node-b');
     fireEvent.click(nodeA);
-    fireEvent.click(nodeB, { ctrlKey: true });
+    ctrlClickNode(nodeB);
     await waitFor(() => expect(screen.getByTestId('bt-context-wrap')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('bt-context-wrap'));
     await waitFor(() => expect(screen.getByTestId('bt-context-open-subtree')).toBeInTheDocument());

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -214,6 +214,7 @@ describe('BehaviorTreePanel', () => {
     reactFlowMock.setCenter.mockReset();
     reactFlowMock.fitView.mockReset();
     executorMock.instances = [];
+    window.confirm = vi.fn(() => true);
     localStorage.clear();
   });
 
@@ -1579,8 +1580,8 @@ describe('BehaviorTreePanel', () => {
       ])
     );
     reactFlowMock.nodeRects = {
-      'node-a': createRect(30, 30, 100, 70),
-      'node-b': createRect(210, 45, 100, 70),
+      'node-a': createRect(80, 80, 100, 70),
+      'node-b': createRect(260, 95, 100, 70),
     };
 
     render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
@@ -1603,14 +1604,14 @@ describe('BehaviorTreePanel', () => {
       pointerId: 1,
       pointerType: 'mouse',
       button: 0,
-      clientX: 10,
-      clientY: 10,
+      clientX: 40,
+      clientY: 40,
     });
     fireEvent.pointerMove(flow, {
       pointerId: 1,
       pointerType: 'mouse',
-      clientX: 95,
-      clientY: 80,
+      clientX: 190,
+      clientY: 160,
     });
 
     await waitFor(() => {
@@ -1625,8 +1626,8 @@ describe('BehaviorTreePanel', () => {
     fireEvent.pointerMove(flow, {
       pointerId: 1,
       pointerType: 'mouse',
-      clientX: 340,
-      clientY: 140,
+      clientX: 390,
+      clientY: 190,
     });
 
     await waitFor(() => {
@@ -1640,8 +1641,8 @@ describe('BehaviorTreePanel', () => {
     fireEvent.pointerUp(flow, {
       pointerId: 1,
       pointerType: 'mouse',
-      clientX: 340,
-      clientY: 140,
+      clientX: 390,
+      clientY: 190,
     });
     await waitFor(() => expect(screen.getByTestId('bt-selection-actions')).toBeInTheDocument());
     expect(screen.queryByTestId('bt-custom-selection')).not.toBeInTheDocument();

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -894,6 +894,16 @@ describe('BehaviorTreePanel', () => {
     fireEvent.click(screen.getByTestId('bt-context-open-subtree'));
     await waitFor(() => expect(screen.getByTestId('bt-subtree-parent')).toBeInTheDocument());
 
+    let subtreeNodeCountBeforeRetry = 0;
+    await waitFor(() => {
+      const latestProps = reactFlowMock.render.mock.lastCall?.[0] as {
+        nodes: Array<Record<string, any>>;
+      };
+      expect(latestProps.nodes.map((node) => node.id)).toEqual(expect.arrayContaining(['node-a', 'node-b']));
+      subtreeNodeCountBeforeRetry = latestProps.nodes.length;
+      expect(subtreeNodeCountBeforeRetry).toBeGreaterThanOrEqual(2);
+    });
+
     fireEvent.click(screen.getByTestId('bt-palette-toggle'));
     fireEvent.click(screen.getByText('Retry'));
     await waitFor(() => {
@@ -911,7 +921,7 @@ describe('BehaviorTreePanel', () => {
         nodes: Array<Record<string, any>>;
       };
       expect(latestProps.nodes.map((node) => node.id)).toEqual(expect.arrayContaining(['node-a', 'node-b']));
-      expect(latestProps.nodes).toHaveLength(2);
+      expect(latestProps.nodes).toHaveLength(subtreeNodeCountBeforeRetry);
       expect(latestProps.nodes.some((node) => node.type === 'retry')).toBe(false);
     });
     expect(screen.getByTestId('bt-subtree-parent')).toBeInTheDocument();

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -501,6 +501,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const customBoxSelectionRectRef = useRef<DOMRect | null>(null);
   const subtreeReturnAnchorFrameRef = useRef<number | null>(null);
   const manualEdgeSelectionRef = useRef<ManualEdgeSelection | null>(null);
+  const nodeMultiSelectSnapshotRef = useRef<Set<string> | null>(null);
   const isFollowModeRef = useRef(false);
   const followExecutionFrameRef = useRef<number | null>(null);
 
@@ -1315,6 +1316,30 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       manualEdgeSelectionRef.current = null;
       setOrderingParentId(null);
 
+      if (event.ctrlKey || event.metaKey) {
+        const nextSelectedNodeIds = new Set(
+          nodeMultiSelectSnapshotRef.current ?? selectedNodeIdsRef.current
+        );
+        const nextSelectedEdgeIds = new Set(selectedEdgeIdsRef.current);
+
+        if (nextSelectedNodeIds.has(node.id)) {
+          nextSelectedNodeIds.delete(node.id);
+        } else {
+          nextSelectedNodeIds.add(node.id);
+        }
+
+        nodeMultiSelectSnapshotRef.current = null;
+        manualEdgeSelectionRef.current = {
+          nodeIds: nextSelectedNodeIds,
+          edgeIds: nextSelectedEdgeIds,
+          expiresAt: Date.now() + MANUAL_EDGE_SELECTION_SUPPRESSION_MS,
+        };
+        commitSelectionState(nextSelectedNodeIds, nextSelectedEdgeIds);
+        return;
+      }
+
+      nodeMultiSelectSnapshotRef.current = null;
+
       if (!window.matchMedia(MOBILE_BREAKPOINT).matches) return;
       if (
         node.type !== BehaviorNodeType.Action &&
@@ -1335,7 +1360,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         openNodeEditor(node);
       }
     },
-    [openNodeEditor]
+    [commitSelectionState, openNodeEditor]
   );
 
   const onEdgeClick = useCallback((event: React.MouseEvent, edge: Edge) => {
@@ -2036,6 +2061,14 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   );
   const handleCanvasPointerDownCapture = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      nodeMultiSelectSnapshotRef.current =
+        (event.ctrlKey || event.metaKey) && target.closest('.react-flow__node')
+          ? new Set(selectedNodeIdsRef.current)
+          : null;
+
       if (canvasInteractionMode !== 'select') return;
       const isNonPrimaryMouseButton =
         event.pointerType === 'mouse' &&
@@ -2043,8 +2076,6 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         event.button !== 0;
       if (isNonPrimaryMouseButton) return;
 
-      const target = event.target;
-      if (!(target instanceof Element)) return;
       if (!target.closest('.react-flow')) return;
       if (
         target.closest(

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -6,9 +6,9 @@ import ReactFlow, {
   Connection,
   Edge,
   Node,
+  applyNodeChanges,
+  applyEdgeChanges,
   addEdge,
-  useNodesState,
-  useEdgesState,
   ReactFlowProvider,
   BackgroundVariant,
   ConnectionMode,
@@ -28,7 +28,11 @@ import ActionParameterEditor from './ActionParameterEditor';
 import ServiceParameterEditor from './ServiceParameterEditor';
 import { BehaviorTreeExecutor } from '../engine/executor';
 import { arrangeBehaviorTree } from '../layoutUtils';
-import { saveBehaviorTree, exportBehaviorTree } from '../storage/treeStorage';
+import {
+  exportBehaviorTree,
+  saveBehaviorTree,
+  syncBehaviorTreeReferences,
+} from '../storage/treeStorage';
 import {
   createBehaviorTreeNode,
   duplicateSelectedBehaviorNodes,
@@ -55,6 +59,19 @@ import {
   ROSServiceInfo,
   ROSTopicInfo,
 } from '../types';
+import {
+  areTreePathsEqual,
+  cloneBehaviorTree,
+  createSubtreeNode,
+  explodeSubtreeNode,
+  getTreeAtPath,
+  isSubtreeNode,
+  resetBehaviorTreeExecutionState,
+  replaceTreeAtPath,
+  syncReferencedSubtrees,
+  updateTreeAtPath,
+  wrapSelectionIntoSubtree,
+} from '../subtreeUtils';
 import './BehaviorTreePanel.css';
 
 interface BehaviorTreePanelProps {
@@ -118,6 +135,24 @@ const getDefaultNodeName = (node: BehaviorTreeNode): string => {
     default:
       return data.label || 'Node';
   }
+};
+
+const getExecutionNodeKey = (nodeId: string, treePath: string[]): string =>
+  `${treePath.join('/') || 'root'}::${nodeId}`;
+
+const collectExecutionNodeLabels = (
+  tree: BehaviorTree,
+  treePath: string[] = [],
+  labels: Map<string, string> = new Map()
+): Map<string, string> => {
+  tree.nodes.forEach((node) => {
+    labels.set(getExecutionNodeKey(node.id, treePath), node.data.label || node.id);
+    if (isSubtreeNode(node)) {
+      collectExecutionNodeLabels(node.data.tree, [...treePath, node.id], labels);
+    }
+  });
+
+  return labels;
 };
 
 const ChildOrderPanel: React.FC<ChildOrderPanelProps> = ({
@@ -199,9 +234,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   onExecutionChange,
   onExecutionControlsChange,
 }) => {
-  const [nodes, setNodes, onNodesChange] = useNodesState([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [nodes, setNodes] = useState<BehaviorTreeNode[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
   const [currentTree, setCurrentTree] = useState<BehaviorTree | null>(null);
+  const [rootTree, setRootTree] = useState<BehaviorTree | null>(null);
+  const [treePath, setTreePath] = useState<string[]>([]);
   const [isExecuting, setIsExecuting] = useState(false);
   const [isPaletteCollapsed, setIsPaletteCollapsed] = useState(true);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
@@ -226,8 +263,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const executionNodeLabels = useRef<Map<string, string>>(new Map());
   const executionStartedAt = useRef<number | undefined>(undefined);
   const lastMobileNodeTap = useRef<{ nodeId: string; timestamp: number } | null>(null);
+  const currentTreeRef = useRef<BehaviorTree | null>(null);
+  const rootTreeRef = useRef<BehaviorTree | null>(null);
+  const treePathRef = useRef<string[]>([]);
 
-  const { screenToFlowPosition, deleteElements, fitView, getZoom, setCenter } = useReactFlow();
+  const { screenToFlowPosition, fitView, getZoom, setCenter } = useReactFlow();
 
   const allocateNodeId = useCallback((existingNodes: Node[]) => {
     const id = getNextBehaviorNodeId(existingNodes, nodeIdCounter.current);
@@ -235,15 +275,140 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     return id;
   }, []);
 
-  const addNodeAtPosition = useCallback(
-    (nodeType: BehaviorNodeType, position: { x: number; y: number }, rosInfo?: ROSNodeInfo) => {
-      setNodes((currentNodes) => {
-        const id = allocateNodeId(currentNodes);
-        const newNode = createBehaviorTreeNode({ id, nodeType, position, rosInfo });
-        return newNode ? currentNodes.concat(newNode) : currentNodes;
-      });
+  const resetTransientNodeState = useCallback((treeNodes: BehaviorTreeNode[]): BehaviorTreeNode[] => {
+    return treeNodes.map((node) => ({
+      ...node,
+      selected: false,
+      dragging: false,
+      data: {
+        ...node.data,
+        isHighlighted: false,
+      },
+    }));
+  }, []);
+
+  const resetTransientEdgeState = useCallback((treeEdges: Edge[]): Edge[] => {
+    return treeEdges.map((edge) => ({
+      ...edge,
+      selected: false,
+      sourceHandle: null,
+      targetHandle: null,
+    }));
+  }, []);
+
+  useEffect(() => {
+    currentTreeRef.current = currentTree;
+  }, [currentTree]);
+
+  useEffect(() => {
+    rootTreeRef.current = rootTree;
+  }, [rootTree]);
+
+  useEffect(() => {
+    treePathRef.current = treePath;
+  }, [treePath]);
+
+  const syncEditorState = useCallback(
+    (tree: BehaviorTree, nextPath: string[]) => {
+      const nextNodes = resetTransientNodeState(tree.nodes);
+      const nextEdges = resetTransientEdgeState(tree.edges);
+      const nextTree = {
+        ...tree,
+        nodes: nextNodes,
+        edges: nextEdges,
+      };
+
+      currentTreeRef.current = nextTree;
+      treePathRef.current = nextPath;
+      setCurrentTree(nextTree);
+      setTreePath(nextPath);
+      setNodes(nextNodes);
+      setEdges(nextEdges);
+      setSelectedNodes([]);
+      setOrderingParentId(null);
+      setRenamingNodeId(null);
+      setEditingAction(null);
+      setEditingService(null);
+      nodeIdCounter.current = getNodeCounterAfterNodes(nextNodes);
     },
-    [allocateNodeId, setNodes]
+    [resetTransientEdgeState, resetTransientNodeState]
+  );
+
+  const persistEditorTree = useCallback(
+    (
+      nextNodes: BehaviorTreeNode[],
+      nextEdges: Edge[],
+      treeOverrides: Partial<BehaviorTree> = {}
+    ): BehaviorTree | null => {
+      if (!currentTree) return null;
+
+      const nextTree: BehaviorTree = {
+        ...currentTree,
+        ...treeOverrides,
+        nodes: nextNodes,
+        edges: nextEdges,
+        updatedAt: Date.now(),
+      };
+
+      currentTreeRef.current = nextTree;
+      setCurrentTree(nextTree);
+      setNodes(nextNodes);
+      setEdges(nextEdges);
+      setRootTree((previousRootTree) => {
+        const nextRootTree =
+          !previousRootTree || treePath.length === 0
+            ? nextTree
+            : updateTreeAtPath(previousRootTree, treePath, () => nextTree);
+        rootTreeRef.current = nextRootTree;
+        return nextRootTree;
+      });
+      return nextTree;
+    },
+    [currentTree, treePath]
+  );
+
+  const loadRootTree = useCallback(
+    (tree: BehaviorTree) => {
+      const hydrated: BehaviorTree = {
+        ...tree,
+        nodes: resetTransientNodeState(tree.nodes),
+        edges: resetTransientEdgeState(tree.edges),
+      };
+      rootTreeRef.current = hydrated;
+      setRootTree(hydrated);
+      syncEditorState(hydrated, []);
+    },
+    [resetTransientEdgeState, resetTransientNodeState, syncEditorState]
+  );
+
+  const addNodeAtPosition = useCallback(
+    (
+      nodeType: BehaviorNodeType,
+      position: { x: number; y: number },
+      item?: ROSNodeInfo | BehaviorTree
+    ) => {
+      if (nodeType === BehaviorNodeType.Subtree && item && 'nodes' in item && 'edges' in item) {
+        const subtreeNode = createSubtreeNode({
+          id: allocateNodeId(nodes),
+          label: item.name,
+          position,
+          tree: cloneBehaviorTree(item),
+          sourceTreeId: item.id,
+        });
+        persistEditorTree([...nodes, subtreeNode], edges);
+        return;
+      }
+
+      const newNode = createBehaviorTreeNode({
+        id: allocateNodeId(nodes),
+        nodeType,
+        position,
+        rosInfo: item as ROSNodeInfo | undefined,
+      });
+      if (!newNode) return;
+      persistEditorTree([...nodes, newNode], edges);
+    },
+    [allocateNodeId, edges, nodes, persistEditorTree]
   );
 
   const showSaveNotice = useCallback((notice: Omit<SaveNotice, 'id'>) => {
@@ -268,7 +433,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   // Initialize with empty tree
   useEffect(() => {
-    if (!currentTree) {
+    if (!rootTree) {
       const newTree: BehaviorTree = {
         id: uuidv4(),
         name: 'Untitled Behavior Tree',
@@ -277,9 +442,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         createdAt: Date.now(),
         updatedAt: Date.now(),
       };
-      setCurrentTree(newTree);
+      loadRootTree(newTree);
     }
-  }, [currentTree]);
+  }, [loadRootTree, rootTree]);
 
   useEffect(() => {
     return () => {
@@ -299,9 +464,23 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const onConnect = useCallback(
     (connection: Connection) => {
-      setEdges((eds) => addEdge(normalizeEdge(connection), eds));
+      persistEditorTree(nodes, addEdge(normalizeEdge(connection), edges));
     },
-    [setEdges]
+    [edges, nodes, persistEditorTree]
+  );
+
+  const onNodesChange = useCallback(
+    (changes: Parameters<typeof applyNodeChanges>[0]) => {
+      persistEditorTree(applyNodeChanges(changes, nodes) as BehaviorTreeNode[], edges);
+    },
+    [edges, nodes, persistEditorTree]
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: Parameters<typeof applyEdgeChanges>[0]) => {
+      persistEditorTree(nodes, applyEdgeChanges(changes, edges));
+    },
+    [edges, nodes, persistEditorTree]
   );
 
   const onDragOver = useCallback((event: React.DragEvent) => {
@@ -319,7 +498,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       const dataStr = event.dataTransfer.getData('application/reactflow');
       if (!dataStr) return;
 
-      let data: { nodeType?: BehaviorNodeType; rosInfo?: ROSNodeInfo };
+      let data: { nodeType?: BehaviorNodeType; item?: ROSNodeInfo | BehaviorTree };
       try {
         data = JSON.parse(dataStr);
       } catch {
@@ -333,7 +512,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         y: event.clientY - 40,
       });
 
-      addNodeAtPosition(data.nodeType, position, data.rosInfo);
+      addNodeAtPosition(data.nodeType, position, data.item);
     },
     [addNodeAtPosition, screenToFlowPosition]
   );
@@ -355,9 +534,15 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   // Delete selected nodes (and their connected edges)
   const handleDeleteSelected = useCallback(() => {
-    deleteElements({ nodes: selectedNodes });
+    const selectedIds = new Set(selectedNodes.map((node) => node.id));
+    if (selectedIds.size === 0) return;
+
+    persistEditorTree(
+      nodes.filter((node) => !selectedIds.has(node.id)),
+      edges.filter((edge) => !selectedIds.has(edge.source) && !selectedIds.has(edge.target))
+    );
     setSelectedNodes([]);
-  }, [deleteElements, selectedNodes]);
+  }, [edges, nodes, persistEditorTree, selectedNodes]);
 
   const handleDuplicateSelected = useCallback(() => {
     const selectedNodeIds = selectedNodes.map((node) => node.id);
@@ -373,10 +558,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     if (result.duplicatedNodes.length === 0) return;
 
     nodeIdCounter.current = result.nextNodeCounter;
-    setNodes(result.nodes);
-    setEdges(result.edges);
+    persistEditorTree(result.nodes, result.edges);
     setSelectedNodes(result.duplicatedNodes);
-  }, [edges, nodes, selectedNodes, setEdges, setNodes]);
+  }, [edges, nodes, persistEditorTree, selectedNodes]);
 
   const handleOpenSelectedNodeRename = useCallback(() => {
     if (selectedNodes.length !== 1) return;
@@ -387,16 +571,80 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     (name: string) => {
       if (!renamingNodeId) return;
 
-      const updateName = (node: Node) =>
+      const nextNodes = nodes.map((node) =>
         node.id === renamingNodeId
-          ? { ...node, data: { ...node.data, label: name } }
-          : node;
+          ? {
+              ...node,
+              data: isSubtreeNode(node)
+                ? {
+                    ...node.data,
+                    label: name,
+                    tree: {
+                      ...node.data.tree,
+                      name,
+                    },
+                  }
+                : { ...node.data, label: name },
+            }
+          : node
+      );
 
-      setNodes((currentNodes) => currentNodes.map(updateName));
-      setSelectedNodes((currentNodes) => currentNodes.map(updateName));
+      persistEditorTree(nextNodes, edges);
+      setSelectedNodes((currentNodes) =>
+        currentNodes.map((node) =>
+          node.id === renamingNodeId
+            ? {
+                ...node,
+                data:
+                  'tree' in node.data
+                    ? {
+                        ...node.data,
+                        label: name,
+                        tree: {
+                          ...node.data.tree,
+                          name,
+                        },
+                      }
+                    : { ...node.data, label: name },
+              }
+            : node
+        )
+      );
       setRenamingNodeId(null);
     },
-    [renamingNodeId, setNodes]
+    [edges, nodes, persistEditorTree, renamingNodeId]
+  );
+
+  const openSubtreeNode = useCallback((subtreeNodeId: string) => {
+    if (!rootTree) return;
+    const nextPath = [...treePath, subtreeNodeId];
+    const nextTree = getTreeAtPath(rootTree, nextPath);
+    if (!nextTree) return;
+
+    syncEditorState(nextTree, nextPath);
+  }, [rootTree, syncEditorState, treePath]);
+
+  const handleOpenSelectedSubtree = useCallback(() => {
+    if (selectedNodes.length !== 1) return;
+    const selectedNode = nodes.find((node) => node.id === selectedNodes[0].id);
+    if (!isSubtreeNode(selectedNode)) return;
+    openSubtreeNode(selectedNode.id);
+  }, [nodes, openSubtreeNode, selectedNodes]);
+
+  const highlightClickedNode = useCallback(
+    (clickedNodeId: string | null) => {
+      persistEditorTree(
+        nodes.map((node) => ({
+          ...node,
+          data: {
+            ...node.data,
+            isHighlighted: node.id === clickedNodeId,
+          },
+        })),
+        edges
+      );
+    },
+    [edges, nodes, persistEditorTree]
   );
 
   const openNodeEditor = useCallback((node: Node) => {
@@ -404,10 +652,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       setEditingAction({ nodeId: node.id, data: node.data as ROSActionNodeData });
     } else if (node.type === BehaviorNodeType.Service) {
       setEditingService({ nodeId: node.id, data: node.data as ROSServiceNodeData });
+    } else if (isSubtreeNode(node as BehaviorTreeNode)) {
+      openSubtreeNode(node.id);
     } else if (isOrderedControlNode(node as BehaviorTreeNode)) {
       setOrderingParentId(node.id);
     }
-  }, []);
+  }, [openSubtreeNode]);
 
   const onNodeDoubleClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
@@ -418,10 +668,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const onNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
+      highlightClickedNode(node.id);
+
       if (!window.matchMedia(MOBILE_BREAKPOINT).matches) return;
       if (
         node.type !== BehaviorNodeType.Action &&
         node.type !== BehaviorNodeType.Service &&
+        node.type !== BehaviorNodeType.Subtree &&
         !isOrderedControlNode(node as BehaviorTreeNode)
       ) {
         return;
@@ -436,7 +689,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         openNodeEditor(node);
       }
     },
-    [openNodeEditor]
+    [highlightClickedNode, openNodeEditor]
   );
 
   const onEdgeClick = useCallback(
@@ -446,51 +699,54 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
       const selectedTargetNode = { ...targetNode, selected: true, dragging: false };
 
-      setNodes((currentNodes) =>
-        currentNodes.map((node) => ({
+      const nextNodes = nodes.map((node) => ({
           ...node,
           selected: node.id === edge.target,
           dragging: false,
-        }))
-      );
-      setEdges((currentEdges) =>
-        currentEdges.map((currentEdge) => ({
+          data: {
+            ...node.data,
+            isHighlighted: node.id === edge.target,
+          },
+        }));
+      const nextEdges = edges.map((currentEdge) => ({
           ...currentEdge,
           selected: currentEdge.id === edge.id,
-        }))
-      );
+        }));
+      persistEditorTree(nextNodes, nextEdges);
       setSelectedNodes([selectedTargetNode]);
       setOrderingParentId(null);
     },
-    [nodes, setEdges, setNodes]
+    [edges, nodes, persistEditorTree]
   );
 
   const handleSaveActionParameters = useCallback(
     (parameters: Record<string, any>) => {
       if (!editingAction) return;
       const { nodeId } = editingAction;
-      setNodes((nds) =>
-        nds.map((node) => {
+      persistEditorTree(
+        nodes.map((node) => {
           if (node.id !== nodeId) return node;
           return { ...node, data: { ...node.data, parameters } };
-        })
+        }),
+        edges
       );
     },
-    [editingAction, setNodes]
+    [editingAction, edges, nodes, persistEditorTree]
   );
 
   const handleSaveServiceRequest = useCallback(
     (request: Record<string, any>) => {
       if (!editingService) return;
       const { nodeId } = editingService;
-      setNodes((nds) =>
-        nds.map((node) => {
+      persistEditorTree(
+        nodes.map((node) => {
           if (node.id !== nodeId) return node;
           return { ...node, data: { ...node.data, request } };
-        })
+        }),
+        edges
       );
     },
-    [editingService, setNodes]
+    [editingService, edges, nodes, persistEditorTree]
   );
 
   const handleSave = useCallback(() => {
@@ -503,7 +759,28 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     };
     const success = saveBehaviorTree(updatedTree);
     if (success) {
-      setCurrentTree(updatedTree);
+      syncBehaviorTreeReferences(updatedTree);
+
+      const activePath = treePathRef.current;
+      const baseRootTree = rootTreeRef.current;
+      const syncedRootTree = baseRootTree
+        ? syncReferencedSubtrees(
+            activePath.length === 0 ? updatedTree : updateTreeAtPath(baseRootTree, activePath, () => updatedTree),
+            updatedTree
+          )
+        : updatedTree;
+
+      rootTreeRef.current = syncedRootTree;
+      setRootTree(syncedRootTree);
+
+      const nextCurrentTree =
+        activePath.length === 0 ? syncedRootTree : getTreeAtPath(syncedRootTree, activePath);
+      if (nextCurrentTree) {
+        syncEditorState(nextCurrentTree, activePath);
+      } else {
+        persistEditorTree(nodes, edges, { name: updatedTree.name });
+      }
+
       showSaveNotice({
         type: 'success',
         title: 'Tree saved',
@@ -516,29 +793,45 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         message: 'The tree could not be saved. Please try again.',
       });
     }
-  }, [currentTree, nodes, edges, showSaveNotice]);
+  }, [currentTree, edges, nodes, persistEditorTree, showSaveNotice, syncEditorState]);
 
   const handleLoad = useCallback((tree: BehaviorTree) => {
-    const loadedNodes = tree.nodes.map((node) => ({
-      ...node,
-      selected: false,
-      dragging: false,
-    }));
-    // Strip legacy sourceHandle values (out-1, out-2, out-3) from saved trees.
-    const loadedEdges = tree.edges.map((e) => ({
-      ...e,
-      sourceHandle: null,
-      targetHandle: null,
-      selected: false,
-    }));
-    setCurrentTree({ ...tree, nodes: loadedNodes, edges: loadedEdges });
-    setNodes(loadedNodes);
-    setEdges(loadedEdges);
-    setSelectedNodes([]);
-    setOrderingParentId(null);
-    setRenamingNodeId(null);
-    nodeIdCounter.current = getNodeCounterAfterNodes(loadedNodes);
-  }, [setNodes, setEdges]);
+    if (treePath.length === 0) {
+      loadRootTree(tree);
+      return;
+    }
+
+    const loadedTree = { ...tree, name: tree.name || currentTree?.name || 'Subtree' };
+    const nextRootTree = rootTree ? replaceTreeAtPath(rootTree, treePath, loadedTree) : loadedTree;
+    const subtreeNodeId = treePath[treePath.length - 1];
+    const parentPath = treePath.slice(0, -1);
+    const parentTree =
+      parentPath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, parentPath);
+
+    const nextRootWithLabel =
+      subtreeNodeId && parentTree
+        ? parentPath.length === 0
+          ? {
+              ...parentTree,
+              nodes: parentTree.nodes.map((node) =>
+                node.id === subtreeNodeId && isSubtreeNode(node)
+                  ? { ...node, data: { ...node.data, label: loadedTree.name, tree: loadedTree } }
+                  : node
+              ),
+            }
+          : replaceTreeAtPath(nextRootTree, parentPath, {
+              ...parentTree,
+              nodes: parentTree.nodes.map((node) =>
+                node.id === subtreeNodeId && isSubtreeNode(node)
+                  ? { ...node, data: { ...node.data, label: loadedTree.name, tree: loadedTree } }
+                  : node
+              ),
+            })
+        : nextRootTree;
+
+    setRootTree(nextRootWithLabel);
+    syncEditorState(loadedTree, treePath);
+  }, [currentTree?.name, loadRootTree, rootTree, syncEditorState, treePath]);
 
   const handleNew = useCallback(() => {
     if (nodes.length > 0 || edges.length > 0) {
@@ -554,13 +847,40 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    setCurrentTree(newTree);
-    setNodes([]);
-    setEdges([]);
-    setOrderingParentId(null);
-    setRenamingNodeId(null);
-    nodeIdCounter.current = 0;
-  }, [nodes, edges, setNodes, setEdges]);
+    if (treePath.length === 0) {
+      loadRootTree(newTree);
+      return;
+    }
+
+    const nextRootTree = rootTree ? replaceTreeAtPath(rootTree, treePath, newTree) : newTree;
+    const subtreeNodeId = treePath[treePath.length - 1];
+    const parentPath = treePath.slice(0, -1);
+    const parentTree =
+      parentPath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, parentPath);
+    const nextRootWithLabel =
+      subtreeNodeId && parentTree
+        ? parentPath.length === 0
+          ? {
+              ...parentTree,
+              nodes: parentTree.nodes.map((node) =>
+                node.id === subtreeNodeId && isSubtreeNode(node)
+                  ? { ...node, data: { ...node.data, label: newTree.name, tree: newTree } }
+                  : node
+              ),
+            }
+          : replaceTreeAtPath(nextRootTree, parentPath, {
+              ...parentTree,
+              nodes: parentTree.nodes.map((node) =>
+                node.id === subtreeNodeId && isSubtreeNode(node)
+                  ? { ...node, data: { ...node.data, label: newTree.name, tree: newTree } }
+                  : node
+              ),
+            })
+        : nextRootTree;
+
+    setRootTree(nextRootWithLabel);
+    syncEditorState(newTree, treePath);
+  }, [edges.length, loadRootTree, nodes.length, rootTree, syncEditorState, treePath]);
 
   const handleExport = useCallback(() => {
     if (!currentTree) return;
@@ -570,36 +890,107 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const handleArrange = useCallback(() => {
     if (nodes.length === 0) return;
 
-    setNodes(arrangeBehaviorTree(nodes as BehaviorTreeNode[], edges));
+    persistEditorTree(arrangeBehaviorTree(nodes as BehaviorTreeNode[], edges), edges);
     window.requestAnimationFrame(() => {
       fitView({ padding: 0.18, duration: 450, maxZoom: 1.15 });
     });
-  }, [edges, fitView, nodes, setNodes]);
+  }, [edges, fitView, nodes, persistEditorTree]);
 
   const handleRename = useCallback((name: string) => {
-    setCurrentTree((prev) => (prev ? { ...prev, name } : null));
+    if (!currentTree) return;
+
+    const nextTree = { ...currentTree, name };
+    currentTreeRef.current = nextTree;
+    setCurrentTree(nextTree);
+    setRootTree((previousRootTree) => {
+      if (!previousRootTree || treePath.length === 0) {
+        rootTreeRef.current = nextTree;
+        return nextTree;
+      }
+
+      const renamedRootTree = replaceTreeAtPath(previousRootTree, treePath, nextTree);
+      const subtreeNodeId = treePath[treePath.length - 1];
+      const parentPath = treePath.slice(0, -1);
+      if (!subtreeNodeId) return renamedRootTree;
+
+      const parentTree = parentPath.length === 0 ? renamedRootTree : getTreeAtPath(renamedRootTree, parentPath);
+      if (!parentTree) return renamedRootTree;
+
+      const renamedParentTree: BehaviorTree = {
+        ...parentTree,
+        nodes: parentTree.nodes.map((node) =>
+          node.id === subtreeNodeId && isSubtreeNode(node)
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  label: name,
+                  tree: nextTree,
+                },
+              }
+            : node
+        ),
+      };
+
+      const nextRootTree = parentPath.length === 0
+        ? renamedParentTree
+        : replaceTreeAtPath(renamedRootTree, parentPath, renamedParentTree);
+      rootTreeRef.current = nextRootTree;
+      return nextRootTree;
+    });
+  }, [currentTree, treePath]);
+
+  const updateDisplayedNodeStatus = useCallback((nodeId: string, status: ExecutionStatus) => {
+    setNodes((currentNodes) =>
+      currentNodes.map((node) =>
+        node.id === nodeId ? { ...node, data: { ...node.data, status } } : node
+      )
+    );
+    setCurrentTree((previousTree) => {
+      if (!previousTree) return previousTree;
+
+      const nextTree = {
+        ...previousTree,
+        nodes: previousTree.nodes.map((node) =>
+          node.id === nodeId ? { ...node, data: { ...node.data, status } } : node
+        ),
+      };
+      currentTreeRef.current = nextTree;
+      return nextTree;
+    });
   }, []);
 
   const handleExecutionEvent = useCallback(
     (event: ExecutionEvent) => {
       if (event.nodeId && event.data?.status) {
         const nodeId = event.nodeId;
-        setNodes((nds) =>
-          nds.map((node) => {
-            if (node.id === nodeId) {
-              return { ...node, data: { ...node.data, status: event.data.status } };
-            }
-            return node;
-          })
-        );
-
         const status = event.data.status as ExecutionStatus;
+        const eventPath = Array.isArray(event.data.treePath) ? event.data.treePath : [];
+
+        setRootTree((previousRootTree) => {
+          if (!previousRootTree) return previousRootTree;
+
+          const nextRootTree = updateTreeAtPath(previousRootTree, eventPath, (targetTree) => ({
+            ...targetTree,
+            nodes: targetTree.nodes.map((node) =>
+              node.id === nodeId ? { ...node, data: { ...node.data, status } } : node
+            ),
+          }));
+          rootTreeRef.current = nextRootTree;
+          return nextRootTree;
+        });
+
+        if (areTreePathsEqual(eventPath, treePathRef.current)) {
+          updateDisplayedNodeStatus(nodeId, status);
+        }
+
         if (status === ExecutionStatus.Running) {
           setExecutionSnapshot((prev) => ({
             ...prev,
             isExecuting: true,
             activeNodeId: nodeId,
-            activeNodeLabel: executionNodeLabels.current.get(nodeId) ?? nodeId,
+            activeNodeLabel:
+              executionNodeLabels.current.get(getExecutionNodeKey(nodeId, eventPath)) ?? nodeId,
             status,
           }));
         }
@@ -621,16 +1012,36 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
           status,
         }));
         setTimeout(() => {
-          setNodes((nds) =>
-            nds.map((node) => ({
-              ...node,
-              data: { ...node.data, status: ExecutionStatus.Idle },
-            }))
-          );
+          setRootTree((previousRootTree) => {
+            if (!previousRootTree) return previousRootTree;
+
+            const nextRootTree = resetBehaviorTreeExecutionState(previousRootTree);
+            rootTreeRef.current = nextRootTree;
+
+            const activePath = treePathRef.current;
+            const nextCurrentTree =
+              activePath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, activePath);
+
+            if (nextCurrentTree) {
+              const nextNodes = resetTransientNodeState(nextCurrentTree.nodes);
+              const nextEdges = resetTransientEdgeState(nextCurrentTree.edges);
+              const hydratedCurrentTree = {
+                ...nextCurrentTree,
+                nodes: nextNodes,
+                edges: nextEdges,
+              };
+              currentTreeRef.current = hydratedCurrentTree;
+              setCurrentTree(hydratedCurrentTree);
+              setNodes(nextNodes);
+              setEdges(nextEdges);
+            }
+
+            return nextRootTree;
+          });
         }, 2000);
       }
     },
-    [setNodes]
+    [resetTransientEdgeState, resetTransientNodeState, updateDisplayedNodeStatus]
   );
 
   const handleExecute = useCallback(() => {
@@ -647,9 +1058,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       nodes: nodes as BehaviorTreeNode[],
       edges,
     };
-    executionNodeLabels.current = new Map(
-      treeToExecute.nodes.map((node) => [node.id, node.data.label || node.id])
-    );
+    executionNodeLabels.current = collectExecutionNodeLabels(treeToExecute);
     executionStartedAt.current = Date.now();
     executorRef.current = new BehaviorTreeExecutor(treeToExecute, ros, handleExecutionEvent);
     setIsExecuting(true);
@@ -666,18 +1075,37 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const handleStop = useCallback(() => {
     if (executorRef.current) executorRef.current.stop();
     setIsExecuting(false);
-    setNodes((nds) =>
-      nds.map((node) => ({
-        ...node,
-        data: { ...node.data, status: ExecutionStatus.Idle },
-      }))
-    );
+    setRootTree((previousRootTree) => {
+      if (!previousRootTree) return previousRootTree;
+
+      const nextRootTree = resetBehaviorTreeExecutionState(previousRootTree);
+      rootTreeRef.current = nextRootTree;
+      const activePath = treePathRef.current;
+      const nextCurrentTree =
+        activePath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, activePath);
+
+      if (nextCurrentTree) {
+        const nextNodes = resetTransientNodeState(nextCurrentTree.nodes);
+        const nextEdges = resetTransientEdgeState(nextCurrentTree.edges);
+        const hydratedCurrentTree = {
+          ...nextCurrentTree,
+          nodes: nextNodes,
+          edges: nextEdges,
+        };
+        currentTreeRef.current = hydratedCurrentTree;
+        setCurrentTree(hydratedCurrentTree);
+        setNodes(nextNodes);
+        setEdges(nextEdges);
+      }
+
+      return nextRootTree;
+    });
     setExecutionSnapshot((prev) => ({
       ...prev,
       isExecuting: false,
       status: 'stopped',
     }));
-  }, [setNodes]);
+  }, [resetTransientEdgeState, resetTransientNodeState]);
 
   useEffect(() => {
     onExecutionChange?.(executionSnapshot);
@@ -696,7 +1124,10 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   // Add a node at the centre of the visible canvas — used for mobile tap-to-add.
   const handleAddNode = useCallback(
-    (nodeType: BehaviorNodeType, rosInfo?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo) => {
+    (
+      nodeType: BehaviorNodeType,
+      item?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo | BehaviorTree
+    ) => {
       const bounds = reactFlowWrapper.current?.getBoundingClientRect();
       if (!bounds) return;
 
@@ -705,7 +1136,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         y: bounds.top + bounds.height / 2,
       });
 
-      addNodeAtPosition(nodeType, position, rosInfo);
+      addNodeAtPosition(nodeType, position, item);
 
       // Close palette on mobile after adding
       if (window.matchMedia(MOBILE_BREAKPOINT).matches) {
@@ -716,10 +1147,34 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   );
 
   const behaviorNodes = useMemo(() => nodes as BehaviorTreeNode[], [nodes]);
-  const displayedEdges = useMemo(
-    () => annotateOrderedEdges(behaviorNodes, edges),
-    [behaviorNodes, edges]
-  );
+  const displayedEdges = useMemo(() => {
+    const nodeStatusById = new Map(
+      behaviorNodes.map((node) => [node.id, node.data.status ?? ExecutionStatus.Idle])
+    );
+
+    return annotateOrderedEdges(behaviorNodes, edges).map((edge) => {
+      const targetStatus = nodeStatusById.get(edge.target) ?? ExecutionStatus.Idle;
+      const isRunning = targetStatus === ExecutionStatus.Running;
+      const isSuccess = targetStatus === ExecutionStatus.Success;
+      const isFailure = targetStatus === ExecutionStatus.Failure;
+
+      return {
+        ...edge,
+        animated: isRunning,
+        style: {
+          stroke: isRunning
+            ? '#ffc107'
+            : isSuccess
+              ? '#4caf50'
+              : isFailure
+                ? '#f44336'
+                : 'var(--primary-color, #4285f4)',
+          strokeWidth: isRunning ? 4 : isSuccess || isFailure ? 3 : 2,
+          opacity: isRunning || isSuccess || isFailure ? 1 : 0.9,
+        },
+      };
+    });
+  }, [behaviorNodes, edges]);
   const orderingParent = useMemo(() => {
     const parent = behaviorNodes.find((node) => node.id === orderingParentId);
     return isOrderedControlNode(parent) ? parent : null;
@@ -735,15 +1190,178 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const handleMoveOrderedChild = useCallback(
     (edgeId: string, direction: -1 | 1) => {
       if (!orderingParent) return;
-      setEdges((currentEdges) =>
-        moveOrderedChildEdge(currentEdges, orderingParent.id, edgeId, direction)
+      persistEditorTree(
+        nodes,
+        moveOrderedChildEdge(edges, orderingParent.id, edgeId, direction)
       );
     },
-    [orderingParent, setEdges]
+    [edges, nodes, orderingParent, persistEditorTree]
   );
   const handlePaneClick = useCallback(() => {
     setOrderingParentId(null);
   }, []);
+
+  const selectedSubtreeNode = useMemo(() => {
+    if (selectedNodes.length !== 1) return null;
+    const node = behaviorNodes.find((candidate) => candidate.id === selectedNodes[0].id);
+    return isSubtreeNode(node) ? node : null;
+  }, [behaviorNodes, selectedNodes]);
+
+  const canWrapSelection = useMemo(() => {
+    if (!currentTree || selectedNodes.length < 2) return false;
+
+    return wrapSelectionIntoSubtree({
+      tree: { ...currentTree, nodes: behaviorNodes, edges },
+      selectedNodeIds: selectedNodes.map((node) => node.id),
+      subtreeNodeId: 'preview-subtree',
+      subtreeTreeId: 'preview-tree',
+      subtreeLabel: 'Subtree',
+    }).ok;
+  }, [behaviorNodes, currentTree, edges, selectedNodes]);
+
+  const handleWrapSelectedIntoSubtree = useCallback(() => {
+    if (!currentTree) return;
+
+    const result = wrapSelectionIntoSubtree({
+      tree: { ...currentTree, nodes: behaviorNodes, edges },
+      selectedNodeIds: selectedNodes.map((node) => node.id),
+      subtreeNodeId: allocateNodeId(behaviorNodes),
+      subtreeTreeId: uuidv4(),
+      subtreeLabel: 'Subtree',
+    });
+
+    if (!result.ok) {
+      showSaveNotice({
+        type: 'error',
+        title: 'Wrap failed',
+        message: result.reason,
+      });
+      return;
+    }
+
+    const nextNodes = (result.tree.nodes as BehaviorTreeNode[]).map((node) => ({
+      ...node,
+      selected: node.id === result.subtreeNode.id,
+      data: {
+        ...node.data,
+        isHighlighted: node.id === result.subtreeNode.id,
+      },
+    }));
+
+    persistEditorTree(nextNodes, result.tree.edges, {
+      updatedAt: result.tree.updatedAt,
+    });
+    setSelectedNodes([
+      {
+        ...result.subtreeNode,
+        selected: true,
+        data: {
+          ...result.subtreeNode.data,
+          isHighlighted: true,
+        },
+      },
+    ]);
+    setOrderingParentId(null);
+  }, [
+    allocateNodeId,
+    behaviorNodes,
+    currentTree,
+    edges,
+    persistEditorTree,
+    selectedNodes,
+    showSaveNotice,
+  ]);
+
+  const handleSaveSelectedSubtree = useCallback(() => {
+    if (!selectedSubtreeNode) return;
+
+    const subtreeTree = cloneBehaviorTree(selectedSubtreeNode.data.tree);
+    const savedTree: BehaviorTree = {
+      ...subtreeTree,
+      name: selectedSubtreeNode.data.label,
+      updatedAt: Date.now(),
+    };
+    const success = saveBehaviorTree(savedTree);
+
+    if (success) {
+      syncBehaviorTreeReferences(savedTree);
+      if (rootTreeRef.current) {
+        const syncedRootTree = syncReferencedSubtrees(rootTreeRef.current, savedTree);
+        rootTreeRef.current = syncedRootTree;
+        setRootTree(syncedRootTree);
+
+        const activePath = treePathRef.current;
+        const nextCurrentTree =
+          activePath.length === 0 ? syncedRootTree : getTreeAtPath(syncedRootTree, activePath);
+        if (nextCurrentTree) {
+          syncEditorState(nextCurrentTree, activePath);
+        }
+      }
+    }
+
+    showSaveNotice(
+      success
+        ? {
+            type: 'success',
+            title: 'Subtree saved',
+            message: `"${selectedSubtreeNode.data.label}" is ready to drag back into a tree.`,
+          }
+        : {
+            type: 'error',
+            title: 'Save failed',
+            message: 'The selected subtree could not be saved.',
+          }
+    );
+  }, [selectedSubtreeNode, showSaveNotice, syncEditorState]);
+
+  const handleExplodeSelectedSubtree = useCallback(() => {
+    if (!currentTree || !selectedSubtreeNode) return;
+
+    const result = explodeSubtreeNode({
+      tree: { ...currentTree, nodes: behaviorNodes, edges },
+      subtreeNodeId: selectedSubtreeNode.id,
+      startNodeIndex: nodeIdCounter.current,
+    });
+
+    if (!result.ok) {
+      showSaveNotice({
+        type: 'error',
+        title: 'Explode failed',
+        message: result.reason,
+      });
+      return;
+    }
+
+    nodeIdCounter.current = result.nextNodeCounter;
+    persistEditorTree(result.tree.nodes as BehaviorTreeNode[], result.tree.edges, {
+      updatedAt: result.tree.updatedAt,
+    });
+    setSelectedNodes(
+      result.tree.nodes
+        .filter((node) => result.insertedNodeIds.includes(node.id))
+        .map((node) => ({
+          ...node,
+          selected: true,
+          dragging: false,
+        }))
+    );
+    setOrderingParentId(null);
+  }, [
+    behaviorNodes,
+    currentTree,
+    edges,
+    persistEditorTree,
+    selectedSubtreeNode,
+    showSaveNotice,
+  ]);
+
+  const handleNavigateUp = useCallback(() => {
+    if (!rootTree || treePath.length === 0) return;
+    const nextPath = treePath.slice(0, -1);
+    const nextTree = nextPath.length === 0 ? rootTree : getTreeAtPath(rootTree, nextPath);
+    if (!nextTree) return;
+    syncEditorState(nextTree, nextPath);
+  }, [rootTree, syncEditorState, treePath]);
 
   const handleSearchSelect = useCallback(
     (node: BehaviorTreeNode) => {
@@ -752,18 +1370,23 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       const centerY = position.y + (node.height ?? 80) / 2;
       const selectedNode = { ...node, selected: true, dragging: false };
 
-      setNodes((currentNodes) =>
-        currentNodes.map((currentNode) => ({
+      persistEditorTree(
+        nodes.map((currentNode) => ({
           ...currentNode,
           selected: currentNode.id === node.id,
           dragging: false,
-        }))
+          data: {
+            ...currentNode.data,
+            isHighlighted: currentNode.id === node.id,
+          },
+        })),
+        edges
       );
       setSelectedNodes([selectedNode]);
       setOrderingParentId(null);
       setCenter(centerX, centerY, { zoom: Math.max(getZoom(), 1), duration: 400 });
     },
-    [getZoom, setCenter, setNodes]
+    [edges, getZoom, nodes, persistEditorTree, setCenter]
   );
 
   return (
@@ -772,8 +1395,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         currentTree={currentTree}
         isExecuting={isExecuting}
         isPaletteCollapsed={isPaletteCollapsed}
+        isEditingSubtree={treePath.length > 0}
         nodeCount={nodes.length}
         selectedNodeCount={selectedNodes.length}
+        canWrapSelection={canWrapSelection}
+        hasSelectedSubtree={Boolean(selectedSubtreeNode)}
         onSave={handleSave}
         onLoad={handleLoad}
         onNew={handleNew}
@@ -785,6 +1411,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         onDeleteSelected={handleDeleteSelected}
         onDuplicateSelected={handleDuplicateSelected}
         onRenameSelected={handleOpenSelectedNodeRename}
+        onWrapSelection={handleWrapSelectedIntoSubtree}
+        onOpenSelectedSubtree={handleOpenSelectedSubtree}
+        onSaveSelectedSubtree={handleSaveSelectedSubtree}
+        onExplodeSelectedSubtree={handleExplodeSelectedSubtree}
+        onNavigateUp={handleNavigateUp}
         onRename={handleRename}
       />
 

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -155,9 +155,6 @@ const SELECTION_ACTIONS_MAX_WIDTH = 360;
 const BOX_SELECTION_CLEAR_SUPPRESSION_MS = 120;
 const BOX_SELECTION_DRAG_THRESHOLD = 4;
 const MANUAL_EDGE_SELECTION_SUPPRESSION_MS = 160;
-const SUBTREE_PARENT_BUTTON_WIDTH = 108;
-const SUBTREE_PARENT_BUTTON_HEIGHT = 42;
-const SUBTREE_PARENT_BUTTON_GAP = 10;
 
 const getKnownReactFlowElementId = (
   element: Element,
@@ -1945,17 +1942,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       return;
     }
 
-    const x = Math.min(
-      Math.max(
-        bounds.left - canvasRect.left - SUBTREE_PARENT_BUTTON_WIDTH - SUBTREE_PARENT_BUTTON_GAP,
-        8
-      ),
-      Math.max(canvasRect.width - SUBTREE_PARENT_BUTTON_WIDTH - 8, 8)
-    );
-    const y = Math.min(
-      Math.max(bounds.top - canvasRect.top + 4, 8),
-      Math.max(canvasRect.height - SUBTREE_PARENT_BUTTON_HEIGHT - 8, 8)
-    );
+    const x = Math.min(Math.max(bounds.left - canvasRect.left - 2, 8), Math.max(canvasRect.width - 132, 8));
+    const aboveY = bounds.top - canvasRect.top - 46;
+    const y =
+      aboveY >= 8
+        ? aboveY
+        : Math.min(Math.max(bounds.bottom - canvasRect.top + 10, 8), Math.max(canvasRect.height - 40, 8));
 
     setSubtreeReturnAnchor({ x, y });
   }, []);

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -143,11 +143,21 @@ interface CustomBoxSelectionBox {
   height: number;
 }
 
+interface ManualEdgeSelection {
+  nodeIds: Set<string>;
+  edgeIds: Set<string>;
+  expiresAt: number;
+}
+
 const MOBILE_BREAKPOINT = '(max-width: 768px)';
 const MAX_UNDO_HISTORY = 80;
 const SELECTION_ACTIONS_MAX_WIDTH = 360;
 const BOX_SELECTION_CLEAR_SUPPRESSION_MS = 120;
 const BOX_SELECTION_DRAG_THRESHOLD = 4;
+const MANUAL_EDGE_SELECTION_SUPPRESSION_MS = 160;
+const SUBTREE_PARENT_BUTTON_WIDTH = 108;
+const SUBTREE_PARENT_BUTTON_HEIGHT = 42;
+const SUBTREE_PARENT_BUTTON_GAP = 10;
 
 const getKnownReactFlowElementId = (
   element: Element,
@@ -420,6 +430,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const [canRedo, setCanRedo] = useState(false);
   const [canvasInteractionMode, setCanvasInteractionMode] =
     useState<BehaviorTreeInteractionMode>('pan');
+  const [isFollowMode, setIsFollowMode] = useState(false);
   // Action node currently being edited via the parameter editor modal.
   const [editingAction, setEditingAction] = useState<
     { nodeId: string; data: ROSActionNodeData } | null
@@ -460,6 +471,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const customBoxSelectionGestureRef = useRef<CustomBoxSelectionGesture | null>(null);
   const customBoxSelectionRectRef = useRef<DOMRect | null>(null);
   const subtreeReturnAnchorFrameRef = useRef<number | null>(null);
+  const manualEdgeSelectionRef = useRef<ManualEdgeSelection | null>(null);
+  const isFollowModeRef = useRef(false);
+  const followExecutionFrameRef = useRef<number | null>(null);
 
   const { screenToFlowPosition, fitView, getZoom, setCenter } = useReactFlow();
 
@@ -501,6 +515,10 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   useEffect(() => {
     treePathRef.current = treePath;
   }, [treePath]);
+
+  useEffect(() => {
+    isFollowModeRef.current = isFollowMode;
+  }, [isFollowMode]);
 
   const centerTreeInView = useCallback(() => {
     window.requestAnimationFrame(() => {
@@ -675,6 +693,21 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     },
     [applySelectionState]
   );
+
+  const getManualEdgeSelectionOverride = useCallback(() => {
+    const override = manualEdgeSelectionRef.current;
+    if (!override) return null;
+
+    if (Date.now() > override.expiresAt) {
+      manualEdgeSelectionRef.current = null;
+      return null;
+    }
+
+    return {
+      nodeIds: new Set(override.nodeIds),
+      edgeIds: new Set(override.edgeIds),
+    };
+  }, []);
 
   const loadRootTree = useCallback(
     (tree: BehaviorTree) => {
@@ -920,6 +953,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       });
 
       if (changes.every((change) => change.type === 'select')) {
+        const manualEdgeSelection = getManualEdgeSelectionOverride();
+        if (manualEdgeSelection) {
+          commitSelectionState(manualEdgeSelection.nodeIds, manualEdgeSelection.edgeIds);
+          return;
+        }
+
         const flowSelectedNodeIds = new Set(
           nextNodes.filter((node) => node.selected).map((node) => node.id)
         );
@@ -953,6 +992,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     [
       commitSelectionState,
       edges,
+      getManualEdgeSelectionOverride,
       getBoxSelectionEdgeIds,
       getBoxSelectionNodeIds,
       nodes,
@@ -966,6 +1006,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       const nextEdges = applyEdgeChanges(changes, edges);
 
       if (changes.every((change) => change.type === 'select')) {
+        const manualEdgeSelection = getManualEdgeSelectionOverride();
+        if (manualEdgeSelection) {
+          commitSelectionState(manualEdgeSelection.nodeIds, manualEdgeSelection.edgeIds);
+          return;
+        }
+
         const selectedNodeIds = selectedNodeIdsRef.current;
         const selectedEdgeIds = boxSelectionActiveRef.current
           ? getBoxSelectionEdgeIds(selectedNodeIds)
@@ -980,6 +1026,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     [
       commitSelectionState,
       edges,
+      getManualEdgeSelectionOverride,
       getBoxSelectionEdgeIds,
       nodes,
       persistEditorTree,
@@ -1031,6 +1078,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   // Track selected nodes for the delete button
   const onSelectionChange = useCallback(
     ({ nodes: sel, edges: selectedFlowEdges }: { nodes: Node[]; edges: Edge[] }) => {
+      const manualEdgeSelection = getManualEdgeSelectionOverride();
+      if (manualEdgeSelection) {
+        commitSelectionState(manualEdgeSelection.nodeIds, manualEdgeSelection.edgeIds);
+        return;
+      }
+
       const flowSelectedNodeIds = new Set(sel.map((node) => node.id));
       const selectedNodeIds = boxSelectionActiveRef.current
         ? getBoxSelectionNodeIds(flowSelectedNodeIds)
@@ -1044,6 +1097,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     },
     [
       commitSelectionState,
+      getManualEdgeSelectionOverride,
       getBoxSelectionEdgeIds,
       getBoxSelectionNodeIds,
       shouldIgnoreRecentBoxSelectionReduction,
@@ -1071,6 +1125,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     boxSelectionNodeIdsRef.current = null;
     boxSelectionEdgeIdsRef.current = null;
     boxSelectionEndedAtRef.current = 0;
+    manualEdgeSelectionRef.current = null;
     setOrderingParentId(null);
     setSelectionActionAnchor(null);
     commitSelectionState(new Set(), new Set());
@@ -1221,6 +1276,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const onNodeClick = useCallback(
     (event: React.MouseEvent, node: Node) => {
+      manualEdgeSelectionRef.current = null;
       setOrderingParentId(null);
 
       if (!window.matchMedia(MOBILE_BREAKPOINT).matches) return;
@@ -1246,9 +1302,32 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     [openNodeEditor]
   );
 
-  const onEdgeClick = useCallback(() => {
+  const onEdgeClick = useCallback((event: React.MouseEvent, edge: Edge) => {
+    event.preventDefault();
+    event.stopPropagation();
     setOrderingParentId(null);
-  }, []);
+
+    const isMultiSelect = event.ctrlKey || event.metaKey;
+    const nextSelectedNodeIds = isMultiSelect
+      ? new Set(selectedNodeIdsRef.current)
+      : new Set<string>();
+    const nextSelectedEdgeIds = isMultiSelect
+      ? new Set(selectedEdgeIdsRef.current)
+      : new Set<string>();
+
+    if (isMultiSelect && nextSelectedEdgeIds.has(edge.id)) {
+      nextSelectedEdgeIds.delete(edge.id);
+    } else {
+      nextSelectedEdgeIds.add(edge.id);
+    }
+
+    manualEdgeSelectionRef.current = {
+      nodeIds: nextSelectedNodeIds,
+      edgeIds: nextSelectedEdgeIds,
+      expiresAt: Date.now() + MANUAL_EDGE_SELECTION_SUPPRESSION_MS,
+    };
+    commitSelectionState(nextSelectedNodeIds, nextSelectedEdgeIds);
+  }, [commitSelectionState]);
 
   const handleSaveActionParameters = useCallback(
     (parameters: Record<string, any>) => {
@@ -1320,46 +1399,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   }, [edges, nodes, showSaveNotice, syncRootTreeAndEditor]);
 
   const handleLoad = useCallback((tree: BehaviorTree) => {
-    const activePath = treePathRef.current;
-    const activeRootTree = rootTreeRef.current;
-    const activeCurrentTree = currentTreeRef.current;
     pushUndoSnapshot();
-
-    if (activePath.length === 0) {
-      loadRootTree(tree);
-      return;
-    }
-
-    const loadedTree = { ...tree, name: tree.name || activeCurrentTree?.name || 'Subtree' };
-    const nextRootTree = activeRootTree ? replaceTreeAtPath(activeRootTree, activePath, loadedTree) : loadedTree;
-    const subtreeNodeId = activePath[activePath.length - 1];
-    const parentPath = activePath.slice(0, -1);
-    const parentTree =
-      parentPath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, parentPath);
-
-    const nextRootWithLabel =
-      subtreeNodeId && parentTree
-        ? parentPath.length === 0
-          ? {
-              ...parentTree,
-              nodes: parentTree.nodes.map((node) =>
-                node.id === subtreeNodeId && isSubtreeNode(node)
-                  ? { ...node, data: { ...node.data, label: loadedTree.name, tree: loadedTree } }
-                  : node
-              ),
-            }
-          : replaceTreeAtPath(nextRootTree, parentPath, {
-              ...parentTree,
-              nodes: parentTree.nodes.map((node) =>
-                node.id === subtreeNodeId && isSubtreeNode(node)
-                  ? { ...node, data: { ...node.data, label: loadedTree.name, tree: loadedTree } }
-                  : node
-              ),
-            })
-        : nextRootTree;
-
-    syncRootTreeAndEditor(nextRootWithLabel, activePath, { center: true });
-  }, [loadRootTree, pushUndoSnapshot, syncRootTreeAndEditor]);
+    loadRootTree(tree);
+  }, [loadRootTree, pushUndoSnapshot]);
 
   const handleNew = useCallback(() => {
     if (nodes.length > 0 || edges.length > 0) {
@@ -1377,41 +1419,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    const activePath = treePathRef.current;
-    const activeRootTree = rootTreeRef.current;
-    if (activePath.length === 0) {
-      loadRootTree(newTree);
-      return;
-    }
-
-    const nextRootTree = activeRootTree ? replaceTreeAtPath(activeRootTree, activePath, newTree) : newTree;
-    const subtreeNodeId = activePath[activePath.length - 1];
-    const parentPath = activePath.slice(0, -1);
-    const parentTree =
-      parentPath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, parentPath);
-    const nextRootWithLabel =
-      subtreeNodeId && parentTree
-        ? parentPath.length === 0
-          ? {
-              ...parentTree,
-              nodes: parentTree.nodes.map((node) =>
-                node.id === subtreeNodeId && isSubtreeNode(node)
-                  ? { ...node, data: { ...node.data, label: newTree.name, tree: newTree } }
-                  : node
-              ),
-            }
-          : replaceTreeAtPath(nextRootTree, parentPath, {
-              ...parentTree,
-              nodes: parentTree.nodes.map((node) =>
-                node.id === subtreeNodeId && isSubtreeNode(node)
-                  ? { ...node, data: { ...node.data, label: newTree.name, tree: newTree } }
-                  : node
-              ),
-            })
-        : nextRootTree;
-
-    syncRootTreeAndEditor(nextRootWithLabel, activePath);
-  }, [edges.length, loadRootTree, nodes.length, pushUndoSnapshot, syncRootTreeAndEditor]);
+    loadRootTree(newTree);
+  }, [edges.length, loadRootTree, nodes.length, pushUndoSnapshot]);
 
   const handleExport = useCallback(() => {
     if (!currentTree) return;
@@ -1475,6 +1484,32 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     });
   }, [pushUndoSnapshot]);
 
+  const followExecutionNode = useCallback(
+    (nodeId: string) => {
+      const activeTree = currentTreeRef.current;
+      const node = activeTree?.nodes.find((candidate) => candidate.id === nodeId);
+      if (!node) return;
+
+      const position = node.positionAbsolute ?? node.position;
+      const centerX = position.x + (node.width ?? 150) / 2;
+      const centerY = position.y + (node.height ?? 80) / 2;
+
+      if (followExecutionFrameRef.current !== null) {
+        window.cancelAnimationFrame(followExecutionFrameRef.current);
+      }
+
+      followExecutionFrameRef.current = window.requestAnimationFrame(() => {
+        followExecutionFrameRef.current = null;
+        const zoom = getZoom();
+        setCenter(centerX, centerY, {
+          zoom: Number.isFinite(zoom) && zoom > 0 ? zoom : 1,
+          duration: 360,
+        });
+      });
+    },
+    [getZoom, setCenter]
+  );
+
   const updateDisplayedNodeStatus = useCallback((nodeId: string, status: ExecutionStatus) => {
     setNodes((currentNodes) =>
       currentNodes.map((node) =>
@@ -1515,11 +1550,16 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
           return nextRootTree;
         });
 
-        if (areTreePathsEqual(eventPath, treePathRef.current)) {
+        const isVisibleExecutionPath = areTreePathsEqual(eventPath, treePathRef.current);
+        if (isVisibleExecutionPath) {
           updateDisplayedNodeStatus(nodeId, status);
         }
 
         if (status === ExecutionStatus.Running) {
+          if (isVisibleExecutionPath && isFollowModeRef.current) {
+            followExecutionNode(nodeId);
+          }
+
           setExecutionSnapshot((prev) => ({
             ...prev,
             isExecuting: true,
@@ -1576,7 +1616,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         }, 2000);
       }
     },
-    [resetTransientEdgeState, resetTransientNodeState, updateDisplayedNodeStatus]
+    [followExecutionNode, resetTransientEdgeState, resetTransientNodeState, updateDisplayedNodeStatus]
   );
 
   const handleExecute = useCallback(() => {
@@ -1806,6 +1846,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       if (subtreeReturnAnchorFrameRef.current !== null) {
         window.cancelAnimationFrame(subtreeReturnAnchorFrameRef.current);
       }
+      if (followExecutionFrameRef.current !== null) {
+        window.cancelAnimationFrame(followExecutionFrameRef.current);
+      }
     };
   }, []);
 
@@ -1902,12 +1945,17 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       return;
     }
 
-    const x = Math.min(Math.max(bounds.left - canvasRect.left - 2, 8), Math.max(canvasRect.width - 132, 8));
-    const aboveY = bounds.top - canvasRect.top - 46;
-    const y =
-      aboveY >= 8
-        ? aboveY
-        : Math.min(Math.max(bounds.bottom - canvasRect.top + 10, 8), Math.max(canvasRect.height - 40, 8));
+    const x = Math.min(
+      Math.max(
+        bounds.left - canvasRect.left - SUBTREE_PARENT_BUTTON_WIDTH - SUBTREE_PARENT_BUTTON_GAP,
+        8
+      ),
+      Math.max(canvasRect.width - SUBTREE_PARENT_BUTTON_WIDTH - 8, 8)
+    );
+    const y = Math.min(
+      Math.max(bounds.top - canvasRect.top + 4, 8),
+      Math.max(canvasRect.height - SUBTREE_PARENT_BUTTON_HEIGHT - 8, 8)
+    );
 
     setSubtreeReturnAnchor({ x, y });
   }, []);
@@ -1992,6 +2040,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       boxSelectionEdgeIdsRef.current = null;
       boxSelectionEndedAtRef.current = 0;
       boxSelectionEndPendingRef.current = false;
+      manualEdgeSelectionRef.current = null;
       setCustomBoxSelection(null);
       setOrderingParentId(null);
       setSelectionActionAnchor(null);
@@ -2052,6 +2101,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     boxSelectionNodeIdsRef.current = null;
     boxSelectionEdgeIdsRef.current = null;
     boxSelectionEndedAtRef.current = 0;
+    manualEdgeSelectionRef.current = null;
     setOrderingParentId(null);
     setSelectedNodes([]);
     setSelectedEdges([]);
@@ -2359,6 +2409,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         canUndo={canUndo}
         canRedo={canRedo}
         interactionMode={canvasInteractionMode}
+        isFollowMode={isFollowMode}
         onSave={handleSave}
         onLoad={handleLoad}
         onNew={handleNew}
@@ -2370,6 +2421,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         onUndo={handleUndo}
         onRedo={handleRedo}
         onInteractionModeChange={setCanvasInteractionMode}
+        onToggleFollowMode={() =>
+          setIsFollowMode((enabled) => {
+            const nextEnabled = !enabled;
+            isFollowModeRef.current = nextEnabled;
+            return nextEnabled;
+          })
+        }
         onRename={handleRename}
       />
 

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -1992,7 +1992,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const handleCanvasPointerDownCapture = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (canvasInteractionMode !== 'select') return;
-      if (event.pointerType === 'mouse' && event.button !== 0) return;
+      const isNonPrimaryMouseButton =
+        event.pointerType === 'mouse' &&
+        typeof event.button === 'number' &&
+        event.button !== 0;
+      if (isNonPrimaryMouseButton) return;
 
       const target = event.target;
       if (!(target instanceof Element)) return;

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -123,6 +123,7 @@ interface SyncEditorOptions {
 
 interface HistorySnapshot {
   tree: BehaviorTree;
+  activeTree: BehaviorTree | null;
   path: string[];
 }
 
@@ -577,6 +578,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
     return {
       tree: cloneBehaviorTree(rootTreeRef.current),
+      activeTree: currentTreeRef.current ? cloneBehaviorTree(currentTreeRef.current) : null,
       path: [...treePathRef.current],
     };
   }, []);
@@ -1681,7 +1683,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const restoreRootTreeSnapshot = useCallback(
     (snapshot: HistorySnapshot) => {
-      syncRootTreeAndEditor(snapshot.tree, snapshot.path);
+      const activeTree = snapshot.activeTree;
+      const snapshotTree =
+        activeTree && snapshot.path.length > 0
+          ? updateTreeAtPath(snapshot.tree, snapshot.path, () => activeTree)
+          : snapshot.tree;
+
+      syncRootTreeAndEditor(snapshotTree, snapshot.path);
     },
     [syncRootTreeAndEditor]
   );

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -22,9 +22,11 @@ import {
   FaArrowDown,
   FaArrowUp,
   FaClone,
+  FaCog,
   FaEdit,
   FaExpandArrowsAlt,
   FaFolderOpen,
+  FaLevelUpAlt,
   FaObjectGroup,
   FaSave,
   FaTrash,
@@ -63,6 +65,7 @@ import {
   BehaviorTree,
   BehaviorTreeNode,
   BehaviorNodeType,
+  ControlFlowNodeData,
   ROSActionNodeData,
   ROSServiceNodeData,
   ExecutionEvent,
@@ -118,10 +121,33 @@ interface SyncEditorOptions {
   center?: boolean;
 }
 
+interface HistorySnapshot {
+  tree: BehaviorTree;
+  path: string[];
+}
+
+interface CustomBoxSelectionGesture {
+  pointerId: number;
+  element: HTMLDivElement;
+  startX: number;
+  startY: number;
+  currentX: number;
+  currentY: number;
+  didDrag: boolean;
+}
+
+interface CustomBoxSelectionBox {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 const MOBILE_BREAKPOINT = '(max-width: 768px)';
 const MAX_UNDO_HISTORY = 80;
 const SELECTION_ACTIONS_MAX_WIDTH = 360;
 const BOX_SELECTION_CLEAR_SUPPRESSION_MS = 120;
+const BOX_SELECTION_DRAG_THRESHOLD = 4;
 
 const getKnownReactFlowElementId = (
   element: Element,
@@ -156,6 +182,18 @@ const rectFullyContains = (outer: DOMRect, inner: DOMRect) =>
   inner.top >= outer.top - 1 &&
   inner.bottom <= outer.bottom + 1;
 
+const createViewportRect = (left: number, top: number, right: number, bottom: number): DOMRect => ({
+  x: left,
+  y: top,
+  width: right - left,
+  height: bottom - top,
+  left,
+  top,
+  right,
+  bottom,
+  toJSON: () => ({}),
+} as DOMRect);
+
 interface ChildOrderPanelProps {
   parent: BehaviorTreeNode;
   childLinks: OrderedChildLink[];
@@ -184,10 +222,26 @@ const getDefaultNodeName = (node: BehaviorTreeNode): string => {
       return 'Selector';
     case BehaviorNodeType.Parallel:
       return 'Parallel';
+    case BehaviorNodeType.Retry:
+      return 'Retry';
+    case BehaviorNodeType.Repeat:
+      return 'Repeat';
     default:
       return data.label || 'Node';
   }
 };
+
+const isIteratingControlNode = (node?: BehaviorTreeNode | Node | null): node is BehaviorTreeNode =>
+  node?.type === BehaviorNodeType.Retry || node?.type === BehaviorNodeType.Repeat;
+
+const normalizeIterationLimit = (value: number): number => {
+  if (value === -1) return -1;
+  if (!Number.isFinite(value)) return 3;
+  return Math.max(1, Math.trunc(value));
+};
+
+const getIterationLimit = (node: BehaviorTreeNode): number =>
+  normalizeIterationLimit((node.data as ControlFlowNodeData).iterationLimit ?? 3);
 
 const getExecutionNodeKey = (nodeId: string, treePath: string[]): string =>
   `${treePath.join('/') || 'root'}::${nodeId}`;
@@ -279,6 +333,71 @@ const ChildOrderPanel: React.FC<ChildOrderPanelProps> = ({
   </div>
 );
 
+interface IterationLimitEditorProps {
+  node: BehaviorTreeNode;
+  onSave: (limit: number) => void;
+  onClose: () => void;
+}
+
+const IterationLimitEditor: React.FC<IterationLimitEditorProps> = ({ node, onSave, onClose }) => {
+  const [value, setValue] = useState(String(getIterationLimit(node)));
+  const parsed = Number(value);
+  const isValid =
+    value.trim() !== '' && Number.isFinite(parsed) && (parsed === -1 || Math.trunc(parsed) >= 1);
+  const nodeKind = node.type === BehaviorNodeType.Retry ? 'Retry' : 'Repeat';
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!isValid) return;
+    onSave(normalizeIterationLimit(parsed));
+  };
+
+  return (
+    <div className="bt-iteration-overlay" role="dialog" aria-modal="true">
+      <form className="bt-iteration-dialog" onSubmit={handleSubmit}>
+        <div className="bt-node-name-header">
+          <div>
+            <div className="bt-node-name-kicker">{node.data.label}</div>
+            <h2>{nodeKind} count</h2>
+          </div>
+          <button
+            type="button"
+            className="bt-node-name-close"
+            onClick={onClose}
+            aria-label="Close count editor"
+          >
+            ×
+          </button>
+        </div>
+
+        <label className="bt-node-name-label" htmlFor="bt-iteration-limit">
+          {node.type === BehaviorNodeType.Retry ? 'Attempts' : 'Repeats'}
+        </label>
+        <input
+          id="bt-iteration-limit"
+          className="bt-node-name-input"
+          type="number"
+          step="1"
+          min="-1"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          autoFocus
+        />
+        <div className="bt-iteration-help">Use -1 for infinite.</div>
+
+        <div className="bt-node-name-actions">
+          <button type="button" className="bt-node-name-cancel" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit" className="bt-node-name-save" disabled={!isValid}>
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
 const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   ros,
   isConnected,
@@ -296,6 +415,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
   const [selectedEdges, setSelectedEdges] = useState<Edge[]>([]);
   const [selectionActionAnchor, setSelectionActionAnchor] = useState<{ x: number; y: number } | null>(null);
+  const [customBoxSelection, setCustomBoxSelection] = useState<CustomBoxSelectionBox | null>(null);
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
   const [canvasInteractionMode, setCanvasInteractionMode] =
@@ -308,7 +428,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     { nodeId: string; data: ROSServiceNodeData } | null
   >(null);
   const [renamingNodeId, setRenamingNodeId] = useState<string | null>(null);
+  const [editingIterationNodeId, setEditingIterationNodeId] = useState<string | null>(null);
   const [orderingParentId, setOrderingParentId] = useState<string | null>(null);
+  const [subtreeReturnAnchor, setSubtreeReturnAnchor] = useState<{ x: number; y: number } | null>(null);
   const [saveNotice, setSaveNotice] = useState<SaveNotice | null>(null);
   const [executionSnapshot, setExecutionSnapshot] = useState<BehaviorTreeExecutionSnapshot>({
     isExecuting: false,
@@ -324,8 +446,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const currentTreeRef = useRef<BehaviorTree | null>(null);
   const rootTreeRef = useRef<BehaviorTree | null>(null);
   const treePathRef = useRef<string[]>([]);
-  const undoHistoryRef = useRef<BehaviorTree[]>([]);
-  const redoHistoryRef = useRef<BehaviorTree[]>([]);
+  const undoHistoryRef = useRef<HistorySnapshot[]>([]);
+  const redoHistoryRef = useRef<HistorySnapshot[]>([]);
   const isRestoringHistory = useRef(false);
   const selectedNodeIdsRef = useRef<Set<string>>(new Set());
   const selectedEdgeIdsRef = useRef<Set<string>>(new Set());
@@ -333,6 +455,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const boxSelectionNodeIdsRef = useRef<Set<string> | null>(null);
   const boxSelectionEdgeIdsRef = useRef<Set<string> | null>(null);
   const boxSelectionEndedAtRef = useRef(0);
+  const boxSelectionPointerDownRef = useRef(false);
+  const boxSelectionEndPendingRef = useRef(false);
+  const customBoxSelectionGestureRef = useRef<CustomBoxSelectionGesture | null>(null);
+  const customBoxSelectionRectRef = useRef<DOMRect | null>(null);
+  const subtreeReturnAnchorFrameRef = useRef<number | null>(null);
 
   const { screenToFlowPosition, fitView, getZoom, setCenter } = useReactFlow();
 
@@ -405,6 +532,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       selectedEdgeIdsRef.current = new Set();
       setOrderingParentId(null);
       setRenamingNodeId(null);
+      setEditingIterationNodeId(null);
       setEditingAction(null);
       setEditingService(null);
       nodeIdCounter.current = getNodeCounterAfterNodes(nextNodes);
@@ -415,17 +543,42 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     [centerTreeInView, resetTransientEdgeState, resetTransientNodeState]
   );
 
+  const syncRootTreeAndEditor = useCallback(
+    (nextRootTree: BehaviorTree, preferredPath: string[], options: SyncEditorOptions = {}) => {
+      const nextTreeAtPath =
+        preferredPath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, preferredPath);
+      const nextPath = nextTreeAtPath ? preferredPath : [];
+      const nextTree = nextTreeAtPath ?? nextRootTree;
+
+      rootTreeRef.current = nextRootTree;
+      setRootTree(nextRootTree);
+      syncEditorState(nextTree, nextPath, options);
+    },
+    [syncEditorState]
+  );
+
+  const createHistorySnapshot = useCallback((): HistorySnapshot | null => {
+    if (!rootTreeRef.current) return null;
+
+    return {
+      tree: cloneBehaviorTree(rootTreeRef.current),
+      path: [...treePathRef.current],
+    };
+  }, []);
+
   const pushUndoSnapshot = useCallback(() => {
     if (isRestoringHistory.current || !rootTreeRef.current) return;
+    const snapshot = createHistorySnapshot();
+    if (!snapshot) return;
 
     undoHistoryRef.current = [
       ...undoHistoryRef.current.slice(-(MAX_UNDO_HISTORY - 1)),
-      cloneBehaviorTree(rootTreeRef.current),
+      snapshot,
     ];
     redoHistoryRef.current = [];
     setCanUndo(true);
     setCanRedo(false);
-  }, []);
+  }, [createHistorySnapshot]);
 
   const persistEditorTree = useCallback(
     (
@@ -433,11 +586,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       nextEdges: Edge[],
       treeOverrides: Partial<BehaviorTree> = {}
     ): BehaviorTree | null => {
-      if (!currentTree) return null;
+      const activeTree = currentTreeRef.current;
+      const activePath = treePathRef.current;
+      if (!activeTree) return null;
       pushUndoSnapshot();
 
       const nextTree: BehaviorTree = {
-        ...currentTree,
+        ...activeTree,
         ...treeOverrides,
         nodes: nextNodes,
         edges: nextEdges,
@@ -449,16 +604,17 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       setNodes(nextNodes);
       setEdges(nextEdges);
       setRootTree((previousRootTree) => {
+        const baseRootTree = previousRootTree ?? rootTreeRef.current;
         const nextRootTree =
-          !previousRootTree || treePath.length === 0
+          !baseRootTree || activePath.length === 0
             ? nextTree
-            : updateTreeAtPath(previousRootTree, treePath, () => nextTree);
+            : updateTreeAtPath(baseRootTree, activePath, () => nextTree);
         rootTreeRef.current = nextRootTree;
         return nextRootTree;
       });
       return nextTree;
     },
-    [currentTree, pushUndoSnapshot, treePath]
+    [pushUndoSnapshot]
   );
 
   const applySelectionState = useCallback(
@@ -527,11 +683,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         nodes: resetTransientNodeState(tree.nodes),
         edges: resetTransientEdgeState(tree.edges),
       };
-      rootTreeRef.current = hydrated;
-      setRootTree(hydrated);
-      syncEditorState(hydrated, [], { center: true });
+      syncRootTreeAndEditor(hydrated, [], { center: true });
     },
-    [resetTransientEdgeState, resetTransientNodeState, syncEditorState]
+    [resetTransientEdgeState, resetTransientNodeState, syncRootTreeAndEditor]
   );
 
   const addNodeAtPosition = useCallback(
@@ -623,6 +777,10 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   );
 
   const getCurrentSelectionRect = useCallback((): DOMRect | null => {
+    if (customBoxSelectionRectRef.current) {
+      return customBoxSelectionRectRef.current;
+    }
+
     const canvas = reactFlowWrapper.current;
     const selectionElement = canvas?.querySelector<HTMLElement>('.react-flow__selection');
     if (!canvas || !selectionElement) return null;
@@ -733,6 +891,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const shouldIgnoreRecentBoxSelectionReduction = useCallback(
     (nextSelectedNodeIds: Set<string>, nextSelectedEdgeIds: Set<string>) => {
+      if (boxSelectionPointerDownRef.current && boxSelectionEndPendingRef.current) {
+        return (
+          nextSelectedNodeIds.size < selectedNodeIdsRef.current.size ||
+          nextSelectedEdgeIds.size < selectedEdgeIdsRef.current.size
+        );
+      }
       if (boxSelectionActiveRef.current) return false;
       if (Date.now() - boxSelectionEndedAtRef.current > BOX_SELECTION_CLEAR_SUPPRESSION_MS) {
         return false;
@@ -886,7 +1050,23 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     ]
   );
 
-  const handleSelectionStart = useCallback(() => {
+  const finalizeBoxSelection = useCallback(() => {
+    if (!boxSelectionActiveRef.current) return;
+
+    const selectedNodeIds = getBoxSelectionNodeIds(new Set(selectedNodeIdsRef.current));
+    const selectedEdgeIds = getBoxSelectionEdgeIds(selectedNodeIds);
+    commitSelectionState(selectedNodeIds, selectedEdgeIds);
+    boxSelectionActiveRef.current = false;
+    boxSelectionEndPendingRef.current = false;
+    boxSelectionEndedAtRef.current =
+      selectedNodeIds.size > 0 || selectedEdgeIds.size > 0 ? Date.now() : 0;
+  }, [commitSelectionState, getBoxSelectionEdgeIds, getBoxSelectionNodeIds]);
+
+  const handleSelectionStart = useCallback((event?: React.MouseEvent | React.TouchEvent) => {
+    if (event) {
+      boxSelectionPointerDownRef.current = true;
+      boxSelectionEndPendingRef.current = false;
+    }
     boxSelectionActiveRef.current = true;
     boxSelectionNodeIdsRef.current = null;
     boxSelectionEdgeIdsRef.current = null;
@@ -898,14 +1078,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const handleSelectionEnd = useCallback(() => {
     if (!boxSelectionActiveRef.current) return;
+    if (boxSelectionPointerDownRef.current) {
+      boxSelectionEndPendingRef.current = true;
+      return;
+    }
 
-    const selectedNodeIds = getBoxSelectionNodeIds(new Set(selectedNodeIdsRef.current));
-    const selectedEdgeIds = getBoxSelectionEdgeIds(selectedNodeIds);
-    commitSelectionState(selectedNodeIds, selectedEdgeIds);
-    boxSelectionActiveRef.current = false;
-    boxSelectionEndedAtRef.current =
-      selectedNodeIds.size > 0 || selectedEdgeIds.size > 0 ? Date.now() : 0;
-  }, [commitSelectionState, getBoxSelectionEdgeIds, getBoxSelectionNodeIds]);
+    finalizeBoxSelection();
+  }, [finalizeBoxSelection]);
 
   // Delete selected nodes (and their connected edges)
   const handleDeleteSelected = useCallback(() => {
@@ -1002,13 +1181,15 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   );
 
   const openSubtreeNode = useCallback((subtreeNodeId: string) => {
-    if (!rootTree) return;
-    const nextPath = [...treePath, subtreeNodeId];
-    const nextTree = getTreeAtPath(rootTree, nextPath);
+    const activeRootTree = rootTreeRef.current;
+    const activePath = treePathRef.current;
+    if (!activeRootTree) return;
+    const nextPath = [...activePath, subtreeNodeId];
+    const nextTree = getTreeAtPath(activeRootTree, nextPath);
     if (!nextTree) return;
 
     syncEditorState(nextTree, nextPath, { center: true });
-  }, [rootTree, syncEditorState, treePath]);
+  }, [syncEditorState]);
 
   const handleOpenSelectedSubtree = useCallback(() => {
     if (selectedNodes.length !== 1) return;
@@ -1024,6 +1205,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       setEditingService({ nodeId: node.id, data: node.data as ROSServiceNodeData });
     } else if (isSubtreeNode(node as BehaviorTreeNode)) {
       openSubtreeNode(node.id);
+    } else if (isIteratingControlNode(node)) {
+      setEditingIterationNodeId(node.id);
     } else if (isOrderedControlNode(node as BehaviorTreeNode)) {
       setOrderingParentId(node.id);
     }
@@ -1045,6 +1228,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         node.type !== BehaviorNodeType.Action &&
         node.type !== BehaviorNodeType.Service &&
         node.type !== BehaviorNodeType.Subtree &&
+        !isIteratingControlNode(node) &&
         !isOrderedControlNode(node as BehaviorTreeNode)
       ) {
         return;
@@ -1097,9 +1281,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   );
 
   const handleSave = useCallback(() => {
-    if (!currentTree) return;
+    const activeTree = currentTreeRef.current;
+    const activePath = treePathRef.current;
+    const activeRootTree = rootTreeRef.current;
+    if (!activeTree) return;
+
     const updatedTree: BehaviorTree = {
-      ...currentTree,
+      ...activeTree,
       nodes: nodes as BehaviorTreeNode[],
       edges,
       updatedAt: Date.now(),
@@ -1108,25 +1296,14 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     if (success) {
       syncBehaviorTreeReferences(updatedTree);
 
-      const activePath = treePathRef.current;
-      const baseRootTree = rootTreeRef.current;
-      const syncedRootTree = baseRootTree
+      const syncedRootTree = activeRootTree
         ? syncReferencedSubtrees(
-            activePath.length === 0 ? updatedTree : updateTreeAtPath(baseRootTree, activePath, () => updatedTree),
+            activePath.length === 0 ? updatedTree : updateTreeAtPath(activeRootTree, activePath, () => updatedTree),
             updatedTree
           )
         : updatedTree;
 
-      rootTreeRef.current = syncedRootTree;
-      setRootTree(syncedRootTree);
-
-      const nextCurrentTree =
-        activePath.length === 0 ? syncedRootTree : getTreeAtPath(syncedRootTree, activePath);
-      if (nextCurrentTree) {
-        syncEditorState(nextCurrentTree, activePath);
-      } else {
-        persistEditorTree(nodes, edges, { name: updatedTree.name });
-      }
+      syncRootTreeAndEditor(syncedRootTree, activePath);
 
       showSaveNotice({
         type: 'success',
@@ -1140,20 +1317,23 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         message: 'The tree could not be saved. Please try again.',
       });
     }
-  }, [currentTree, edges, nodes, persistEditorTree, showSaveNotice, syncEditorState]);
+  }, [edges, nodes, showSaveNotice, syncRootTreeAndEditor]);
 
   const handleLoad = useCallback((tree: BehaviorTree) => {
+    const activePath = treePathRef.current;
+    const activeRootTree = rootTreeRef.current;
+    const activeCurrentTree = currentTreeRef.current;
     pushUndoSnapshot();
 
-    if (treePath.length === 0) {
+    if (activePath.length === 0) {
       loadRootTree(tree);
       return;
     }
 
-    const loadedTree = { ...tree, name: tree.name || currentTree?.name || 'Subtree' };
-    const nextRootTree = rootTree ? replaceTreeAtPath(rootTree, treePath, loadedTree) : loadedTree;
-    const subtreeNodeId = treePath[treePath.length - 1];
-    const parentPath = treePath.slice(0, -1);
+    const loadedTree = { ...tree, name: tree.name || activeCurrentTree?.name || 'Subtree' };
+    const nextRootTree = activeRootTree ? replaceTreeAtPath(activeRootTree, activePath, loadedTree) : loadedTree;
+    const subtreeNodeId = activePath[activePath.length - 1];
+    const parentPath = activePath.slice(0, -1);
     const parentTree =
       parentPath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, parentPath);
 
@@ -1178,9 +1358,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
             })
         : nextRootTree;
 
-    setRootTree(nextRootWithLabel);
-    syncEditorState(loadedTree, treePath, { center: true });
-  }, [currentTree?.name, loadRootTree, pushUndoSnapshot, rootTree, syncEditorState, treePath]);
+    syncRootTreeAndEditor(nextRootWithLabel, activePath, { center: true });
+  }, [loadRootTree, pushUndoSnapshot, syncRootTreeAndEditor]);
 
   const handleNew = useCallback(() => {
     if (nodes.length > 0 || edges.length > 0) {
@@ -1198,14 +1377,16 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    if (treePath.length === 0) {
+    const activePath = treePathRef.current;
+    const activeRootTree = rootTreeRef.current;
+    if (activePath.length === 0) {
       loadRootTree(newTree);
       return;
     }
 
-    const nextRootTree = rootTree ? replaceTreeAtPath(rootTree, treePath, newTree) : newTree;
-    const subtreeNodeId = treePath[treePath.length - 1];
-    const parentPath = treePath.slice(0, -1);
+    const nextRootTree = activeRootTree ? replaceTreeAtPath(activeRootTree, activePath, newTree) : newTree;
+    const subtreeNodeId = activePath[activePath.length - 1];
+    const parentPath = activePath.slice(0, -1);
     const parentTree =
       parentPath.length === 0 ? nextRootTree : getTreeAtPath(nextRootTree, parentPath);
     const nextRootWithLabel =
@@ -1229,9 +1410,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
             })
         : nextRootTree;
 
-    setRootTree(nextRootWithLabel);
-    syncEditorState(newTree, treePath);
-  }, [edges.length, loadRootTree, nodes.length, pushUndoSnapshot, rootTree, syncEditorState, treePath]);
+    syncRootTreeAndEditor(nextRootWithLabel, activePath);
+  }, [edges.length, loadRootTree, nodes.length, pushUndoSnapshot, syncRootTreeAndEditor]);
 
   const handleExport = useCallback(() => {
     if (!currentTree) return;
@@ -1248,21 +1428,24 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   }, [edges, fitView, nodes, persistEditorTree]);
 
   const handleRename = useCallback((name: string) => {
-    if (!currentTree) return;
+    const activeTree = currentTreeRef.current;
+    const activePath = treePathRef.current;
+    if (!activeTree) return;
     pushUndoSnapshot();
 
-    const nextTree = { ...currentTree, name };
+    const nextTree = { ...activeTree, name };
     currentTreeRef.current = nextTree;
     setCurrentTree(nextTree);
     setRootTree((previousRootTree) => {
-      if (!previousRootTree || treePath.length === 0) {
+      const baseRootTree = previousRootTree ?? rootTreeRef.current;
+      if (!baseRootTree || activePath.length === 0) {
         rootTreeRef.current = nextTree;
         return nextTree;
       }
 
-      const renamedRootTree = replaceTreeAtPath(previousRootTree, treePath, nextTree);
-      const subtreeNodeId = treePath[treePath.length - 1];
-      const parentPath = treePath.slice(0, -1);
+      const renamedRootTree = replaceTreeAtPath(baseRootTree, activePath, nextTree);
+      const subtreeNodeId = activePath[activePath.length - 1];
+      const parentPath = activePath.slice(0, -1);
       if (!subtreeNodeId) return renamedRootTree;
 
       const parentTree = parentPath.length === 0 ? renamedRootTree : getTreeAtPath(renamedRootTree, parentPath);
@@ -1290,7 +1473,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       rootTreeRef.current = nextRootTree;
       return nextRootTree;
     });
-  }, [currentTree, pushUndoSnapshot, treePath]);
+  }, [pushUndoSnapshot]);
 
   const updateDisplayedNodeStatus = useCallback((nodeId: string, status: ExecutionStatus) => {
     setNodes((currentNodes) =>
@@ -1460,50 +1643,45 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   }, [resetTransientEdgeState, resetTransientNodeState]);
 
   const restoreRootTreeSnapshot = useCallback(
-    (snapshot: BehaviorTree) => {
-      const activePath = treePathRef.current;
-      const activeTree = activePath.length === 0 ? snapshot : getTreeAtPath(snapshot, activePath);
-      const nextPath = activeTree ? activePath : [];
-      const nextTree = activeTree ?? snapshot;
-
-      rootTreeRef.current = snapshot;
-      setRootTree(snapshot);
-      syncEditorState(nextTree, nextPath);
+    (snapshot: HistorySnapshot) => {
+      syncRootTreeAndEditor(snapshot.tree, snapshot.path);
     },
-    [syncEditorState]
+    [syncRootTreeAndEditor]
   );
 
   const handleUndo = useCallback(() => {
-    const previousRootTree = undoHistoryRef.current.pop();
-    if (!previousRootTree || !rootTreeRef.current) return;
+    const previousSnapshot = undoHistoryRef.current.pop();
+    const redoSnapshot = createHistorySnapshot();
+    if (!previousSnapshot || !redoSnapshot) return;
 
     redoHistoryRef.current = [
       ...redoHistoryRef.current.slice(-(MAX_UNDO_HISTORY - 1)),
-      cloneBehaviorTree(rootTreeRef.current),
+      redoSnapshot,
     ];
 
     isRestoringHistory.current = true;
-    restoreRootTreeSnapshot(previousRootTree);
+    restoreRootTreeSnapshot(previousSnapshot);
     setCanUndo(undoHistoryRef.current.length > 0);
     setCanRedo(true);
     isRestoringHistory.current = false;
-  }, [restoreRootTreeSnapshot]);
+  }, [createHistorySnapshot, restoreRootTreeSnapshot]);
 
   const handleRedo = useCallback(() => {
-    const nextRootTree = redoHistoryRef.current.pop();
-    if (!nextRootTree || !rootTreeRef.current) return;
+    const nextSnapshot = redoHistoryRef.current.pop();
+    const undoSnapshot = createHistorySnapshot();
+    if (!nextSnapshot || !undoSnapshot) return;
 
     undoHistoryRef.current = [
       ...undoHistoryRef.current.slice(-(MAX_UNDO_HISTORY - 1)),
-      cloneBehaviorTree(rootTreeRef.current),
+      undoSnapshot,
     ];
 
     isRestoringHistory.current = true;
-    restoreRootTreeSnapshot(nextRootTree);
+    restoreRootTreeSnapshot(nextSnapshot);
     setCanUndo(true);
     setCanRedo(redoHistoryRef.current.length > 0);
     isRestoringHistory.current = false;
-  }, [restoreRootTreeSnapshot]);
+  }, [createHistorySnapshot, restoreRootTreeSnapshot]);
 
   useEffect(() => {
     onExecutionChange?.(executionSnapshot);
@@ -1537,6 +1715,85 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     return () => onExecutionControlsChange?.(null);
   }, [handleStop, onExecutionControlsChange]);
 
+  const updateCustomBoxSelection = useCallback(
+    (gesture: CustomBoxSelectionGesture) => {
+      const canvas = reactFlowWrapper.current;
+      if (!canvas) return;
+
+      const left = Math.min(gesture.startX, gesture.currentX);
+      const right = Math.max(gesture.startX, gesture.currentX);
+      const top = Math.min(gesture.startY, gesture.currentY);
+      const bottom = Math.max(gesture.startY, gesture.currentY);
+      const selectionRect = createViewportRect(left, top, right, bottom);
+      const canvasRect = canvas.getBoundingClientRect();
+
+      customBoxSelectionRectRef.current = selectionRect;
+      setCustomBoxSelection({
+        left: left - canvasRect.left,
+        top: top - canvasRect.top,
+        width: selectionRect.width,
+        height: selectionRect.height,
+      });
+
+      if (!gesture.didDrag) return;
+
+      const selectedNodeIds = getBoxSelectionNodeIds(new Set());
+      const selectedEdgeIds = getBoxSelectionEdgeIds(selectedNodeIds);
+      commitSelectionState(selectedNodeIds, selectedEdgeIds);
+    },
+    [commitSelectionState, getBoxSelectionEdgeIds, getBoxSelectionNodeIds]
+  );
+
+  const finishCustomBoxSelection = useCallback((): boolean => {
+    const gesture = customBoxSelectionGestureRef.current;
+    if (!gesture) return false;
+
+    updateCustomBoxSelection(gesture);
+
+    if (typeof gesture.element.hasPointerCapture === 'function' &&
+      gesture.element.hasPointerCapture(gesture.pointerId) &&
+      typeof gesture.element.releasePointerCapture === 'function'
+    ) {
+      gesture.element.releasePointerCapture(gesture.pointerId);
+    }
+
+    customBoxSelectionGestureRef.current = null;
+    customBoxSelectionRectRef.current = null;
+    setCustomBoxSelection(null);
+    boxSelectionActiveRef.current = false;
+    boxSelectionPointerDownRef.current = false;
+    boxSelectionEndPendingRef.current = false;
+    boxSelectionEndedAtRef.current =
+      gesture.didDrag && (selectedNodeIdsRef.current.size > 0 || selectedEdgeIdsRef.current.size > 0)
+        ? Date.now()
+        : 0;
+
+    return true;
+  }, [updateCustomBoxSelection]);
+
+  const releaseBoxSelectionPointer = useCallback(() => {
+    if (finishCustomBoxSelection()) return;
+
+    if (!boxSelectionPointerDownRef.current) return;
+    boxSelectionPointerDownRef.current = false;
+
+    if (boxSelectionActiveRef.current || boxSelectionEndPendingRef.current) {
+      finalizeBoxSelection();
+    }
+  }, [finalizeBoxSelection, finishCustomBoxSelection]);
+
+  useEffect(() => {
+    document.addEventListener('pointerup', releaseBoxSelectionPointer);
+    document.addEventListener('pointercancel', releaseBoxSelectionPointer);
+    window.addEventListener('blur', releaseBoxSelectionPointer);
+
+    return () => {
+      document.removeEventListener('pointerup', releaseBoxSelectionPointer);
+      document.removeEventListener('pointercancel', releaseBoxSelectionPointer);
+      window.removeEventListener('blur', releaseBoxSelectionPointer);
+    };
+  }, [releaseBoxSelectionPointer]);
+
   useEffect(() => {
     return () => {
       if (executorRef.current) executorRef.current.stop();
@@ -1544,6 +1801,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       boxSelectionNodeIdsRef.current = null;
       boxSelectionEdgeIdsRef.current = null;
       boxSelectionEndedAtRef.current = 0;
+      boxSelectionPointerDownRef.current = false;
+      boxSelectionEndPendingRef.current = false;
+      if (subtreeReturnAnchorFrameRef.current !== null) {
+        window.cancelAnimationFrame(subtreeReturnAnchorFrameRef.current);
+      }
     };
   }, []);
 
@@ -1603,6 +1865,68 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       };
     });
   }, [behaviorNodes, edges]);
+
+  const updateSubtreeReturnAnchor = useCallback(() => {
+    if (treePathRef.current.length === 0) {
+      setSubtreeReturnAnchor(null);
+      return;
+    }
+
+    const canvas = reactFlowWrapper.current;
+    if (!canvas) return;
+
+    const canvasRect = canvas.getBoundingClientRect();
+    const nodeElements = Array.from(canvas.querySelectorAll<HTMLElement>('.react-flow__node'));
+
+    if (nodeElements.length === 0) {
+      setSubtreeReturnAnchor({ x: 16, y: 64 });
+      return;
+    }
+
+    const bounds = nodeElements.reduce(
+      (acc, element) => {
+        const rect = element.getBoundingClientRect();
+        if (rect.width <= 0 && rect.height <= 0) return acc;
+        return {
+          left: Math.min(acc.left, rect.left),
+          top: Math.min(acc.top, rect.top),
+          right: Math.max(acc.right, rect.right),
+          bottom: Math.max(acc.bottom, rect.bottom),
+        };
+      },
+      { left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity }
+    );
+
+    if (!Number.isFinite(bounds.left)) {
+      setSubtreeReturnAnchor({ x: 16, y: 64 });
+      return;
+    }
+
+    const x = Math.min(Math.max(bounds.left - canvasRect.left - 2, 8), Math.max(canvasRect.width - 132, 8));
+    const aboveY = bounds.top - canvasRect.top - 46;
+    const y =
+      aboveY >= 8
+        ? aboveY
+        : Math.min(Math.max(bounds.bottom - canvasRect.top + 10, 8), Math.max(canvasRect.height - 40, 8));
+
+    setSubtreeReturnAnchor({ x, y });
+  }, []);
+
+  const scheduleSubtreeReturnAnchorUpdate = useCallback(() => {
+    if (subtreeReturnAnchorFrameRef.current !== null) {
+      window.cancelAnimationFrame(subtreeReturnAnchorFrameRef.current);
+    }
+
+    subtreeReturnAnchorFrameRef.current = window.requestAnimationFrame(() => {
+      subtreeReturnAnchorFrameRef.current = null;
+      updateSubtreeReturnAnchor();
+    });
+  }, [updateSubtreeReturnAnchor]);
+
+  useEffect(() => {
+    scheduleSubtreeReturnAnchorUpdate();
+  }, [nodes, scheduleSubtreeReturnAnchorUpdate, treePath]);
+
   const orderingParent = useMemo(() => {
     const parent = behaviorNodes.find((node) => node.id === orderingParentId);
     return isOrderedControlNode(parent) ? parent : null;
@@ -1625,7 +1949,98 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     },
     [edges, nodes, orderingParent, persistEditorTree]
   );
+  const handleCanvasPointerDownCapture = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (canvasInteractionMode !== 'select') return;
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (!target.closest('.react-flow')) return;
+      if (
+        target.closest(
+          '.react-flow__node, .react-flow__edge, .react-flow__handle, .react-flow__controls, .react-flow__minimap, .bt-node-search, .bt-selection-actions, .bt-subtree-parent-action'
+        )
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      if (typeof event.currentTarget.setPointerCapture === 'function') {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }
+
+      customBoxSelectionGestureRef.current = {
+        pointerId: event.pointerId,
+        element: event.currentTarget,
+        startX: event.clientX,
+        startY: event.clientY,
+        currentX: event.clientX,
+        currentY: event.clientY,
+        didDrag: false,
+      };
+      customBoxSelectionRectRef.current = createViewportRect(
+        event.clientX,
+        event.clientY,
+        event.clientX,
+        event.clientY
+      );
+      boxSelectionPointerDownRef.current = true;
+      boxSelectionActiveRef.current = true;
+      boxSelectionNodeIdsRef.current = null;
+      boxSelectionEdgeIdsRef.current = null;
+      boxSelectionEndedAtRef.current = 0;
+      boxSelectionEndPendingRef.current = false;
+      setCustomBoxSelection(null);
+      setOrderingParentId(null);
+      setSelectionActionAnchor(null);
+      commitSelectionState(new Set(), new Set());
+    },
+    [canvasInteractionMode, commitSelectionState]
+  );
+
+  const handleCanvasPointerMoveCapture = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const gesture = customBoxSelectionGestureRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      gesture.currentX = event.clientX;
+      gesture.currentY = event.clientY;
+      if (
+        Math.hypot(gesture.currentX - gesture.startX, gesture.currentY - gesture.startY) >=
+        BOX_SELECTION_DRAG_THRESHOLD
+      ) {
+        gesture.didDrag = true;
+      }
+
+      updateCustomBoxSelection(gesture);
+    },
+    [updateCustomBoxSelection]
+  );
+
+  const handleCanvasPointerEndCapture = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const gesture = customBoxSelectionGestureRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      gesture.currentX = event.clientX;
+      gesture.currentY = event.clientY;
+      finishCustomBoxSelection();
+    },
+    [finishCustomBoxSelection]
+  );
+
   const handlePaneClick = useCallback(() => {
+    if (boxSelectionActiveRef.current || boxSelectionPointerDownRef.current) {
+      return;
+    }
+
     if (
       Date.now() - boxSelectionEndedAtRef.current <= BOX_SELECTION_CLEAR_SUPPRESSION_MS &&
       (selectedNodeIdsRef.current.size > 0 || selectedEdgeIdsRef.current.size > 0)
@@ -1648,6 +2063,55 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     const node = behaviorNodes.find((candidate) => candidate.id === selectedNodes[0].id);
     return isSubtreeNode(node) ? node : null;
   }, [behaviorNodes, selectedNodes]);
+  const selectedIterationNode = useMemo(() => {
+    if (selectedNodes.length !== 1) return null;
+    const node = behaviorNodes.find((candidate) => candidate.id === selectedNodes[0].id);
+    return isIteratingControlNode(node) ? node : null;
+  }, [behaviorNodes, selectedNodes]);
+  const editingIterationNode = useMemo(
+    () => behaviorNodes.find((node) => node.id === editingIterationNodeId && isIteratingControlNode(node)) ?? null,
+    [behaviorNodes, editingIterationNodeId]
+  );
+
+  const handleOpenSelectedIterationSettings = useCallback(() => {
+    if (!selectedIterationNode) return;
+    setEditingIterationNodeId(selectedIterationNode.id);
+  }, [selectedIterationNode]);
+
+  const handleSaveIterationLimit = useCallback(
+    (limit: number) => {
+      if (!editingIterationNode) return;
+      const normalizedLimit = normalizeIterationLimit(limit);
+      const nextNodes = nodes.map((node) =>
+        node.id === editingIterationNode.id
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                iterationLimit: normalizedLimit,
+              },
+            }
+          : node
+      ) as BehaviorTreeNode[];
+
+      persistEditorTree(nextNodes, edges);
+      setSelectedNodes((currentNodes) =>
+        currentNodes.map((node) =>
+          node.id === editingIterationNode.id
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  iterationLimit: normalizedLimit,
+                },
+              }
+            : node
+        )
+      );
+      setEditingIterationNodeId(null);
+    },
+    [editingIterationNode, edges, nodes, persistEditorTree]
+  );
 
   const canWrapSelection = useMemo(() => {
     if (!currentTree || selectedNodes.length < 2) return false;
@@ -1860,12 +2324,14 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   ]);
 
   const handleNavigateUp = useCallback(() => {
-    if (!rootTree || treePath.length === 0) return;
-    const nextPath = treePath.slice(0, -1);
-    const nextTree = nextPath.length === 0 ? rootTree : getTreeAtPath(rootTree, nextPath);
+    const activeRootTree = rootTreeRef.current;
+    const activePath = treePathRef.current;
+    if (!activeRootTree || activePath.length === 0) return;
+    const nextPath = activePath.slice(0, -1);
+    const nextTree = nextPath.length === 0 ? activeRootTree : getTreeAtPath(activeRootTree, nextPath);
     if (!nextTree) return;
     syncEditorState(nextTree, nextPath, { center: true });
-  }, [rootTree, syncEditorState, treePath]);
+  }, [syncEditorState]);
 
   const handleSearchSelect = useCallback(
     (node: BehaviorTreeNode) => {
@@ -1889,7 +2355,6 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         currentTree={currentTree}
         isExecuting={isExecuting}
         isPaletteCollapsed={isPaletteCollapsed}
-        isEditingSubtree={treePath.length > 0}
         nodeCount={nodes.length}
         canUndo={canUndo}
         canRedo={canRedo}
@@ -1905,7 +2370,6 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         onUndo={handleUndo}
         onRedo={handleRedo}
         onInteractionModeChange={setCanvasInteractionMode}
-        onNavigateUp={handleNavigateUp}
         onRename={handleRename}
       />
 
@@ -1961,7 +2425,15 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
           onAddNode={handleAddNode}
         />
 
-        <div className="bt-canvas" ref={reactFlowWrapper} data-testid="bt-canvas">
+        <div
+          className="bt-canvas"
+          ref={reactFlowWrapper}
+          onPointerDownCapture={handleCanvasPointerDownCapture}
+          onPointerMoveCapture={handleCanvasPointerMoveCapture}
+          onPointerUpCapture={handleCanvasPointerEndCapture}
+          onPointerCancelCapture={handleCanvasPointerEndCapture}
+          data-testid="bt-canvas"
+        >
           <ReactFlow
             nodes={nodes}
             edges={displayedEdges}
@@ -1978,12 +2450,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
             onSelectionChange={onSelectionChange}
             onSelectionStart={handleSelectionStart}
             onSelectionEnd={handleSelectionEnd}
+            onMove={scheduleSubtreeReturnAnchorUpdate}
             nodeTypes={nodeTypes}
             connectionMode={ConnectionMode.Loose}
             selectionMode={SelectionMode.Partial}
             multiSelectionKeyCode={['Control', 'Meta']}
             panOnDrag={canvasInteractionMode === 'pan'}
-            selectionOnDrag={canvasInteractionMode === 'select'}
+            selectionOnDrag={false}
             connectionRadius={48}
             fitView
             minZoom={0.1}
@@ -2006,7 +2479,37 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
               }}
             />
           </ReactFlow>
+          {customBoxSelection && (
+            <div
+              className="bt-custom-selection"
+              style={{
+                left: customBoxSelection.left,
+                top: customBoxSelection.top,
+                width: customBoxSelection.width,
+                height: customBoxSelection.height,
+              }}
+              data-testid="bt-custom-selection"
+            />
+          )}
           <NodeSearch nodes={behaviorNodes} onSelectNode={handleSearchSelect} />
+          {treePath.length > 0 && subtreeReturnAnchor && (
+            <button
+              type="button"
+              className="bt-subtree-parent-action"
+              style={{ left: subtreeReturnAnchor.x, top: subtreeReturnAnchor.y }}
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                handleNavigateUp();
+              }}
+              title="Back to parent tree"
+              aria-label="Back to parent tree"
+              data-testid="bt-subtree-parent"
+            >
+              <FaLevelUpAlt aria-hidden="true" />
+              <span>Parent</span>
+            </button>
+          )}
           {selectionActionAnchor && (selectedNodes.length > 0 || selectedEdges.length > 0) && (
             <div
               className="bt-selection-actions"
@@ -2029,6 +2532,19 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
                 >
                   <FaEdit aria-hidden="true" />
                   <span>Rename</span>
+                </button>
+              )}
+              {selectedIterationNode && (
+                <button
+                  type="button"
+                  className="bt-selection-action"
+                  onClick={handleOpenSelectedIterationSettings}
+                  title="Set retry/repeat count"
+                  aria-label="Set retry/repeat count"
+                  data-testid="bt-configure-iteration"
+                >
+                  <FaCog aria-hidden="true" />
+                  <span>Count</span>
                 </button>
               )}
               {selectedNodes.length > 0 && (
@@ -2141,6 +2657,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
           defaultName={getDefaultNodeName(renamingNode)}
           onSave={handleSaveNodeName}
           onClose={() => setRenamingNodeId(null)}
+        />
+      )}
+      {editingIterationNode && (
+        <IterationLimitEditor
+          node={editingIterationNode}
+          onSave={handleSaveIterationLimit}
+          onClose={() => setEditingIterationNodeId(null)}
         />
       )}
     </div>

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -155,6 +155,11 @@ const MAX_UNDO_HISTORY = 80;
 const SELECTION_ACTIONS_MAX_WIDTH = 360;
 const BOX_SELECTION_CLEAR_SUPPRESSION_MS = 120;
 const BOX_SELECTION_DRAG_THRESHOLD = 4;
+const PALETTE_ADD_NODE_X_GAP = 190;
+const PALETTE_ADD_NODE_Y_GAP = 130;
+const PALETTE_ADD_NODE_COLUMNS = 3;
+const NODE_POSITION_COLLISION_X = 160;
+const NODE_POSITION_COLLISION_Y = 110;
 const MANUAL_EDGE_SELECTION_SUPPRESSION_MS = 160;
 
 const getKnownReactFlowElementId = (
@@ -201,6 +206,32 @@ const createViewportRect = (left: number, top: number, right: number, bottom: nu
   bottom,
   toJSON: () => ({}),
 } as DOMRect);
+
+const findOpenPaletteAddPosition = (
+  position: { x: number; y: number },
+  existingNodes: BehaviorTreeNode[]
+): { x: number; y: number } => {
+  const isOccupied = (candidate: { x: number; y: number }) =>
+    existingNodes.some(
+      (node) =>
+        Math.abs(node.position.x - candidate.x) < NODE_POSITION_COLLISION_X &&
+        Math.abs(node.position.y - candidate.y) < NODE_POSITION_COLLISION_Y
+    );
+
+  for (let index = 0; index < 12; index += 1) {
+    const candidate = {
+      x: position.x + (index % PALETTE_ADD_NODE_COLUMNS) * PALETTE_ADD_NODE_X_GAP,
+      y: position.y + Math.floor(index / PALETTE_ADD_NODE_COLUMNS) * PALETTE_ADD_NODE_Y_GAP,
+    };
+
+    if (!isOccupied(candidate)) return candidate;
+  }
+
+  return {
+    x: position.x + existingNodes.length * 48,
+    y: position.y + existingNodes.length * 48,
+  };
+};
 
 interface ChildOrderPanelProps {
   parent: BehaviorTreeNode;
@@ -724,13 +755,19 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     (
       nodeType: BehaviorNodeType,
       position: { x: number; y: number },
-      item?: ROSNodeInfo | BehaviorTree
+      item?: ROSNodeInfo | BehaviorTree,
+      options: { avoidOverlap?: boolean } = {}
     ) => {
+      const existingBehaviorNodes = nodes as BehaviorTreeNode[];
+      const nextPosition = options.avoidOverlap
+        ? findOpenPaletteAddPosition(position, existingBehaviorNodes)
+        : position;
+
       if (nodeType === BehaviorNodeType.Subtree && item && 'nodes' in item && 'edges' in item) {
         const subtreeNode = createSubtreeNode({
           id: allocateNodeId(nodes),
           label: item.name,
-          position,
+          position: nextPosition,
           tree: cloneBehaviorTree(item),
           sourceTreeId: item.id,
         });
@@ -741,7 +778,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       const newNode = createBehaviorTreeNode({
         id: allocateNodeId(nodes),
         nodeType,
-        position,
+        position: nextPosition,
         rosInfo: item as ROSNodeInfo | undefined,
       });
       if (!newNode) return;
@@ -1871,7 +1908,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         y: bounds.top + bounds.height / 2,
       });
 
-      addNodeAtPosition(nodeType, position, item);
+      addNodeAtPosition(nodeType, position, item, { avoidOverlap: true });
 
       // Close palette on mobile after adding
       if (window.matchMedia(MOBILE_BREAKPOINT).matches) {

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -2328,6 +2328,11 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     setSelectedEdges([]);
     selectedNodeIdsRef.current = new Set([subtreeNode.id]);
     selectedEdgeIdsRef.current = new Set();
+    manualEdgeSelectionRef.current = {
+      nodeIds: new Set([subtreeNode.id]),
+      edgeIds: new Set(),
+      expiresAt: Date.now() + MANUAL_EDGE_SELECTION_SUPPRESSION_MS,
+    };
     setSelectedNodes([
       {
         ...subtreeNode,

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -12,17 +12,29 @@ import ReactFlow, {
   ReactFlowProvider,
   BackgroundVariant,
   ConnectionMode,
+  SelectionMode,
   useReactFlow,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import type { Ros } from 'roslib';
 import { v4 as uuidv4 } from 'uuid';
-import { FaArrowDown, FaArrowUp } from 'react-icons/fa';
+import {
+  FaArrowDown,
+  FaArrowUp,
+  FaClone,
+  FaEdit,
+  FaExpandArrowsAlt,
+  FaFolderOpen,
+  FaObjectGroup,
+  FaSave,
+  FaTrash,
+} from 'react-icons/fa';
 
 import { nodeTypes } from './nodes/nodeTypes';
 import NodePalette from './NodePalette';
 import NodeSearch from './NodeSearch';
 import BehaviorTreeToolbar from './BehaviorTreeToolbar';
+import type { BehaviorTreeInteractionMode } from './BehaviorTreeToolbar';
 import NodeNameEditor from './NodeNameEditor';
 import ActionParameterEditor from './ActionParameterEditor';
 import ServiceParameterEditor from './ServiceParameterEditor';
@@ -102,7 +114,47 @@ interface SaveNotice {
   message: string;
 }
 
+interface SyncEditorOptions {
+  center?: boolean;
+}
+
 const MOBILE_BREAKPOINT = '(max-width: 768px)';
+const MAX_UNDO_HISTORY = 80;
+const SELECTION_ACTIONS_MAX_WIDTH = 360;
+const BOX_SELECTION_CLEAR_SUPPRESSION_MS = 120;
+
+const getKnownReactFlowElementId = (
+  element: Element,
+  knownIds: Set<string>,
+  testIdPrefixes: string[]
+): string | null => {
+  const dataId = element.getAttribute('data-id');
+  if (dataId && knownIds.has(dataId)) return dataId;
+
+  const testId = element.getAttribute('data-testid');
+  if (!testId) return null;
+
+  for (const prefix of testIdPrefixes) {
+    if (testId.startsWith(prefix)) {
+      const id = testId.slice(prefix.length);
+      if (knownIds.has(id)) return id;
+    }
+  }
+
+  return null;
+};
+
+const rectsIntersect = (first: DOMRect, second: DOMRect) =>
+  first.right >= second.left - 1 &&
+  first.left <= second.right + 1 &&
+  first.bottom >= second.top - 1 &&
+  first.top <= second.bottom + 1;
+
+const rectFullyContains = (outer: DOMRect, inner: DOMRect) =>
+  inner.left >= outer.left - 1 &&
+  inner.right <= outer.right + 1 &&
+  inner.top >= outer.top - 1 &&
+  inner.bottom <= outer.bottom + 1;
 
 interface ChildOrderPanelProps {
   parent: BehaviorTreeNode;
@@ -242,6 +294,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const [isExecuting, setIsExecuting] = useState(false);
   const [isPaletteCollapsed, setIsPaletteCollapsed] = useState(true);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
+  const [selectedEdges, setSelectedEdges] = useState<Edge[]>([]);
+  const [selectionActionAnchor, setSelectionActionAnchor] = useState<{ x: number; y: number } | null>(null);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const [canvasInteractionMode, setCanvasInteractionMode] =
+    useState<BehaviorTreeInteractionMode>('pan');
   // Action node currently being edited via the parameter editor modal.
   const [editingAction, setEditingAction] = useState<
     { nodeId: string; data: ROSActionNodeData } | null
@@ -266,6 +324,15 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const currentTreeRef = useRef<BehaviorTree | null>(null);
   const rootTreeRef = useRef<BehaviorTree | null>(null);
   const treePathRef = useRef<string[]>([]);
+  const undoHistoryRef = useRef<BehaviorTree[]>([]);
+  const redoHistoryRef = useRef<BehaviorTree[]>([]);
+  const isRestoringHistory = useRef(false);
+  const selectedNodeIdsRef = useRef<Set<string>>(new Set());
+  const selectedEdgeIdsRef = useRef<Set<string>>(new Set());
+  const boxSelectionActiveRef = useRef(false);
+  const boxSelectionNodeIdsRef = useRef<Set<string> | null>(null);
+  const boxSelectionEdgeIdsRef = useRef<Set<string> | null>(null);
+  const boxSelectionEndedAtRef = useRef(0);
 
   const { screenToFlowPosition, fitView, getZoom, setCenter } = useReactFlow();
 
@@ -308,8 +375,16 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     treePathRef.current = treePath;
   }, [treePath]);
 
+  const centerTreeInView = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        fitView({ padding: 0.22, duration: 380, maxZoom: 1.1 });
+      });
+    });
+  }, [fitView]);
+
   const syncEditorState = useCallback(
-    (tree: BehaviorTree, nextPath: string[]) => {
+    (tree: BehaviorTree, nextPath: string[], options: SyncEditorOptions = {}) => {
       const nextNodes = resetTransientNodeState(tree.nodes);
       const nextEdges = resetTransientEdgeState(tree.edges);
       const nextTree = {
@@ -325,14 +400,32 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       setNodes(nextNodes);
       setEdges(nextEdges);
       setSelectedNodes([]);
+      setSelectedEdges([]);
+      selectedNodeIdsRef.current = new Set();
+      selectedEdgeIdsRef.current = new Set();
       setOrderingParentId(null);
       setRenamingNodeId(null);
       setEditingAction(null);
       setEditingService(null);
       nodeIdCounter.current = getNodeCounterAfterNodes(nextNodes);
+      if (options.center && nextNodes.length > 0) {
+        centerTreeInView();
+      }
     },
-    [resetTransientEdgeState, resetTransientNodeState]
+    [centerTreeInView, resetTransientEdgeState, resetTransientNodeState]
   );
+
+  const pushUndoSnapshot = useCallback(() => {
+    if (isRestoringHistory.current || !rootTreeRef.current) return;
+
+    undoHistoryRef.current = [
+      ...undoHistoryRef.current.slice(-(MAX_UNDO_HISTORY - 1)),
+      cloneBehaviorTree(rootTreeRef.current),
+    ];
+    redoHistoryRef.current = [];
+    setCanUndo(true);
+    setCanRedo(false);
+  }, []);
 
   const persistEditorTree = useCallback(
     (
@@ -341,6 +434,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       treeOverrides: Partial<BehaviorTree> = {}
     ): BehaviorTree | null => {
       if (!currentTree) return null;
+      pushUndoSnapshot();
 
       const nextTree: BehaviorTree = {
         ...currentTree,
@@ -364,7 +458,66 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       });
       return nextTree;
     },
-    [currentTree, treePath]
+    [currentTree, pushUndoSnapshot, treePath]
+  );
+
+  const applySelectionState = useCallback(
+    (selectedNodeIds: Set<string>, selectedEdgeIds: Set<string>) => {
+      const nextSelectedNodeIds = new Set(selectedNodeIds);
+      const nextSelectedEdgeIds = new Set(selectedEdgeIds);
+      selectedNodeIdsRef.current = nextSelectedNodeIds;
+      selectedEdgeIdsRef.current = nextSelectedEdgeIds;
+      if (nextSelectedNodeIds.size === 0 && nextSelectedEdgeIds.size === 0) {
+        setSelectionActionAnchor(null);
+      }
+
+      setNodes((currentNodes) => {
+        const nextNodes = currentNodes.map((node) => ({
+          ...node,
+          selected: nextSelectedNodeIds.has(node.id),
+          data: {
+            ...node.data,
+            isHighlighted: nextSelectedNodeIds.has(node.id),
+          },
+        }));
+        setSelectedNodes(
+          nextNodes
+            .filter((candidate) => nextSelectedNodeIds.has(candidate.id))
+            .map((candidate) => ({ ...candidate, selected: true, dragging: false }))
+        );
+
+        setEdges((currentEdges) => {
+          const nextEdges = currentEdges.map((edge) => ({
+            ...edge,
+            selected: nextSelectedEdgeIds.has(edge.id),
+          }));
+          setSelectedEdges(
+            nextEdges
+              .filter((candidate) => nextSelectedEdgeIds.has(candidate.id))
+              .map((candidate) => ({ ...candidate, selected: true }))
+          );
+
+          currentTreeRef.current = currentTreeRef.current
+            ? { ...currentTreeRef.current, nodes: nextNodes, edges: nextEdges }
+            : currentTreeRef.current;
+          setCurrentTree((previousTree) =>
+            previousTree ? { ...previousTree, nodes: nextNodes, edges: nextEdges } : previousTree
+          );
+
+          return nextEdges;
+        });
+
+        return nextNodes;
+      });
+    },
+    []
+  );
+
+  const commitSelectionState = useCallback(
+    (selectedNodeIds: Set<string>, selectedEdgeIds: Set<string>) => {
+      applySelectionState(selectedNodeIds, selectedEdgeIds);
+    },
+    [applySelectionState]
   );
 
   const loadRootTree = useCallback(
@@ -376,7 +529,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       };
       rootTreeRef.current = hydrated;
       setRootTree(hydrated);
-      syncEditorState(hydrated, []);
+      syncEditorState(hydrated, [], { center: true });
     },
     [resetTransientEdgeState, resetTransientNodeState, syncEditorState]
   );
@@ -469,18 +622,205 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     [edges, nodes, persistEditorTree]
   );
 
+  const getCurrentSelectionRect = useCallback((): DOMRect | null => {
+    const canvas = reactFlowWrapper.current;
+    const selectionElement = canvas?.querySelector<HTMLElement>('.react-flow__selection');
+    if (!canvas || !selectionElement) return null;
+
+    const selectionRect = selectionElement.getBoundingClientRect();
+    return selectionRect && (selectionRect.width > 0 || selectionRect.height > 0)
+      ? selectionRect
+      : null;
+  }, []);
+
+  const getPartiallyEnclosedBoxNodeIds = useCallback((): Set<string> | null => {
+    const canvas = reactFlowWrapper.current;
+    const selectionRect = getCurrentSelectionRect();
+    if (!canvas || !selectionRect) return null;
+
+    const knownNodeIds = new Set(nodes.map((node) => node.id));
+    const selectedNodeIds = new Set<string>();
+    let sawMeasurableNode = false;
+
+    canvas.querySelectorAll<HTMLElement>('.react-flow__node').forEach((nodeElement) => {
+      const nodeId = getKnownReactFlowElementId(nodeElement, knownNodeIds, [
+        'rf__node-',
+        'rf-node-',
+      ]);
+      if (!nodeId) return;
+
+      const nodeRect = nodeElement.getBoundingClientRect();
+      if (nodeRect.width <= 0 && nodeRect.height <= 0) return;
+      sawMeasurableNode = true;
+
+      if (rectsIntersect(nodeRect, selectionRect)) {
+        selectedNodeIds.add(nodeId);
+      }
+    });
+
+    return sawMeasurableNode ? selectedNodeIds : null;
+  }, [getCurrentSelectionRect, nodes]);
+
+  const getEdgesWithSelectedEndpoints = useCallback(
+    (selectedNodeIds: Set<string>) =>
+      new Set(
+        edges
+          .filter((edge) => selectedNodeIds.has(edge.source) && selectedNodeIds.has(edge.target))
+          .map((edge) => edge.id)
+      ),
+    [edges]
+  );
+
+  const getFullyEnclosedBoxEdgeIds = useCallback((): Set<string> | null => {
+    const canvas = reactFlowWrapper.current;
+    const selectionRect = getCurrentSelectionRect();
+    if (!canvas || !selectionRect) return null;
+
+    const knownEdgeIds = new Set(edges.map((edge) => edge.id));
+    const selectedEdgeIds = new Set<string>();
+    let sawMeasurableEdge = false;
+
+    canvas.querySelectorAll<SVGGElement>('.react-flow__edge').forEach((edgeElement) => {
+      const edgeId = getKnownReactFlowElementId(edgeElement, knownEdgeIds, [
+        'rf__edge-',
+        'rf-edge-',
+      ]);
+      if (!edgeId) return;
+
+      const edgeRect = edgeElement.getBoundingClientRect();
+      if (edgeRect.width <= 0 && edgeRect.height <= 0) return;
+      sawMeasurableEdge = true;
+
+      if (rectFullyContains(selectionRect, edgeRect)) {
+        selectedEdgeIds.add(edgeId);
+      }
+    });
+
+    return sawMeasurableEdge ? selectedEdgeIds : null;
+  }, [edges, getCurrentSelectionRect]);
+
+  const getBoxSelectionNodeIds = useCallback(
+    (fallbackNodeIds: Set<string>) => {
+      const measuredNodeIds = getPartiallyEnclosedBoxNodeIds();
+      if (measuredNodeIds) {
+        boxSelectionNodeIdsRef.current = new Set(measuredNodeIds);
+        return measuredNodeIds;
+      }
+
+      return boxSelectionNodeIdsRef.current
+        ? new Set(boxSelectionNodeIdsRef.current)
+        : new Set(fallbackNodeIds);
+    },
+    [getPartiallyEnclosedBoxNodeIds]
+  );
+
+  const getBoxSelectionEdgeIds = useCallback(
+    (selectedNodeIds: Set<string>) => {
+      const measuredEdgeIds = getFullyEnclosedBoxEdgeIds();
+      if (measuredEdgeIds) {
+        boxSelectionEdgeIdsRef.current = new Set(measuredEdgeIds);
+        return measuredEdgeIds;
+      }
+
+      if (boxSelectionEdgeIdsRef.current) {
+        return new Set(boxSelectionEdgeIdsRef.current);
+      }
+
+      return getEdgesWithSelectedEndpoints(selectedNodeIds);
+    },
+    [getEdgesWithSelectedEndpoints, getFullyEnclosedBoxEdgeIds]
+  );
+
+  const shouldIgnoreRecentBoxSelectionReduction = useCallback(
+    (nextSelectedNodeIds: Set<string>, nextSelectedEdgeIds: Set<string>) => {
+      if (boxSelectionActiveRef.current) return false;
+      if (Date.now() - boxSelectionEndedAtRef.current > BOX_SELECTION_CLEAR_SUPPRESSION_MS) {
+        return false;
+      }
+
+      return (
+        nextSelectedNodeIds.size < selectedNodeIdsRef.current.size ||
+        nextSelectedEdgeIds.size < selectedEdgeIdsRef.current.size
+      );
+    },
+    []
+  );
+
   const onNodesChange = useCallback(
     (changes: Parameters<typeof applyNodeChanges>[0]) => {
-      persistEditorTree(applyNodeChanges(changes, nodes) as BehaviorTreeNode[], edges);
+      const nextNodes = applyNodeChanges(changes, nodes) as BehaviorTreeNode[];
+
+      const shouldOnlyUpdateViewportState = changes.every((change) => {
+        if (change.type === 'select' || change.type === 'dimensions') return true;
+        return change.type === 'position' && 'dragging' in change && change.dragging === true;
+      });
+
+      if (changes.every((change) => change.type === 'select')) {
+        const flowSelectedNodeIds = new Set(
+          nextNodes.filter((node) => node.selected).map((node) => node.id)
+        );
+        const selectedNodeIds = boxSelectionActiveRef.current
+          ? getBoxSelectionNodeIds(flowSelectedNodeIds)
+          : flowSelectedNodeIds;
+        const selectedEdgeIds = boxSelectionActiveRef.current
+          ? getBoxSelectionEdgeIds(selectedNodeIds)
+          : selectedEdgeIdsRef.current;
+        if (shouldIgnoreRecentBoxSelectionReduction(selectedNodeIds, selectedEdgeIds)) return;
+        commitSelectionState(selectedNodeIds, selectedEdgeIds);
+        return;
+      }
+
+      if (shouldOnlyUpdateViewportState) {
+        setNodes(
+          nextNodes.map((node) => ({
+            ...node,
+            selected: selectedNodeIdsRef.current.has(node.id),
+            data: {
+              ...node.data,
+              isHighlighted: selectedNodeIdsRef.current.has(node.id),
+            },
+          }))
+        );
+        return;
+      }
+
+      persistEditorTree(nextNodes, edges);
     },
-    [edges, nodes, persistEditorTree]
+    [
+      commitSelectionState,
+      edges,
+      getBoxSelectionEdgeIds,
+      getBoxSelectionNodeIds,
+      nodes,
+      persistEditorTree,
+      shouldIgnoreRecentBoxSelectionReduction,
+    ]
   );
 
   const onEdgesChange = useCallback(
     (changes: Parameters<typeof applyEdgeChanges>[0]) => {
-      persistEditorTree(nodes, applyEdgeChanges(changes, edges));
+      const nextEdges = applyEdgeChanges(changes, edges);
+
+      if (changes.every((change) => change.type === 'select')) {
+        const selectedNodeIds = selectedNodeIdsRef.current;
+        const selectedEdgeIds = boxSelectionActiveRef.current
+          ? getBoxSelectionEdgeIds(selectedNodeIds)
+          : new Set(nextEdges.filter((edge) => edge.selected).map((edge) => edge.id));
+        if (shouldIgnoreRecentBoxSelectionReduction(selectedNodeIds, selectedEdgeIds)) return;
+        commitSelectionState(selectedNodeIds, selectedEdgeIds);
+        return;
+      }
+
+      persistEditorTree(nodes, nextEdges);
     },
-    [edges, nodes, persistEditorTree]
+    [
+      commitSelectionState,
+      edges,
+      getBoxSelectionEdgeIds,
+      nodes,
+      persistEditorTree,
+      shouldIgnoreRecentBoxSelectionReduction,
+    ]
   );
 
   const onDragOver = useCallback((event: React.DragEvent) => {
@@ -526,23 +866,67 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   // Track selected nodes for the delete button
   const onSelectionChange = useCallback(
-    ({ nodes: sel }: { nodes: Node[] }) => {
-      setSelectedNodes(sel);
+    ({ nodes: sel, edges: selectedFlowEdges }: { nodes: Node[]; edges: Edge[] }) => {
+      const flowSelectedNodeIds = new Set(sel.map((node) => node.id));
+      const selectedNodeIds = boxSelectionActiveRef.current
+        ? getBoxSelectionNodeIds(flowSelectedNodeIds)
+        : flowSelectedNodeIds;
+      const selectedEdgeIds = boxSelectionActiveRef.current
+        ? getBoxSelectionEdgeIds(selectedNodeIds)
+        : new Set(selectedFlowEdges.map((edge) => edge.id));
+
+      if (shouldIgnoreRecentBoxSelectionReduction(selectedNodeIds, selectedEdgeIds)) return;
+      commitSelectionState(selectedNodeIds, selectedEdgeIds);
     },
-    []
+    [
+      commitSelectionState,
+      getBoxSelectionEdgeIds,
+      getBoxSelectionNodeIds,
+      shouldIgnoreRecentBoxSelectionReduction,
+    ]
   );
+
+  const handleSelectionStart = useCallback(() => {
+    boxSelectionActiveRef.current = true;
+    boxSelectionNodeIdsRef.current = null;
+    boxSelectionEdgeIdsRef.current = null;
+    boxSelectionEndedAtRef.current = 0;
+    setOrderingParentId(null);
+    setSelectionActionAnchor(null);
+    commitSelectionState(new Set(), new Set());
+  }, [commitSelectionState]);
+
+  const handleSelectionEnd = useCallback(() => {
+    if (!boxSelectionActiveRef.current) return;
+
+    const selectedNodeIds = getBoxSelectionNodeIds(new Set(selectedNodeIdsRef.current));
+    const selectedEdgeIds = getBoxSelectionEdgeIds(selectedNodeIds);
+    commitSelectionState(selectedNodeIds, selectedEdgeIds);
+    boxSelectionActiveRef.current = false;
+    boxSelectionEndedAtRef.current =
+      selectedNodeIds.size > 0 || selectedEdgeIds.size > 0 ? Date.now() : 0;
+  }, [commitSelectionState, getBoxSelectionEdgeIds, getBoxSelectionNodeIds]);
 
   // Delete selected nodes (and their connected edges)
   const handleDeleteSelected = useCallback(() => {
     const selectedIds = new Set(selectedNodes.map((node) => node.id));
-    if (selectedIds.size === 0) return;
+    const selectedEdgeIds = new Set(selectedEdges.map((edge) => edge.id));
+    if (selectedIds.size === 0 && selectedEdgeIds.size === 0) return;
 
     persistEditorTree(
       nodes.filter((node) => !selectedIds.has(node.id)),
-      edges.filter((edge) => !selectedIds.has(edge.source) && !selectedIds.has(edge.target))
+      edges.filter(
+        (edge) =>
+          !selectedEdgeIds.has(edge.id) &&
+          !selectedIds.has(edge.source) &&
+          !selectedIds.has(edge.target)
+      )
     );
     setSelectedNodes([]);
-  }, [edges, nodes, persistEditorTree, selectedNodes]);
+    setSelectedEdges([]);
+    selectedNodeIdsRef.current = new Set();
+    selectedEdgeIdsRef.current = new Set();
+  }, [edges, nodes, persistEditorTree, selectedEdges, selectedNodes]);
 
   const handleDuplicateSelected = useCallback(() => {
     const selectedNodeIds = selectedNodes.map((node) => node.id);
@@ -560,6 +944,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     nodeIdCounter.current = result.nextNodeCounter;
     persistEditorTree(result.nodes, result.edges);
     setSelectedNodes(result.duplicatedNodes);
+    selectedNodeIdsRef.current = new Set(result.duplicatedNodes.map((node) => node.id));
+    selectedEdgeIdsRef.current = new Set();
   }, [edges, nodes, persistEditorTree, selectedNodes]);
 
   const handleOpenSelectedNodeRename = useCallback(() => {
@@ -621,7 +1007,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     const nextTree = getTreeAtPath(rootTree, nextPath);
     if (!nextTree) return;
 
-    syncEditorState(nextTree, nextPath);
+    syncEditorState(nextTree, nextPath, { center: true });
   }, [rootTree, syncEditorState, treePath]);
 
   const handleOpenSelectedSubtree = useCallback(() => {
@@ -630,22 +1016,6 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     if (!isSubtreeNode(selectedNode)) return;
     openSubtreeNode(selectedNode.id);
   }, [nodes, openSubtreeNode, selectedNodes]);
-
-  const highlightClickedNode = useCallback(
-    (clickedNodeId: string | null) => {
-      persistEditorTree(
-        nodes.map((node) => ({
-          ...node,
-          data: {
-            ...node.data,
-            isHighlighted: node.id === clickedNodeId,
-          },
-        })),
-        edges
-      );
-    },
-    [edges, nodes, persistEditorTree]
-  );
 
   const openNodeEditor = useCallback((node: Node) => {
     if (node.type === BehaviorNodeType.Action) {
@@ -667,8 +1037,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   );
 
   const onNodeClick = useCallback(
-    (_event: React.MouseEvent, node: Node) => {
-      highlightClickedNode(node.id);
+    (event: React.MouseEvent, node: Node) => {
+      setOrderingParentId(null);
 
       if (!window.matchMedia(MOBILE_BREAKPOINT).matches) return;
       if (
@@ -689,35 +1059,12 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         openNodeEditor(node);
       }
     },
-    [highlightClickedNode, openNodeEditor]
+    [openNodeEditor]
   );
 
-  const onEdgeClick = useCallback(
-    (_event: React.MouseEvent, edge: Edge) => {
-      const targetNode = nodes.find((node) => node.id === edge.target);
-      if (!targetNode) return;
-
-      const selectedTargetNode = { ...targetNode, selected: true, dragging: false };
-
-      const nextNodes = nodes.map((node) => ({
-          ...node,
-          selected: node.id === edge.target,
-          dragging: false,
-          data: {
-            ...node.data,
-            isHighlighted: node.id === edge.target,
-          },
-        }));
-      const nextEdges = edges.map((currentEdge) => ({
-          ...currentEdge,
-          selected: currentEdge.id === edge.id,
-        }));
-      persistEditorTree(nextNodes, nextEdges);
-      setSelectedNodes([selectedTargetNode]);
-      setOrderingParentId(null);
-    },
-    [edges, nodes, persistEditorTree]
-  );
+  const onEdgeClick = useCallback(() => {
+    setOrderingParentId(null);
+  }, []);
 
   const handleSaveActionParameters = useCallback(
     (parameters: Record<string, any>) => {
@@ -796,6 +1143,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   }, [currentTree, edges, nodes, persistEditorTree, showSaveNotice, syncEditorState]);
 
   const handleLoad = useCallback((tree: BehaviorTree) => {
+    pushUndoSnapshot();
+
     if (treePath.length === 0) {
       loadRootTree(tree);
       return;
@@ -830,8 +1179,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         : nextRootTree;
 
     setRootTree(nextRootWithLabel);
-    syncEditorState(loadedTree, treePath);
-  }, [currentTree?.name, loadRootTree, rootTree, syncEditorState, treePath]);
+    syncEditorState(loadedTree, treePath, { center: true });
+  }, [currentTree?.name, loadRootTree, pushUndoSnapshot, rootTree, syncEditorState, treePath]);
 
   const handleNew = useCallback(() => {
     if (nodes.length > 0 || edges.length > 0) {
@@ -839,6 +1188,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         return;
       }
     }
+    pushUndoSnapshot();
+
     const newTree: BehaviorTree = {
       id: uuidv4(),
       name: 'Untitled Behavior Tree',
@@ -880,7 +1231,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
     setRootTree(nextRootWithLabel);
     syncEditorState(newTree, treePath);
-  }, [edges.length, loadRootTree, nodes.length, rootTree, syncEditorState, treePath]);
+  }, [edges.length, loadRootTree, nodes.length, pushUndoSnapshot, rootTree, syncEditorState, treePath]);
 
   const handleExport = useCallback(() => {
     if (!currentTree) return;
@@ -898,6 +1249,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const handleRename = useCallback((name: string) => {
     if (!currentTree) return;
+    pushUndoSnapshot();
 
     const nextTree = { ...currentTree, name };
     currentTreeRef.current = nextTree;
@@ -938,7 +1290,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       rootTreeRef.current = nextRootTree;
       return nextRootTree;
     });
-  }, [currentTree, treePath]);
+  }, [currentTree, pushUndoSnapshot, treePath]);
 
   const updateDisplayedNodeStatus = useCallback((nodeId: string, status: ExecutionStatus) => {
     setNodes((currentNodes) =>
@@ -1107,9 +1459,78 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     }));
   }, [resetTransientEdgeState, resetTransientNodeState]);
 
+  const restoreRootTreeSnapshot = useCallback(
+    (snapshot: BehaviorTree) => {
+      const activePath = treePathRef.current;
+      const activeTree = activePath.length === 0 ? snapshot : getTreeAtPath(snapshot, activePath);
+      const nextPath = activeTree ? activePath : [];
+      const nextTree = activeTree ?? snapshot;
+
+      rootTreeRef.current = snapshot;
+      setRootTree(snapshot);
+      syncEditorState(nextTree, nextPath);
+    },
+    [syncEditorState]
+  );
+
+  const handleUndo = useCallback(() => {
+    const previousRootTree = undoHistoryRef.current.pop();
+    if (!previousRootTree || !rootTreeRef.current) return;
+
+    redoHistoryRef.current = [
+      ...redoHistoryRef.current.slice(-(MAX_UNDO_HISTORY - 1)),
+      cloneBehaviorTree(rootTreeRef.current),
+    ];
+
+    isRestoringHistory.current = true;
+    restoreRootTreeSnapshot(previousRootTree);
+    setCanUndo(undoHistoryRef.current.length > 0);
+    setCanRedo(true);
+    isRestoringHistory.current = false;
+  }, [restoreRootTreeSnapshot]);
+
+  const handleRedo = useCallback(() => {
+    const nextRootTree = redoHistoryRef.current.pop();
+    if (!nextRootTree || !rootTreeRef.current) return;
+
+    undoHistoryRef.current = [
+      ...undoHistoryRef.current.slice(-(MAX_UNDO_HISTORY - 1)),
+      cloneBehaviorTree(rootTreeRef.current),
+    ];
+
+    isRestoringHistory.current = true;
+    restoreRootTreeSnapshot(nextRootTree);
+    setCanUndo(true);
+    setCanRedo(redoHistoryRef.current.length > 0);
+    isRestoringHistory.current = false;
+  }, [restoreRootTreeSnapshot]);
+
   useEffect(() => {
     onExecutionChange?.(executionSnapshot);
   }, [executionSnapshot, onExecutionChange]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      const isEditableTarget =
+        target instanceof HTMLElement &&
+        (target.isContentEditable || target.tagName === 'INPUT' || target.tagName === 'TEXTAREA');
+
+      if (isEditableTarget) return;
+
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          handleRedo();
+        } else {
+          handleUndo();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleRedo, handleUndo]);
 
   useEffect(() => {
     onExecutionControlsChange?.({ stop: handleStop });
@@ -1119,6 +1540,10 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   useEffect(() => {
     return () => {
       if (executorRef.current) executorRef.current.stop();
+      boxSelectionActiveRef.current = false;
+      boxSelectionNodeIdsRef.current = null;
+      boxSelectionEdgeIdsRef.current = null;
+      boxSelectionEndedAtRef.current = 0;
     };
   }, []);
 
@@ -1157,20 +1582,23 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       const isRunning = targetStatus === ExecutionStatus.Running;
       const isSuccess = targetStatus === ExecutionStatus.Success;
       const isFailure = targetStatus === ExecutionStatus.Failure;
+      const isSelected = Boolean(edge.selected);
 
       return {
         ...edge,
         animated: isRunning,
         style: {
-          stroke: isRunning
+          stroke: isSelected
+            ? '#ffb300'
+            : isRunning
             ? '#ffc107'
             : isSuccess
               ? '#4caf50'
               : isFailure
                 ? '#f44336'
                 : 'var(--primary-color, #4285f4)',
-          strokeWidth: isRunning ? 4 : isSuccess || isFailure ? 3 : 2,
-          opacity: isRunning || isSuccess || isFailure ? 1 : 0.9,
+          strokeWidth: isSelected ? 5 : isRunning ? 4 : isSuccess || isFailure ? 3 : 2,
+          opacity: isSelected || isRunning || isSuccess || isFailure ? 1 : 0.9,
         },
       };
     });
@@ -1198,8 +1626,22 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     [edges, nodes, orderingParent, persistEditorTree]
   );
   const handlePaneClick = useCallback(() => {
+    if (
+      Date.now() - boxSelectionEndedAtRef.current <= BOX_SELECTION_CLEAR_SUPPRESSION_MS &&
+      (selectedNodeIdsRef.current.size > 0 || selectedEdgeIdsRef.current.size > 0)
+    ) {
+      return;
+    }
+
+    boxSelectionActiveRef.current = false;
+    boxSelectionNodeIdsRef.current = null;
+    boxSelectionEdgeIdsRef.current = null;
+    boxSelectionEndedAtRef.current = 0;
     setOrderingParentId(null);
-  }, []);
+    setSelectedNodes([]);
+    setSelectedEdges([]);
+    applySelectionState(new Set(), new Set());
+  }, [applySelectionState]);
 
   const selectedSubtreeNode = useMemo(() => {
     if (selectedNodes.length !== 1) return null;
@@ -1218,6 +1660,47 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       subtreeLabel: 'Subtree',
     }).ok;
   }, [behaviorNodes, currentTree, edges, selectedNodes]);
+
+  useEffect(() => {
+    if (selectedNodes.length === 0 && selectedEdges.length === 0) {
+      setSelectionActionAnchor(null);
+      return;
+    }
+
+    const canvas = reactFlowWrapper.current;
+    if (!canvas) return;
+
+    const selectedElements = Array.from(
+      canvas.querySelectorAll<Element>('.react-flow__node.selected, .react-flow__edge.selected')
+    );
+    if (selectedElements.length === 0) {
+      return;
+    }
+
+    const canvasRect = canvas.getBoundingClientRect();
+    const selectionRect = selectedElements.reduce(
+      (acc, element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          left: Math.min(acc.left, rect.left),
+          top: Math.min(acc.top, rect.top),
+          right: Math.max(acc.right, rect.right),
+          bottom: Math.max(acc.bottom, rect.bottom),
+        };
+      },
+      { left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity }
+    );
+    setSelectionActionAnchor({
+      x: Math.min(
+        Math.max(selectionRect.right - canvasRect.left + 10, 8),
+        Math.max(canvasRect.width - SELECTION_ACTIONS_MAX_WIDTH, 8)
+      ),
+      y: Math.min(
+        Math.max(selectionRect.top - canvasRect.top, 8),
+        Math.max(canvasRect.height - 48, 8)
+      ),
+    });
+  }, [edges, nodes, selectedEdges, selectedNodes]);
 
   const handleWrapSelectedIntoSubtree = useCallback(() => {
     if (!currentTree) return;
@@ -1238,25 +1721,33 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       });
       return;
     }
+    if (!isSubtreeNode(result.subtreeNode)) return;
 
-    const nextNodes = (result.tree.nodes as BehaviorTreeNode[]).map((node) => ({
-      ...node,
-      selected: node.id === result.subtreeNode.id,
-      data: {
-        ...node.data,
-        isHighlighted: node.id === result.subtreeNode.id,
-      },
-    }));
+    const subtreeNode = result.subtreeNode;
+    const nextNodes = (result.tree.nodes as BehaviorTreeNode[]).map((node) => {
+      const nextNode = node.id === subtreeNode.id ? subtreeNode : node;
+      return {
+        ...nextNode,
+        selected: nextNode.id === subtreeNode.id,
+        data: {
+          ...nextNode.data,
+          isHighlighted: nextNode.id === subtreeNode.id,
+        },
+      };
+    });
 
     persistEditorTree(nextNodes, result.tree.edges, {
       updatedAt: result.tree.updatedAt,
     });
+    setSelectedEdges([]);
+    selectedNodeIdsRef.current = new Set([subtreeNode.id]);
+    selectedEdgeIdsRef.current = new Set();
     setSelectedNodes([
       {
-        ...result.subtreeNode,
+        ...subtreeNode,
         selected: true,
         data: {
-          ...result.subtreeNode.data,
+          ...subtreeNode.data,
           isHighlighted: true,
         },
       },
@@ -1333,9 +1824,22 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     }
 
     nodeIdCounter.current = result.nextNodeCounter;
-    persistEditorTree(result.tree.nodes as BehaviorTreeNode[], result.tree.edges, {
+    const insertedNodeIds = new Set(result.insertedNodeIds);
+    const nextNodes = (result.tree.nodes as BehaviorTreeNode[]).map((node) => ({
+      ...node,
+      selected: insertedNodeIds.has(node.id),
+      data: {
+        ...node.data,
+        isHighlighted: insertedNodeIds.has(node.id),
+      },
+    }));
+
+    persistEditorTree(nextNodes, result.tree.edges, {
       updatedAt: result.tree.updatedAt,
     });
+    setSelectedEdges([]);
+    selectedNodeIdsRef.current = insertedNodeIds;
+    selectedEdgeIdsRef.current = new Set();
     setSelectedNodes(
       result.tree.nodes
         .filter((node) => result.insertedNodeIds.includes(node.id))
@@ -1360,7 +1864,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     const nextPath = treePath.slice(0, -1);
     const nextTree = nextPath.length === 0 ? rootTree : getTreeAtPath(rootTree, nextPath);
     if (!nextTree) return;
-    syncEditorState(nextTree, nextPath);
+    syncEditorState(nextTree, nextPath, { center: true });
   }, [rootTree, syncEditorState, treePath]);
 
   const handleSearchSelect = useCallback(
@@ -1370,23 +1874,13 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       const centerY = position.y + (node.height ?? 80) / 2;
       const selectedNode = { ...node, selected: true, dragging: false };
 
-      persistEditorTree(
-        nodes.map((currentNode) => ({
-          ...currentNode,
-          selected: currentNode.id === node.id,
-          dragging: false,
-          data: {
-            ...currentNode.data,
-            isHighlighted: currentNode.id === node.id,
-          },
-        })),
-        edges
-      );
       setSelectedNodes([selectedNode]);
+      setSelectedEdges([]);
+      applySelectionState(new Set([node.id]), new Set());
       setOrderingParentId(null);
       setCenter(centerX, centerY, { zoom: Math.max(getZoom(), 1), duration: 400 });
     },
-    [edges, getZoom, nodes, persistEditorTree, setCenter]
+    [applySelectionState, getZoom, setCenter]
   );
 
   return (
@@ -1397,9 +1891,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         isPaletteCollapsed={isPaletteCollapsed}
         isEditingSubtree={treePath.length > 0}
         nodeCount={nodes.length}
-        selectedNodeCount={selectedNodes.length}
-        canWrapSelection={canWrapSelection}
-        hasSelectedSubtree={Boolean(selectedSubtreeNode)}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        interactionMode={canvasInteractionMode}
         onSave={handleSave}
         onLoad={handleLoad}
         onNew={handleNew}
@@ -1408,13 +1902,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         onExport={handleExport}
         onArrange={handleArrange}
         onTogglePalette={() => setIsPaletteCollapsed((collapsed) => !collapsed)}
-        onDeleteSelected={handleDeleteSelected}
-        onDuplicateSelected={handleDuplicateSelected}
-        onRenameSelected={handleOpenSelectedNodeRename}
-        onWrapSelection={handleWrapSelectedIntoSubtree}
-        onOpenSelectedSubtree={handleOpenSelectedSubtree}
-        onSaveSelectedSubtree={handleSaveSelectedSubtree}
-        onExplodeSelectedSubtree={handleExplodeSelectedSubtree}
+        onUndo={handleUndo}
+        onRedo={handleRedo}
+        onInteractionModeChange={setCanvasInteractionMode}
         onNavigateUp={handleNavigateUp}
         onRename={handleRename}
       />
@@ -1486,8 +1976,14 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
             onEdgeClick={onEdgeClick}
             onPaneClick={handlePaneClick}
             onSelectionChange={onSelectionChange}
+            onSelectionStart={handleSelectionStart}
+            onSelectionEnd={handleSelectionEnd}
             nodeTypes={nodeTypes}
             connectionMode={ConnectionMode.Loose}
+            selectionMode={SelectionMode.Partial}
+            multiSelectionKeyCode={['Control', 'Meta']}
+            panOnDrag={canvasInteractionMode === 'pan'}
+            selectionOnDrag={canvasInteractionMode === 'select'}
             connectionRadius={48}
             fitView
             minZoom={0.1}
@@ -1511,6 +2007,107 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
             />
           </ReactFlow>
           <NodeSearch nodes={behaviorNodes} onSelectNode={handleSearchSelect} />
+          {selectionActionAnchor && (selectedNodes.length > 0 || selectedEdges.length > 0) && (
+            <div
+              className="bt-selection-actions"
+              style={{
+                left: selectionActionAnchor.x,
+                top: selectionActionAnchor.y,
+              }}
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => event.stopPropagation()}
+              data-testid="bt-selection-actions"
+            >
+              {selectedNodes.length === 1 && (
+                <button
+                  type="button"
+                  className="bt-selection-action"
+                  onClick={handleOpenSelectedNodeRename}
+                  title="Rename selected node"
+                  aria-label="Rename selected node"
+                  data-testid="bt-rename-selected"
+                >
+                  <FaEdit aria-hidden="true" />
+                  <span>Rename</span>
+                </button>
+              )}
+              {selectedNodes.length > 0 && (
+                <button
+                  type="button"
+                  className="bt-selection-action"
+                  onClick={handleDuplicateSelected}
+                  title={`Duplicate ${selectedNodes.length} selected node${selectedNodes.length > 1 ? 's' : ''}`}
+                  aria-label="Duplicate selected nodes"
+                  data-testid="bt-duplicate-selected"
+                >
+                  <FaClone aria-hidden="true" />
+                  <span>Duplicate</span>
+                </button>
+              )}
+              {canWrapSelection && (
+                <button
+                  type="button"
+                  className="bt-selection-action"
+                  onClick={handleWrapSelectedIntoSubtree}
+                  title="Wrap selected nodes in a subtree"
+                  aria-label="Wrap selected nodes in a subtree"
+                  data-testid="bt-context-wrap"
+                >
+                  <FaObjectGroup aria-hidden="true" />
+                  <span>Wrap</span>
+                </button>
+              )}
+              {selectedSubtreeNode && (
+                <>
+                  <button
+                    type="button"
+                    className="bt-selection-action"
+                    onClick={handleOpenSelectedSubtree}
+                    title="Open selected subtree"
+                    aria-label="Open selected subtree"
+                    data-testid="bt-context-open-subtree"
+                  >
+                    <FaFolderOpen aria-hidden="true" />
+                    <span>Open</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="bt-selection-action"
+                    onClick={handleSaveSelectedSubtree}
+                    title="Save selected subtree as a saved tree"
+                    aria-label="Save selected subtree"
+                    data-testid="bt-context-save-subtree"
+                  >
+                    <FaSave aria-hidden="true" />
+                    <span>Save</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="bt-selection-action"
+                    onClick={handleExplodeSelectedSubtree}
+                    title="Explode selected subtree"
+                    aria-label="Explode selected subtree"
+                    data-testid="bt-context-explode"
+                  >
+                    <FaExpandArrowsAlt aria-hidden="true" />
+                    <span>Explode</span>
+                  </button>
+                </>
+              )}
+              {(selectedNodes.length > 0 || selectedEdges.length > 0) && (
+                <button
+                  type="button"
+                  className="bt-selection-action danger"
+                  onClick={handleDeleteSelected}
+                  title={`Delete selected item${selectedNodes.length + selectedEdges.length > 1 ? 's' : ''}`}
+                  aria-label="Delete selected items"
+                >
+                  <FaTrash aria-hidden="true" />
+                  <span>Delete</span>
+                </button>
+              )}
+            </div>
+          )}
           {orderingParent && (
             <ChildOrderPanel
               parent={orderingParent}

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.css
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.css
@@ -104,13 +104,15 @@
 
 .bt-arrange-tree-btn,
 .bt-interaction-mode-btn,
+.bt-follow-mode-btn,
 .bt-undo-tree-btn,
 .bt-redo-tree-btn {
-  width: 44px;
-  height: 44px;
+  width: 48px;
+  height: 48px;
 }
 
-.bt-interaction-mode-btn.active {
+.bt-interaction-mode-btn.active,
+.bt-follow-mode-btn.active {
   background: var(--primary-color, #4285f4);
   border-color: var(--primary-color, #4285f4);
   color: #fff;
@@ -119,14 +121,20 @@
 
 .bt-select-tool-icon,
 .bt-pan-tool-icon {
-  width: 25px;
-  height: 25px;
+  width: 31px;
+  height: 31px;
   display: block;
 }
 
 .bt-pan-tool-icon {
+  width: 32px;
+  height: 32px;
+}
+
+.bt-follow-tool-icon {
   width: 27px;
   height: 27px;
+  display: block;
 }
 
 .bt-undo-tree-btn:disabled,

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.css
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.css
@@ -61,6 +61,16 @@
   opacity: 0.95;
 }
 
+.bt-palette-plus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  font-weight: 400;
+  line-height: 1;
+  transform: translateY(-1px);
+}
+
 .bt-float-icon-btn {
   width: 36px;
   height: 36px;
@@ -82,6 +92,21 @@
   height: 44px;
 }
 
+.bt-parent-tree-btn {
+  width: auto;
+  min-width: 0;
+  gap: 8px;
+  padding: 0 14px 0 10px;
+  border-radius: 18px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.bt-parent-tree-btn svg {
+  width: 21px;
+  height: 21px;
+}
+
 .bt-float-icon-btn:hover {
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.14);
 }
@@ -92,17 +117,31 @@
   color: #fff;
 }
 
-.bt-arrange-tree-btn {
+.bt-arrange-tree-btn,
+.bt-interaction-mode-btn,
+.bt-undo-tree-btn,
+.bt-redo-tree-btn {
   width: 44px;
   height: 44px;
 }
 
+.bt-interaction-mode-btn.active {
+  background: var(--primary-color, #4285f4);
+  border-color: var(--primary-color, #4285f4);
+  color: #fff;
+  box-shadow: 0 4px 14px rgba(66, 133, 244, 0.25);
+}
+
+.bt-undo-tree-btn:disabled,
+.bt-redo-tree-btn:disabled,
 .bt-arrange-tree-btn:disabled {
   cursor: default;
   opacity: 0.45;
   box-shadow: none;
 }
 
+.bt-undo-tree-btn:disabled:hover,
+.bt-redo-tree-btn:disabled:hover,
 .bt-arrange-tree-btn:disabled:hover {
   box-shadow: none;
 }

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.css
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.css
@@ -92,21 +92,6 @@
   height: 44px;
 }
 
-.bt-parent-tree-btn {
-  width: auto;
-  min-width: 0;
-  gap: 8px;
-  padding: 0 14px 0 10px;
-  border-radius: 18px;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.bt-parent-tree-btn svg {
-  width: 21px;
-  height: 21px;
-}
-
 .bt-float-icon-btn:hover {
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.14);
 }
@@ -130,6 +115,18 @@
   border-color: var(--primary-color, #4285f4);
   color: #fff;
   box-shadow: 0 4px 14px rgba(66, 133, 244, 0.25);
+}
+
+.bt-select-tool-icon,
+.bt-pan-tool-icon {
+  width: 25px;
+  height: 25px;
+  display: block;
+}
+
+.bt-pan-tool-icon {
+  width: 27px;
+  height: 27px;
 }
 
 .bt-undo-tree-btn:disabled,

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { BehaviorTree } from '../types';
+import { BehaviorNodeType, BehaviorTree } from '../types';
 import {
+  BEHAVIOR_TREE_STORAGE_EVENT,
   listBehaviorTrees,
   loadBehaviorTree,
   deleteBehaviorTree,
@@ -12,8 +13,11 @@ interface BehaviorTreeToolbarProps {
   currentTree: BehaviorTree | null;
   isExecuting: boolean;
   isPaletteCollapsed: boolean;
+  isEditingSubtree: boolean;
   nodeCount: number;
   selectedNodeCount: number;
+  canWrapSelection: boolean;
+  hasSelectedSubtree: boolean;
   onSave: () => void;
   onLoad: (tree: BehaviorTree) => void;
   onNew: () => void;
@@ -25,6 +29,11 @@ interface BehaviorTreeToolbarProps {
   onDeleteSelected: () => void;
   onDuplicateSelected: () => void;
   onRenameSelected: () => void;
+  onWrapSelection: () => void;
+  onOpenSelectedSubtree: () => void;
+  onSaveSelectedSubtree: () => void;
+  onExplodeSelectedSubtree: () => void;
+  onNavigateUp: () => void;
   onRename: (name: string) => void;
 }
 
@@ -32,8 +41,11 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   currentTree,
   isExecuting,
   isPaletteCollapsed,
+  isEditingSubtree,
   nodeCount,
   selectedNodeCount,
+  canWrapSelection,
+  hasSelectedSubtree,
   onSave,
   onLoad,
   onNew,
@@ -45,6 +57,11 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   onDeleteSelected,
   onDuplicateSelected,
   onRenameSelected,
+  onWrapSelection,
+  onOpenSelectedSubtree,
+  onSaveSelectedSubtree,
+  onExplodeSelectedSubtree,
+  onNavigateUp,
   onRename,
 }) => {
   const [menuOpen, setMenuOpen]       = useState(false);
@@ -57,6 +74,12 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   useEffect(() => {
     setNameValue(currentTree?.name ?? '');
   }, [currentTree?.id, currentTree?.name]);
+
+  useEffect(() => {
+    const handleSavedTreesChanged = () => setSavedTrees(listBehaviorTrees());
+    window.addEventListener(BEHAVIOR_TREE_STORAGE_EVENT, handleSavedTreesChanged);
+    return () => window.removeEventListener(BEHAVIOR_TREE_STORAGE_EVENT, handleSavedTreesChanged);
+  }, []);
 
   const openMenu = () => {
     setSavedTrees(listBehaviorTrees());
@@ -76,6 +99,17 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   const handleLoad = (treeId: string) => {
     const tree = loadBehaviorTree(treeId);
     if (tree) { onLoad(tree); closeMenu(); }
+  };
+
+  const handleTreeDragStart = (event: React.DragEvent, tree: BehaviorTree) => {
+    event.dataTransfer.setData(
+      'application/reactflow',
+      JSON.stringify({
+        nodeType: BehaviorNodeType.Subtree,
+        item: tree,
+      })
+    );
+    event.dataTransfer.effectAllowed = 'move';
   };
 
   const handleDelete = (tree: BehaviorTree, e: React.MouseEvent) => {
@@ -127,6 +161,19 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
     <>
       {/* ── Floating top-left: menu pill ──────────────────────── */}
       <div className="bt-float-bar">
+        {isEditingSubtree && (
+          <button
+            className="bt-float-icon-btn"
+            onClick={onNavigateUp}
+            title="Back to parent tree"
+            aria-label="Back to parent tree"
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M10.5 4.5L6 9l4.5 4.5" />
+              <path d="M6.5 9H14" />
+            </svg>
+          </button>
+        )}
         <button
           className="bt-float-menu-btn"
           onClick={openMenu}
@@ -194,6 +241,64 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
                 </svg>
                 <span className="bt-float-btn-label">Rename</span>
               </button>
+            )}
+            {canWrapSelection && (
+              <button
+                className="bt-float-duplicate-btn"
+                onClick={onWrapSelection}
+                title="Wrap selected sequence items in a subtree"
+                aria-label="Wrap selected nodes in a subtree"
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <rect x="1.5" y="3.5" width="4" height="4" rx="0.8" />
+                  <rect x="10.5" y="3.5" width="4" height="4" rx="0.8" />
+                  <rect x="6" y="9.5" width="4" height="4" rx="0.8" />
+                  <path d="M5.5 5.5h5M8 5.5v4" />
+                </svg>
+                <span className="bt-float-btn-label">Wrap</span>
+              </button>
+            )}
+            {hasSelectedSubtree && (
+              <>
+                <button
+                  className="bt-float-rename-btn"
+                  onClick={onOpenSelectedSubtree}
+                  title="Open selected subtree"
+                  aria-label="Open selected subtree"
+                >
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <rect x="2" y="2" width="12" height="12" rx="2" />
+                    <path d="M6 5h5v5M11 5L5 11" />
+                  </svg>
+                  <span className="bt-float-btn-label">Open</span>
+                </button>
+                <button
+                  className="bt-float-rename-btn"
+                  onClick={onExplodeSelectedSubtree}
+                  title="Explode selected subtree back into this tree"
+                  aria-label="Explode selected subtree"
+                >
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <rect x="2.5" y="2.5" width="11" height="11" rx="2" />
+                    <path d="M8 5v6M5 8h6" />
+                    <path d="M5 5l-2-2M11 5l2-2M5 11l-2 2M11 11l2 2" />
+                  </svg>
+                  <span className="bt-float-btn-label">Explode</span>
+                </button>
+                <button
+                  className="bt-float-duplicate-btn"
+                  onClick={onSaveSelectedSubtree}
+                  title="Save selected subtree as a saved tree"
+                  aria-label="Save selected subtree"
+                >
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M2 0h9l4 4v11a1 1 0 01-1 1H2a1 1 0 01-1-1V1a1 1 0 011-1z" fill="none" stroke="currentColor" strokeWidth="1.5"/>
+                    <rect x="4" y="0" width="6" height="5" rx="0" fill="currentColor" opacity=".5"/>
+                    <rect x="3" y="9" width="10" height="5" rx="1" fill="none" stroke="currentColor" strokeWidth="1.5"/>
+                  </svg>
+                  <span className="bt-float-btn-label">Save Subtree</span>
+                </button>
+              </>
             )}
             <button
               className="bt-float-duplicate-btn"
@@ -321,6 +426,8 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
                     <div
                       key={tree.id}
                       className={`bt-menu-tree-row${tree.id === currentTree?.id ? ' active' : ''}`}
+                      draggable
+                      onDragStart={(event) => handleTreeDragStart(event, tree)}
                       onClick={() => handleLoad(tree.id)}
                       role="button"
                       tabIndex={0}

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
@@ -9,15 +9,17 @@ import {
 } from '../storage/treeStorage';
 import './BehaviorTreeToolbar.css';
 
+export type BehaviorTreeInteractionMode = 'pan' | 'select';
+
 interface BehaviorTreeToolbarProps {
   currentTree: BehaviorTree | null;
   isExecuting: boolean;
   isPaletteCollapsed: boolean;
   isEditingSubtree: boolean;
   nodeCount: number;
-  selectedNodeCount: number;
-  canWrapSelection: boolean;
-  hasSelectedSubtree: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  interactionMode: BehaviorTreeInteractionMode;
   onSave: () => void;
   onLoad: (tree: BehaviorTree) => void;
   onNew: () => void;
@@ -26,13 +28,9 @@ interface BehaviorTreeToolbarProps {
   onExport: () => void;
   onArrange: () => void;
   onTogglePalette: () => void;
-  onDeleteSelected: () => void;
-  onDuplicateSelected: () => void;
-  onRenameSelected: () => void;
-  onWrapSelection: () => void;
-  onOpenSelectedSubtree: () => void;
-  onSaveSelectedSubtree: () => void;
-  onExplodeSelectedSubtree: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onInteractionModeChange: (mode: BehaviorTreeInteractionMode) => void;
   onNavigateUp: () => void;
   onRename: (name: string) => void;
 }
@@ -43,9 +41,9 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   isPaletteCollapsed,
   isEditingSubtree,
   nodeCount,
-  selectedNodeCount,
-  canWrapSelection,
-  hasSelectedSubtree,
+  canUndo,
+  canRedo,
+  interactionMode,
   onSave,
   onLoad,
   onNew,
@@ -54,13 +52,9 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   onExport,
   onArrange,
   onTogglePalette,
-  onDeleteSelected,
-  onDuplicateSelected,
-  onRenameSelected,
-  onWrapSelection,
-  onOpenSelectedSubtree,
-  onSaveSelectedSubtree,
-  onExplodeSelectedSubtree,
+  onUndo,
+  onRedo,
+  onInteractionModeChange,
   onNavigateUp,
   onRename,
 }) => {
@@ -163,15 +157,18 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
       <div className="bt-float-bar">
         {isEditingSubtree && (
           <button
-            className="bt-float-icon-btn"
+            className="bt-float-icon-btn bt-parent-tree-btn"
             onClick={onNavigateUp}
             title="Back to parent tree"
             aria-label="Back to parent tree"
           >
-            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M10.5 4.5L6 9l4.5 4.5" />
-              <path d="M6.5 9H14" />
+            <svg width="21" height="21" viewBox="0 0 21 21" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <rect x="3" y="2.75" width="7.5" height="5.5" rx="1.4" />
+              <rect x="10.5" y="12.75" width="7.5" height="5.5" rx="1.4" />
+              <path d="M14.25 12.75V10H6.75V8.25" />
+              <path d="M6.75 8.25L4.2 10.8M6.75 8.25l2.55 2.55" />
             </svg>
+            <span>Parent</span>
           </button>
         )}
         <button
@@ -197,13 +194,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
           aria-label="Toggle node palette"
           data-testid="bt-palette-toggle"
         >
-          <svg width="28" height="26" viewBox="0 0 28 26" fill="currentColor" aria-hidden="true">
-            <circle cx="14" cy="4" r="3.5"/>
-            <circle cx="5" cy="21" r="3.5"/>
-            <circle cx="23" cy="21" r="3.5"/>
-            <line x1="12.4" y1="7.2" x2="6.8" y2="17.7" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round"/>
-            <line x1="15.6" y1="7.2" x2="21.2" y2="17.7" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round"/>
-          </svg>
+          <span className="bt-palette-plus" aria-hidden="true">+</span>
         </button>
 
         <button
@@ -221,113 +212,65 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
             <path d="M11 6.5v4M5 15.5v-2.5h12v2.5" />
           </svg>
         </button>
+        <button
+          className={`bt-float-icon-btn bt-interaction-mode-btn${interactionMode === 'select' ? ' active' : ''}`}
+          onClick={() => onInteractionModeChange('select')}
+          title="Select nodes by dragging"
+          aria-label="Select nodes by dragging"
+          aria-pressed={interactionMode === 'select'}
+          data-testid="bt-select-mode"
+        >
+          <svg width="23" height="23" viewBox="0 0 23 23" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <rect x="3.2" y="3.2" width="13.6" height="11.8" rx="2" strokeDasharray="3 2" />
+            <path d="M12.5 12.5l5.7 5.7" />
+            <path d="M15.6 18.1l2.6-2.6" />
+          </svg>
+        </button>
+        <button
+          className={`bt-float-icon-btn bt-interaction-mode-btn${interactionMode === 'pan' ? ' active' : ''}`}
+          onClick={() => onInteractionModeChange('pan')}
+          title="Pan canvas"
+          aria-label="Pan canvas"
+          aria-pressed={interactionMode === 'pan'}
+          data-testid="bt-pan-mode"
+        >
+          <svg width="23" height="23" viewBox="0 0 23 23" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M8 11.2V6.4a1.45 1.45 0 0 1 2.9 0v4.3" />
+            <path d="M10.9 10.6V5.1a1.45 1.45 0 0 1 2.9 0v5.5" />
+            <path d="M13.8 11V6.6a1.45 1.45 0 0 1 2.9 0v6" />
+            <path d="M8 11.2l-1-1a1.55 1.55 0 0 0-2.2 2.2l4.9 4.9a6 6 0 0 0 4.2 1.7h.8a4.9 4.9 0 0 0 4.9-4.9v-2.4a1.45 1.45 0 0 0-2.9 0" />
+          </svg>
+        </button>
+        <button
+          className="bt-float-icon-btn bt-undo-tree-btn"
+          onClick={onUndo}
+          disabled={!canUndo}
+          title="Undo last behavior tree change"
+          aria-label="Undo last behavior tree change"
+          data-testid="bt-undo"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M7.5 6H3.5V2" />
+            <path d="M3.8 6A7 7 0 1 1 5 15" />
+          </svg>
+        </button>
+        <button
+          className="bt-float-icon-btn bt-redo-tree-btn"
+          onClick={onRedo}
+          disabled={!canRedo}
+          title="Redo last behavior tree change"
+          aria-label="Redo last behavior tree change"
+          data-testid="bt-redo"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M12.5 6h4V2" />
+            <path d="M16.2 6A7 7 0 1 0 15 15" />
+          </svg>
+        </button>
       </div>
 
       {/* ── Floating top-right: delete + run/stop ─────────────── */}
       <div className="bt-float-actions">
-        {selectedNodeCount > 0 && (
-          <>
-            {selectedNodeCount === 1 && (
-              <button
-                className="bt-float-rename-btn"
-                onClick={onRenameSelected}
-                title="Rename selected node"
-                aria-label="Rename selected node"
-                data-testid="bt-rename-selected"
-              >
-                <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M10.8 1.5l2.7 2.7-8.2 8.2-3.6.9.9-3.6 8.2-8.2z"/>
-                  <path d="M9.2 3.1l2.7 2.7"/>
-                </svg>
-                <span className="bt-float-btn-label">Rename</span>
-              </button>
-            )}
-            {canWrapSelection && (
-              <button
-                className="bt-float-duplicate-btn"
-                onClick={onWrapSelection}
-                title="Wrap selected sequence items in a subtree"
-                aria-label="Wrap selected nodes in a subtree"
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <rect x="1.5" y="3.5" width="4" height="4" rx="0.8" />
-                  <rect x="10.5" y="3.5" width="4" height="4" rx="0.8" />
-                  <rect x="6" y="9.5" width="4" height="4" rx="0.8" />
-                  <path d="M5.5 5.5h5M8 5.5v4" />
-                </svg>
-                <span className="bt-float-btn-label">Wrap</span>
-              </button>
-            )}
-            {hasSelectedSubtree && (
-              <>
-                <button
-                  className="bt-float-rename-btn"
-                  onClick={onOpenSelectedSubtree}
-                  title="Open selected subtree"
-                  aria-label="Open selected subtree"
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                    <rect x="2" y="2" width="12" height="12" rx="2" />
-                    <path d="M6 5h5v5M11 5L5 11" />
-                  </svg>
-                  <span className="bt-float-btn-label">Open</span>
-                </button>
-                <button
-                  className="bt-float-rename-btn"
-                  onClick={onExplodeSelectedSubtree}
-                  title="Explode selected subtree back into this tree"
-                  aria-label="Explode selected subtree"
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                    <rect x="2.5" y="2.5" width="11" height="11" rx="2" />
-                    <path d="M8 5v6M5 8h6" />
-                    <path d="M5 5l-2-2M11 5l2-2M5 11l-2 2M11 11l2 2" />
-                  </svg>
-                  <span className="bt-float-btn-label">Explode</span>
-                </button>
-                <button
-                  className="bt-float-duplicate-btn"
-                  onClick={onSaveSelectedSubtree}
-                  title="Save selected subtree as a saved tree"
-                  aria-label="Save selected subtree"
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                    <path d="M2 0h9l4 4v11a1 1 0 01-1 1H2a1 1 0 01-1-1V1a1 1 0 011-1z" fill="none" stroke="currentColor" strokeWidth="1.5"/>
-                    <rect x="4" y="0" width="6" height="5" rx="0" fill="currentColor" opacity=".5"/>
-                    <rect x="3" y="9" width="10" height="5" rx="1" fill="none" stroke="currentColor" strokeWidth="1.5"/>
-                  </svg>
-                  <span className="bt-float-btn-label">Save Subtree</span>
-                </button>
-              </>
-            )}
-            <button
-              className="bt-float-duplicate-btn"
-              onClick={onDuplicateSelected}
-              title={`Duplicate ${selectedNodeCount} selected node${selectedNodeCount > 1 ? 's' : ''}`}
-              aria-label="Duplicate selected nodes"
-              data-testid="bt-duplicate-selected"
-            >
-              <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <rect x="5" y="5" width="8" height="8" rx="1.2"/>
-                <path d="M2 10V3.2A1.2 1.2 0 0 1 3.2 2H10"/>
-              </svg>
-              <span className="bt-float-btn-label">Duplicate</span>
-            </button>
-            <button
-              className="bt-float-delete-btn"
-              onClick={onDeleteSelected}
-              title={`Delete ${selectedNodeCount} selected node${selectedNodeCount > 1 ? 's' : ''}`}
-            >
-              <svg width="13" height="15" viewBox="0 0 13 15" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <polyline points="0.5,3.5 12.5,3.5"/>
-                <path d="M4 3.5V2a0.8 0.8 0 0 1 0.8-0.8h3.4a0.8 0.8 0 0 1 0.8 0.8v1.5"/>
-                <path d="M2 3.5l0.8 9a0.8 0.8 0 0 0 0.8 0.8h5.8a0.8 0.8 0 0 0 0.8-0.8l0.8-9"/>
-              </svg>
-              <span className="bt-float-count">{selectedNodeCount}</span>
-            </button>
-          </>
-        )}
-
         {isExecuting ? (
           <button className="bt-float-stop-btn" onClick={onStop} title="Stop execution">
             <svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor" aria-hidden="true">

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
@@ -19,6 +19,7 @@ interface BehaviorTreeToolbarProps {
   canUndo: boolean;
   canRedo: boolean;
   interactionMode: BehaviorTreeInteractionMode;
+  isFollowMode: boolean;
   onSave: () => void;
   onLoad: (tree: BehaviorTree) => void;
   onNew: () => void;
@@ -30,6 +31,7 @@ interface BehaviorTreeToolbarProps {
   onUndo: () => void;
   onRedo: () => void;
   onInteractionModeChange: (mode: BehaviorTreeInteractionMode) => void;
+  onToggleFollowMode: () => void;
   onRename: (name: string) => void;
 }
 
@@ -41,6 +43,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   canUndo,
   canRedo,
   interactionMode,
+  isFollowMode,
   onSave,
   onLoad,
   onNew,
@@ -52,6 +55,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   onUndo,
   onRedo,
   onInteractionModeChange,
+  onToggleFollowMode,
   onRename,
 }) => {
   const [menuOpen, setMenuOpen]       = useState(false);
@@ -200,10 +204,11 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
           aria-pressed={interactionMode === 'select'}
           data-testid="bt-select-mode"
         >
-          <svg className="bt-select-tool-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <rect x="3.5" y="3.5" width="11.5" height="11.5" rx="2" stroke="currentColor" strokeWidth="1.8" strokeDasharray="3.4 2.6" />
-            <path d="M12.7 12.7l7.1 7.1" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            <path d="M16.6 20.2l3.6-3.6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          <svg className="bt-select-tool-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M5 3.4v16.8l4.9-4.4 3.3 5.6 3.1-1.8-3.3-5.6 6.5-1.1L5 3.4z"
+              fill="currentColor"
+            />
           </svg>
         </button>
         <button
@@ -215,10 +220,9 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
           data-testid="bt-pan-mode"
         >
           <svg className="bt-pan-tool-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path d="M8.4 12.2V7.1a1.55 1.55 0 0 1 3.1 0v4.7" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M11.5 11.6V5.7a1.55 1.55 0 0 1 3.1 0v6" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M14.6 12.1V7.5a1.55 1.55 0 0 1 3.1 0v7" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M8.4 12.2l-1.2-1.2a1.8 1.8 0 0 0-2.55 2.55l4.75 4.75A6.2 6.2 0 0 0 13.8 20h.85a5.05 5.05 0 0 0 5.05-5.05v-2.2a1.5 1.5 0 0 0-3 0" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M12 3v18M12 3L8.5 6.5M12 3l3.5 3.5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M21 12H3M21 12l-3.5-3.5M21 12l-3.5 3.5M3 12l3.5-3.5M3 12l3.5 3.5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
+            <circle cx="12" cy="12" r="1.7" fill="currentColor" />
           </svg>
         </button>
         <button
@@ -251,6 +255,20 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
 
       {/* ── Floating top-right: delete + run/stop ─────────────── */}
       <div className="bt-float-actions">
+        <button
+          className={`bt-float-icon-btn bt-follow-mode-btn${isFollowMode ? ' active' : ''}`}
+          onClick={onToggleFollowMode}
+          title={isFollowMode ? 'Disable follow mode' : 'Enable follow mode'}
+          aria-label={isFollowMode ? 'Disable follow mode' : 'Enable follow mode'}
+          aria-pressed={isFollowMode}
+          data-testid="bt-follow-mode"
+        >
+          <svg className="bt-follow-tool-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth="2" />
+            <circle cx="12" cy="12" r="2.2" fill="currentColor" />
+            <path d="M12 2.8v3M12 18.2v3M2.8 12h3M18.2 12h3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        </button>
         {isExecuting ? (
           <button className="bt-float-stop-btn" onClick={onStop} title="Stop execution">
             <svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor" aria-hidden="true">

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
@@ -204,11 +204,10 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
           aria-pressed={interactionMode === 'select'}
           data-testid="bt-select-mode"
         >
-          <svg className="bt-select-tool-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M5 3.4v16.8l4.9-4.4 3.3 5.6 3.1-1.8-3.3-5.6 6.5-1.1L5 3.4z"
-              fill="currentColor"
-            />
+          <svg className="bt-select-tool-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="3.5" y="3.5" width="11.5" height="11.5" rx="2" stroke="currentColor" strokeWidth="1.8" strokeDasharray="3.4 2.6" />
+            <path d="M12.7 12.7l7.1 7.1" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            <path d="M16.6 20.2l3.6-3.6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
           </svg>
         </button>
         <button
@@ -220,9 +219,10 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
           data-testid="bt-pan-mode"
         >
           <svg className="bt-pan-tool-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path d="M12 3v18M12 3L8.5 6.5M12 3l3.5 3.5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="M21 12H3M21 12l-3.5-3.5M21 12l-3.5 3.5M3 12l3.5-3.5M3 12l3.5 3.5" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
-            <circle cx="12" cy="12" r="1.7" fill="currentColor" />
+            <path d="M8.4 12.2V7.1a1.55 1.55 0 0 1 3.1 0v4.7" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M11.5 11.6V5.7a1.55 1.55 0 0 1 3.1 0v6" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M14.6 12.1V7.5a1.55 1.55 0 0 1 3.1 0v7" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M8.4 12.2l-1.2-1.2a1.8 1.8 0 0 0-2.55 2.55l4.75 4.75A6.2 6.2 0 0 0 13.8 20h.85a5.05 5.05 0 0 0 5.05-5.05v-2.2a1.5 1.5 0 0 0-3 0" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         </button>
         <button

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
@@ -15,7 +15,6 @@ interface BehaviorTreeToolbarProps {
   currentTree: BehaviorTree | null;
   isExecuting: boolean;
   isPaletteCollapsed: boolean;
-  isEditingSubtree: boolean;
   nodeCount: number;
   canUndo: boolean;
   canRedo: boolean;
@@ -31,7 +30,6 @@ interface BehaviorTreeToolbarProps {
   onUndo: () => void;
   onRedo: () => void;
   onInteractionModeChange: (mode: BehaviorTreeInteractionMode) => void;
-  onNavigateUp: () => void;
   onRename: (name: string) => void;
 }
 
@@ -39,7 +37,6 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   currentTree,
   isExecuting,
   isPaletteCollapsed,
-  isEditingSubtree,
   nodeCount,
   canUndo,
   canRedo,
@@ -55,7 +52,6 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   onUndo,
   onRedo,
   onInteractionModeChange,
-  onNavigateUp,
   onRename,
 }) => {
   const [menuOpen, setMenuOpen]       = useState(false);
@@ -155,22 +151,6 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
     <>
       {/* ── Floating top-left: menu pill ──────────────────────── */}
       <div className="bt-float-bar">
-        {isEditingSubtree && (
-          <button
-            className="bt-float-icon-btn bt-parent-tree-btn"
-            onClick={onNavigateUp}
-            title="Back to parent tree"
-            aria-label="Back to parent tree"
-          >
-            <svg width="21" height="21" viewBox="0 0 21 21" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <rect x="3" y="2.75" width="7.5" height="5.5" rx="1.4" />
-              <rect x="10.5" y="12.75" width="7.5" height="5.5" rx="1.4" />
-              <path d="M14.25 12.75V10H6.75V8.25" />
-              <path d="M6.75 8.25L4.2 10.8M6.75 8.25l2.55 2.55" />
-            </svg>
-            <span>Parent</span>
-          </button>
-        )}
         <button
           className="bt-float-menu-btn"
           onClick={openMenu}
@@ -220,10 +200,10 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
           aria-pressed={interactionMode === 'select'}
           data-testid="bt-select-mode"
         >
-          <svg width="23" height="23" viewBox="0 0 23 23" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <rect x="3.2" y="3.2" width="13.6" height="11.8" rx="2" strokeDasharray="3 2" />
-            <path d="M12.5 12.5l5.7 5.7" />
-            <path d="M15.6 18.1l2.6-2.6" />
+          <svg className="bt-select-tool-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="3.5" y="3.5" width="11.5" height="11.5" rx="2" stroke="currentColor" strokeWidth="1.8" strokeDasharray="3.4 2.6" />
+            <path d="M12.7 12.7l7.1 7.1" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            <path d="M16.6 20.2l3.6-3.6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
           </svg>
         </button>
         <button
@@ -234,11 +214,11 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
           aria-pressed={interactionMode === 'pan'}
           data-testid="bt-pan-mode"
         >
-          <svg width="23" height="23" viewBox="0 0 23 23" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="M8 11.2V6.4a1.45 1.45 0 0 1 2.9 0v4.3" />
-            <path d="M10.9 10.6V5.1a1.45 1.45 0 0 1 2.9 0v5.5" />
-            <path d="M13.8 11V6.6a1.45 1.45 0 0 1 2.9 0v6" />
-            <path d="M8 11.2l-1-1a1.55 1.55 0 0 0-2.2 2.2l4.9 4.9a6 6 0 0 0 4.2 1.7h.8a4.9 4.9 0 0 0 4.9-4.9v-2.4a1.45 1.45 0 0 0-2.9 0" />
+          <svg className="bt-pan-tool-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M8.4 12.2V7.1a1.55 1.55 0 0 1 3.1 0v4.7" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M11.5 11.6V5.7a1.55 1.55 0 0 1 3.1 0v6" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M14.6 12.1V7.5a1.55 1.55 0 0 1 3.1 0v7" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M8.4 12.2l-1.2-1.2a1.8 1.8 0 0 0-2.55 2.55l4.75 4.75A6.2 6.2 0 0 0 13.8 20h.85a5.05 5.05 0 0 0 5.05-5.05v-2.2a1.5 1.5 0 0 0-3 0" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         </button>
         <button

--- a/src/features/behaviorTree/components/NodePalette.test.tsx
+++ b/src/features/behaviorTree/components/NodePalette.test.tsx
@@ -46,6 +46,17 @@ describe('NodePalette', () => {
     expect(onAddNode).toHaveBeenCalledWith(BehaviorNodeType.Parallel, undefined);
   });
 
+  it('calls onAddNode with Retry and Repeat control nodes', () => {
+    const onAddNode = vi.fn();
+    render(<NodePalette {...defaultProps} onAddNode={onAddNode} />);
+
+    fireEvent.click(screen.getByText('Retry'));
+    fireEvent.click(screen.getByText('Repeat'));
+
+    expect(onAddNode).toHaveBeenCalledWith(BehaviorNodeType.Retry, undefined);
+    expect(onAddNode).toHaveBeenCalledWith(BehaviorNodeType.Repeat, undefined);
+  });
+
   it('does not throw when onAddNode is not provided and item is clicked', () => {
     render(<NodePalette {...defaultProps} />);
     expect(() => fireEvent.click(screen.getByText('Sequence'))).not.toThrow();

--- a/src/features/behaviorTree/components/NodePalette.tsx
+++ b/src/features/behaviorTree/components/NodePalette.tsx
@@ -111,6 +111,23 @@ const IconParallel = () => (
     <polyline points="6,7 7.5,9 9,7"/>
   </svg>
 );
+
+const IconRetry = () => (
+  <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M10.5 4.7A4.4 4.4 0 1 0 11 7" />
+    <polyline points="10.5,1.6 10.5,4.7 7.4,4.7" />
+  </svg>
+);
+
+const IconRepeat = () => (
+  <svg width="14" height="12" viewBox="0 0 14 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M2.2 4.5A4 4 0 0 1 5.9 2h5.3" />
+    <polyline points="9.2,0.5 11.2,2 9.2,3.5" />
+    <path d="M11.8 7.5A4 4 0 0 1 8.1 10H2.8" />
+    <polyline points="4.8,8.5 2.8,10 4.8,11.5" />
+  </svg>
+);
+
 const IconSubtree = () => (
   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <rect x="1.5" y="1.5" width="11" height="11" rx="2" />
@@ -275,6 +292,8 @@ const NodePalette: React.FC<NodePaletteProps> = ({
     Sequence: <IconSequence />,
     Selector: <IconSelector />,
     Parallel: <IconParallel />,
+    Retry: <IconRetry />,
+    Repeat: <IconRepeat />,
   };
 
   // Control flow nodes (always available)
@@ -282,6 +301,8 @@ const NodePalette: React.FC<NodePaletteProps> = ({
     { type: BehaviorNodeType.Sequence, label: 'Sequence', icon: '→', category: 'control' },
     { type: BehaviorNodeType.Selector, label: 'Selector', icon: '?', category: 'control' },
     { type: BehaviorNodeType.Parallel, label: 'Parallel', icon: '∥', category: 'control' },
+    { type: BehaviorNodeType.Retry, label: 'Retry', icon: '↻', category: 'control' },
+    { type: BehaviorNodeType.Repeat, label: 'Repeat', icon: '⟳', category: 'control' },
   ];
 
   const resourceSearchTerms = useMemo(

--- a/src/features/behaviorTree/components/NodePalette.tsx
+++ b/src/features/behaviorTree/components/NodePalette.tsx
@@ -1,5 +1,20 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import type { Ros } from 'roslib';
+import { discoverAllROSResources } from '../services/rosDiscovery';
+import {
+  BEHAVIOR_TREE_STORAGE_EVENT,
+  listBehaviorTrees,
+} from '../storage/treeStorage';
+import {
+  BehaviorTree,
+  ROSDiscoveryResult,
+  BehaviorNodeType,
+  NodePaletteItem,
+  ROSActionInfo,
+  ROSServiceInfo,
+  ROSTopicInfo,
+} from '../types';
+import './NodePalette.css';
 
 // ─── Palette icons ────────────────────────────────────────────────────────────
 
@@ -96,23 +111,22 @@ const IconParallel = () => (
     <polyline points="6,7 7.5,9 9,7"/>
   </svg>
 );
-import { discoverAllROSResources } from '../services/rosDiscovery';
-import {
-  ROSDiscoveryResult,
-  BehaviorNodeType,
-  NodePaletteItem,
-  ROSActionInfo,
-  ROSServiceInfo,
-  ROSTopicInfo,
-} from '../types';
-import './NodePalette.css';
+const IconSubtree = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect x="1.5" y="1.5" width="11" height="11" rx="2" />
+    <path d="M4.5 4.5h5M4.5 7h5M4.5 9.5h3" />
+  </svg>
+);
 
 interface NodePaletteProps {
   ros: Ros | null;
   isConnected: boolean;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
-  onAddNode?: (type: BehaviorNodeType, rosInfo?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo) => void;
+  onAddNode?: (
+    type: BehaviorNodeType,
+    item?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo | BehaviorTree
+  ) => void;
 }
 
 const MOBILE_BREAKPOINT = '(max-width: 768px)';
@@ -144,10 +158,12 @@ const NodePalette: React.FC<NodePaletteProps> = ({
   const hasDiscovered = React.useRef(false);
   const [expandedSections, setExpandedSections] = useState({
     control: true,
+    saved: true,
     actions: false,
     services: false,
     topics: false,
   });
+  const [savedTrees, setSavedTrees] = useState(listBehaviorTrees());
 
   const [isMobile, setIsMobile] = React.useState(false);
   // Height controlled by drag; null = CSS default
@@ -303,6 +319,15 @@ const NodePalette: React.FC<NodePaletteProps> = ({
     }
   }, [isConnected, ros]);
 
+  useEffect(() => {
+    const handleSavedTreesChanged = () => {
+      setSavedTrees(listBehaviorTrees());
+    };
+
+    window.addEventListener(BEHAVIOR_TREE_STORAGE_EVENT, handleSavedTreesChanged);
+    return () => window.removeEventListener(BEHAVIOR_TREE_STORAGE_EVENT, handleSavedTreesChanged);
+  }, []);
+
   const handleDiscover = async () => {
     if (!ros) return;
     setIsDiscovering(true);
@@ -323,9 +348,9 @@ const NodePalette: React.FC<NodePaletteProps> = ({
   const handleDragStart = (
     e: React.DragEvent,
     nodeType: BehaviorNodeType,
-    rosInfo?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo
+    item?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo | BehaviorTree
   ) => {
-    e.dataTransfer.setData('application/reactflow', JSON.stringify({ nodeType, rosInfo }));
+    e.dataTransfer.setData('application/reactflow', JSON.stringify({ nodeType, item }));
     e.dataTransfer.effectAllowed = 'move';
   };
 
@@ -429,6 +454,44 @@ const NodePalette: React.FC<NodePaletteProps> = ({
                 <span className="palette-node-label">{node.label}</span>
               </div>
             ))}
+          </div>
+        )}
+      </div>
+
+      <div className="palette-section">
+        <div className="palette-section-header" onClick={() => toggleSection('saved')}>
+          <span className="palette-section-icon">
+            {expandedSections.saved ? <IconChevronDown /> : <IconChevronRight />}
+          </span>
+          <span className="palette-section-title">Saved Trees</span>
+          <span className="palette-section-count">{savedTrees.length}</span>
+        </div>
+        {expandedSections.saved && (
+          <div className="palette-section-content">
+            {savedTrees.length === 0 ? (
+              <div className="palette-empty">Save a tree to reuse it as a subtree</div>
+            ) : (
+              savedTrees.map(({ tree }) => (
+                <div
+                  key={tree.id}
+                  className="palette-node palette-node-ros"
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, BehaviorNodeType.Subtree, tree)}
+                  onClick={() => onAddNode?.(BehaviorNodeType.Subtree, tree)}
+                  title={`Insert "${tree.name}" as a subtree`}
+                >
+                  <span className="palette-node-icon">
+                    <IconSubtree />
+                  </span>
+                  <span className="palette-node-copy">
+                    <span className="palette-node-label">{tree.name}</span>
+                    <span className="palette-node-detail">
+                      {tree.nodes.length} node{tree.nodes.length === 1 ? '' : 's'}
+                    </span>
+                  </span>
+                </div>
+              ))
+            )}
           </div>
         )}
       </div>

--- a/src/features/behaviorTree/components/NodeSearch.css
+++ b/src/features/behaviorTree/components/NodeSearch.css
@@ -1,9 +1,9 @@
 .bt-node-search {
   position: absolute;
-  top: 58px;
+  top: 74px;
   right: 12px;
   z-index: 30;
-  width: min(300px, calc(100% - 24px));
+  width: min(260px, calc(100% - 24px));
   color: var(--text-color, #333333);
 }
 

--- a/src/features/behaviorTree/components/nodes/ActionNode.tsx
+++ b/src/features/behaviorTree/components/nodes/ActionNode.tsx
@@ -7,7 +7,11 @@ const ActionNode: React.FC<NodeProps<ROSActionNodeData>> = ({ data, selected }) 
   const statusClass = data.status || ExecutionStatus.Idle;
 
   return (
-    <div className={`bt-node bt-action-node status-${statusClass} ${selected ? 'selected' : ''}`}>
+    <div
+      className={`bt-node bt-action-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
       <Handle type="target" position={Position.Top} className="bt-handle" />
       
       <div className="bt-node-header">

--- a/src/features/behaviorTree/components/nodes/NodeStyles.css
+++ b/src/features/behaviorTree/components/nodes/NodeStyles.css
@@ -18,6 +18,17 @@
   box-shadow: 0 0 0 2px rgba(66, 133, 244, 0.3);
 }
 
+.bt-node.clicked,
+.bt-node.clicked:hover,
+.bt-node.selected.clicked {
+  border-color: #ff9800;
+  box-shadow:
+    0 0 0 3px rgba(255, 152, 0, 0.32),
+    0 10px 22px rgba(255, 152, 0, 0.16);
+  outline: 2px solid rgba(255, 152, 0, 0.22);
+  outline-offset: 1px;
+}
+
 .bt-node:hover {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
@@ -155,6 +166,10 @@
 
 .bt-parallel-node .bt-node-header {
   color: #3f51b5;
+}
+
+.bt-subtree-node .bt-node-header {
+  color: #795548;
 }
 
 /* React Flow handles */

--- a/src/features/behaviorTree/components/nodes/NodeStyles.css
+++ b/src/features/behaviorTree/components/nodes/NodeStyles.css
@@ -168,6 +168,14 @@
   color: #3f51b5;
 }
 
+.bt-retry-node .bt-node-header {
+  color: #00897b;
+}
+
+.bt-repeat-node .bt-node-header {
+  color: #7b1fa2;
+}
+
 .bt-subtree-node .bt-node-header {
   color: #795548;
 }

--- a/src/features/behaviorTree/components/nodes/ParallelNode.tsx
+++ b/src/features/behaviorTree/components/nodes/ParallelNode.tsx
@@ -7,7 +7,11 @@ const ParallelNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected
   const statusClass = data.status || ExecutionStatus.Idle;
 
   return (
-    <div className={`bt-node bt-parallel-node status-${statusClass} ${selected ? 'selected' : ''}`}>
+    <div
+      className={`bt-node bt-parallel-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
       <Handle type="target" position={Position.Top} className="bt-handle" />
       
       <div className="bt-node-header">
@@ -34,4 +38,3 @@ const ParallelNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected
 };
 
 export default ParallelNode;
-

--- a/src/features/behaviorTree/components/nodes/RepeatNode.tsx
+++ b/src/features/behaviorTree/components/nodes/RepeatNode.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+import { ControlFlowNodeData, ExecutionStatus } from '../../types';
+import './NodeStyles.css';
+
+const getLimitLabel = (limit?: number): string => {
+  if (limit === -1) return 'Infinite';
+  return `${Math.max(1, limit ?? 3)} repeat${Math.max(1, limit ?? 3) === 1 ? '' : 's'}`;
+};
+
+const RepeatNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected }) => {
+  const statusClass = data.status || ExecutionStatus.Idle;
+
+  return (
+    <div
+      className={`bt-node bt-repeat-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="bt-handle" />
+
+      <div className="bt-node-header">
+        <span className="bt-node-icon">⟳</span>
+        <span className="bt-node-type">Repeat</span>
+      </div>
+
+      <div className="bt-node-content">
+        <div className="bt-node-label">{data.label}</div>
+        <div className="bt-node-detail">{getLimitLabel(data.iterationLimit)}</div>
+        {data.description && (
+          <div className="bt-node-subdetail">{data.description}</div>
+        )}
+      </div>
+
+      {data.status && (
+        <div className="bt-node-status">
+          <div className={`bt-status-indicator status-${statusClass}`} />
+        </div>
+      )}
+
+      <Handle type="source" position={Position.Bottom} className="bt-handle" />
+    </div>
+  );
+};
+
+export default RepeatNode;

--- a/src/features/behaviorTree/components/nodes/RetryNode.tsx
+++ b/src/features/behaviorTree/components/nodes/RetryNode.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+import { ControlFlowNodeData, ExecutionStatus } from '../../types';
+import './NodeStyles.css';
+
+const getLimitLabel = (limit?: number): string => {
+  if (limit === -1) return 'Infinite';
+  return `${Math.max(1, limit ?? 3)} attempt${Math.max(1, limit ?? 3) === 1 ? '' : 's'}`;
+};
+
+const RetryNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected }) => {
+  const statusClass = data.status || ExecutionStatus.Idle;
+
+  return (
+    <div
+      className={`bt-node bt-retry-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="bt-handle" />
+
+      <div className="bt-node-header">
+        <span className="bt-node-icon">↻</span>
+        <span className="bt-node-type">Retry</span>
+      </div>
+
+      <div className="bt-node-content">
+        <div className="bt-node-label">{data.label}</div>
+        <div className="bt-node-detail">{getLimitLabel(data.iterationLimit)}</div>
+        {data.description && (
+          <div className="bt-node-subdetail">{data.description}</div>
+        )}
+      </div>
+
+      {data.status && (
+        <div className="bt-node-status">
+          <div className={`bt-status-indicator status-${statusClass}`} />
+        </div>
+      )}
+
+      <Handle type="source" position={Position.Bottom} className="bt-handle" />
+    </div>
+  );
+};
+
+export default RetryNode;

--- a/src/features/behaviorTree/components/nodes/SelectorNode.tsx
+++ b/src/features/behaviorTree/components/nodes/SelectorNode.tsx
@@ -7,7 +7,11 @@ const SelectorNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected
   const statusClass = data.status || ExecutionStatus.Idle;
 
   return (
-    <div className={`bt-node bt-selector-node status-${statusClass} ${selected ? 'selected' : ''}`}>
+    <div
+      className={`bt-node bt-selector-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
       <Handle type="target" position={Position.Top} className="bt-handle" />
       
       <div className="bt-node-header">
@@ -34,4 +38,3 @@ const SelectorNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected
 };
 
 export default SelectorNode;
-

--- a/src/features/behaviorTree/components/nodes/SequenceNode.tsx
+++ b/src/features/behaviorTree/components/nodes/SequenceNode.tsx
@@ -7,7 +7,11 @@ const SequenceNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected
   const statusClass = data.status || ExecutionStatus.Idle;
 
   return (
-    <div className={`bt-node bt-sequence-node status-${statusClass} ${selected ? 'selected' : ''}`}>
+    <div
+      className={`bt-node bt-sequence-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
       <Handle type="target" position={Position.Top} className="bt-handle" />
       
       <div className="bt-node-header">
@@ -34,4 +38,3 @@ const SequenceNode: React.FC<NodeProps<ControlFlowNodeData>> = ({ data, selected
 };
 
 export default SequenceNode;
-

--- a/src/features/behaviorTree/components/nodes/ServiceNode.tsx
+++ b/src/features/behaviorTree/components/nodes/ServiceNode.tsx
@@ -7,7 +7,11 @@ const ServiceNode: React.FC<NodeProps<ROSServiceNodeData>> = ({ data, selected }
   const statusClass = data.status || ExecutionStatus.Idle;
 
   return (
-    <div className={`bt-node bt-service-node status-${statusClass} ${selected ? 'selected' : ''}`}>
+    <div
+      className={`bt-node bt-service-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
       <Handle type="target" position={Position.Top} className="bt-handle" />
       
       <div className="bt-node-header">

--- a/src/features/behaviorTree/components/nodes/SubtreeNode.tsx
+++ b/src/features/behaviorTree/components/nodes/SubtreeNode.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Handle, NodeProps, Position } from 'reactflow';
+
+import { ExecutionStatus, SubtreeNodeData } from '../../types';
+import './NodeStyles.css';
+
+const SubtreeNode: React.FC<NodeProps<SubtreeNodeData>> = ({ data, selected }) => {
+  const statusClass = data.status || ExecutionStatus.Idle;
+  const nodeCount = data.tree.nodes.length;
+
+  return (
+    <div
+      className={`bt-node bt-subtree-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="bt-handle" />
+
+      <div className="bt-node-header">
+        <span className="bt-node-icon">▣</span>
+        <span className="bt-node-type">Subtree</span>
+      </div>
+
+      <div className="bt-node-content">
+        <div className="bt-node-label" title={data.label}>
+          {data.label}
+        </div>
+        <div className="bt-node-detail">
+          {nodeCount} node{nodeCount === 1 ? '' : 's'}
+        </div>
+        <div className="bt-node-subdetail" title={data.tree.name}>
+          {data.tree.name}
+        </div>
+      </div>
+
+      {data.status && (
+        <div className="bt-node-status">
+          <div className={`bt-status-indicator status-${statusClass}`} />
+        </div>
+      )}
+
+      <Handle type="source" position={Position.Bottom} className="bt-handle" />
+    </div>
+  );
+};
+
+export default SubtreeNode;

--- a/src/features/behaviorTree/components/nodes/TopicNode.tsx
+++ b/src/features/behaviorTree/components/nodes/TopicNode.tsx
@@ -7,7 +7,11 @@ const TopicNode: React.FC<NodeProps<ROSTopicNodeData>> = ({ data, selected }) =>
   const statusClass = data.status || ExecutionStatus.Idle;
 
   return (
-    <div className={`bt-node bt-topic-node status-${statusClass} ${selected ? 'selected' : ''}`}>
+    <div
+      className={`bt-node bt-topic-node status-${statusClass} ${selected ? 'selected' : ''} ${
+        data.isHighlighted ? 'clicked' : ''
+      }`}
+    >
       <Handle type="target" position={Position.Top} className="bt-handle" />
       
       <div className="bt-node-header">
@@ -35,4 +39,3 @@ const TopicNode: React.FC<NodeProps<ROSTopicNodeData>> = ({ data, selected }) =>
 };
 
 export default TopicNode;
-

--- a/src/features/behaviorTree/components/nodes/nodeTypes.ts
+++ b/src/features/behaviorTree/components/nodes/nodeTypes.ts
@@ -5,6 +5,7 @@ import TopicNode from './TopicNode';
 import SequenceNode from './SequenceNode';
 import SelectorNode from './SelectorNode';
 import ParallelNode from './ParallelNode';
+import SubtreeNode from './SubtreeNode';
 
 export const nodeTypes: NodeTypes = {
   action: ActionNode,
@@ -13,5 +14,5 @@ export const nodeTypes: NodeTypes = {
   sequence: SequenceNode,
   selector: SelectorNode,
   parallel: ParallelNode,
+  subtree: SubtreeNode,
 };
-

--- a/src/features/behaviorTree/components/nodes/nodeTypes.ts
+++ b/src/features/behaviorTree/components/nodes/nodeTypes.ts
@@ -5,6 +5,8 @@ import TopicNode from './TopicNode';
 import SequenceNode from './SequenceNode';
 import SelectorNode from './SelectorNode';
 import ParallelNode from './ParallelNode';
+import RetryNode from './RetryNode';
+import RepeatNode from './RepeatNode';
 import SubtreeNode from './SubtreeNode';
 
 export const nodeTypes: NodeTypes = {
@@ -14,5 +16,7 @@ export const nodeTypes: NodeTypes = {
   sequence: SequenceNode,
   selector: SelectorNode,
   parallel: ParallelNode,
+  retry: RetryNode,
+  repeat: RepeatNode,
   subtree: SubtreeNode,
 };

--- a/src/features/behaviorTree/engine/executor.test.ts
+++ b/src/features/behaviorTree/engine/executor.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Ros } from 'roslib';
+
+import { BehaviorTreeExecutor } from './executor';
+import {
+  BehaviorNodeType,
+  BehaviorTree,
+  BehaviorTreeNode,
+  ExecutionEvent,
+  ExecutionStatus,
+} from '../types';
+
+const roslibMocks = vi.hoisted(() => ({
+  serviceOutcomes: [] as Array<'success' | 'failure'>,
+  serviceCall: vi.fn(),
+  topicPublish: vi.fn(),
+  topicUnadvertise: vi.fn(),
+}));
+
+vi.mock('roslib', () => ({
+  default: {
+    Service: vi.fn(function () {
+      return {
+        callService: roslibMocks.serviceCall,
+      };
+    }),
+    ServiceRequest: vi.fn(function (value: Record<string, unknown>) {
+      return value;
+    }),
+    Topic: vi.fn(function () {
+      return {
+        publish: roslibMocks.topicPublish,
+        unadvertise: roslibMocks.topicUnadvertise,
+      };
+    }),
+    Message: vi.fn(function (value: Record<string, unknown>) {
+      return value;
+    }),
+  },
+}));
+
+const controlNode = (
+  id: string,
+  type: BehaviorNodeType.Retry | BehaviorNodeType.Repeat,
+  iterationLimit: number
+): BehaviorTreeNode => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: {
+    label: type === BehaviorNodeType.Retry ? 'Retry' : 'Repeat',
+    type: type === BehaviorNodeType.Retry ? 'retry' : 'repeat',
+    iterationLimit,
+  },
+});
+
+const serviceNode = (id = 'service'): BehaviorTreeNode => ({
+  id,
+  type: BehaviorNodeType.Service,
+  position: { x: 0, y: 100 },
+  data: {
+    label: 'Service',
+    serviceName: '/do_work',
+    serviceType: 'example/srv/DoWork',
+  },
+});
+
+const topicNode = (id = 'topic'): BehaviorTreeNode => ({
+  id,
+  type: BehaviorNodeType.Topic,
+  position: { x: 0, y: 100 },
+  data: {
+    label: 'Topic',
+    topicName: '/cmd',
+    messageType: 'example/msg/Cmd',
+    message: { value: true },
+  },
+});
+
+const treeWithControl = (root: BehaviorTreeNode, child: BehaviorTreeNode): BehaviorTree => ({
+  id: 'tree',
+  name: 'Tree',
+  nodes: [root, child],
+  edges: [{ id: 'edge-root-child', source: root.id, target: child.id }],
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+const executeTree = async (tree: BehaviorTree) => {
+  const events: ExecutionEvent[] = [];
+  const executor = new BehaviorTreeExecutor(tree, {} as Ros, (event) => {
+    events.push(event);
+  });
+
+  await executor.start();
+  return events;
+};
+
+describe('BehaviorTreeExecutor retry and repeat nodes', () => {
+  beforeEach(() => {
+    roslibMocks.serviceOutcomes = [];
+    roslibMocks.serviceCall.mockReset();
+    roslibMocks.serviceCall.mockImplementation(
+      (_request: unknown, onSuccess: (result: unknown) => void, onFailure: (error: unknown) => void) => {
+        const outcome = roslibMocks.serviceOutcomes.shift() ?? 'success';
+        if (outcome === 'success') {
+          onSuccess({});
+        } else {
+          onFailure('failed');
+        }
+      }
+    );
+    roslibMocks.topicPublish.mockReset();
+    roslibMocks.topicUnadvertise.mockReset();
+  });
+
+  it('retries child execution until it succeeds within the configured limit', async () => {
+    roslibMocks.serviceOutcomes = ['failure', 'failure', 'success'];
+
+    const events = await executeTree(
+      treeWithControl(controlNode('retry', BehaviorNodeType.Retry, 3), serviceNode())
+    );
+
+    expect(roslibMocks.serviceCall).toHaveBeenCalledTimes(3);
+    expect(events[events.length - 1]).toMatchObject({
+      type: 'completed',
+      data: { result: ExecutionStatus.Success },
+    });
+  });
+
+  it('fails retry when the configured attempt count is exhausted', async () => {
+    roslibMocks.serviceOutcomes = ['failure', 'failure', 'success'];
+
+    const events = await executeTree(
+      treeWithControl(controlNode('retry', BehaviorNodeType.Retry, 2), serviceNode())
+    );
+
+    expect(roslibMocks.serviceCall).toHaveBeenCalledTimes(2);
+    expect(events[events.length - 1]).toMatchObject({
+      type: 'completed',
+      data: { result: ExecutionStatus.Failure },
+    });
+  });
+
+  it('treats -1 retry as unbounded until a child succeeds', async () => {
+    roslibMocks.serviceOutcomes = ['failure', 'failure', 'failure', 'failure', 'success'];
+
+    const events = await executeTree(
+      treeWithControl(controlNode('retry', BehaviorNodeType.Retry, -1), serviceNode())
+    );
+
+    expect(roslibMocks.serviceCall).toHaveBeenCalledTimes(5);
+    expect(events[events.length - 1]).toMatchObject({
+      type: 'completed',
+      data: { result: ExecutionStatus.Success },
+    });
+  });
+
+  it('repeats successful children the configured number of times', async () => {
+    const events = await executeTree(
+      treeWithControl(controlNode('repeat', BehaviorNodeType.Repeat, 3), topicNode())
+    );
+
+    expect(roslibMocks.topicPublish).toHaveBeenCalledTimes(3);
+    expect(roslibMocks.topicUnadvertise).toHaveBeenCalledTimes(3);
+    expect(events[events.length - 1]).toMatchObject({
+      type: 'completed',
+      data: { result: ExecutionStatus.Success },
+    });
+  });
+
+  it('fails repeat immediately when a child fails', async () => {
+    roslibMocks.serviceOutcomes = ['success', 'failure', 'success'];
+
+    const events = await executeTree(
+      treeWithControl(controlNode('repeat', BehaviorNodeType.Repeat, 3), serviceNode())
+    );
+
+    expect(roslibMocks.serviceCall).toHaveBeenCalledTimes(2);
+    expect(events[events.length - 1]).toMatchObject({
+      type: 'completed',
+      data: { result: ExecutionStatus.Failure },
+    });
+  });
+
+  it('treats -1 repeat as unbounded until a child fails', async () => {
+    roslibMocks.serviceOutcomes = ['success', 'success', 'success', 'failure'];
+
+    const events = await executeTree(
+      treeWithControl(controlNode('repeat', BehaviorNodeType.Repeat, -1), serviceNode())
+    );
+
+    expect(roslibMocks.serviceCall).toHaveBeenCalledTimes(4);
+    expect(events[events.length - 1]).toMatchObject({
+      type: 'completed',
+      data: { result: ExecutionStatus.Failure },
+    });
+  });
+});

--- a/src/features/behaviorTree/engine/executor.ts
+++ b/src/features/behaviorTree/engine/executor.ts
@@ -8,6 +8,7 @@ import {
   BehaviorNodeType,
   ROSActionNodeData,
   ROSServiceNodeData,
+  SubtreeNodeData,
   ROSTopicNodeData,
 } from '../types';
 import { ACTION_TEMPLATES } from '../actionTemplates';
@@ -237,6 +238,7 @@ export class BehaviorTreeExecutor {
   private callback: ExecutionCallback;
   private abortController: AbortController | null;
   private activeActions: Map<string, ActiveAction>;
+  private readonly rootPath: string[];
 
   constructor(tree: BehaviorTree, ros: Ros, callback: ExecutionCallback) {
     this.tree = tree;
@@ -246,6 +248,7 @@ export class BehaviorTreeExecutor {
     this.isRunning = false;
     this.abortController = null;
     this.activeActions = new Map();
+    this.rootPath = [];
 
     // Initialize all nodes to idle status
     tree.nodes.forEach(node => {
@@ -278,7 +281,7 @@ export class BehaviorTreeExecutor {
       }
 
       // Execute from root
-      const result = await this.executeNode(rootNode);
+      const result = await this.executeNode(rootNode, this.tree, this.rootPath);
 
       this.emitEvent({
         type: 'completed',
@@ -324,8 +327,8 @@ export class BehaviorTreeExecutor {
   /**
    * Get current status of a node
    */
-  public getNodeStatus(nodeId: string): ExecutionStatus {
-    return this.nodeStatuses.get(nodeId) || ExecutionStatus.Idle;
+  public getNodeStatus(nodeId: string, treePath: string[] = this.rootPath): ExecutionStatus {
+    return this.nodeStatuses.get(this.getExecutionNodeKey(nodeId, treePath)) || ExecutionStatus.Idle;
   }
 
   /**
@@ -335,13 +338,17 @@ export class BehaviorTreeExecutor {
     return new Map(this.nodeStatuses);
   }
 
+  private getExecutionNodeKey(nodeId: string, treePath: string[]): string {
+    return `${treePath.join('/') || 'root'}::${nodeId}`;
+  }
+
   /**
    * Find the root node (no incoming edges).
    * Prefers control-flow nodes over leaf nodes in case of ambiguity.
    */
-  private findRootNode(): BehaviorTreeNode | null {
-    const nodesWithIncoming = new Set(this.tree.edges.map(e => e.target));
-    const roots = this.tree.nodes.filter(node => !nodesWithIncoming.has(node.id));
+  private findRootNode(tree: BehaviorTree = this.tree): BehaviorTreeNode | null {
+    const nodesWithIncoming = new Set(tree.edges.map(e => e.target));
+    const roots = tree.nodes.filter(node => !nodesWithIncoming.has(node.id));
     console.log(
       `[BT] findRootNode: ${roots.length} root candidate(s):`,
       roots.map(n => `${n.id}(${n.type})`).join(', ')
@@ -360,12 +367,12 @@ export class BehaviorTreeExecutor {
   /**
    * Get child nodes of a given node, in edge-insertion order.
    */
-  private getChildNodes(nodeId: string): BehaviorTreeNode[] {
-    const childIds = this.tree.edges.filter(edge => edge.source === nodeId).map(edge => edge.target);
+  private getChildNodes(nodeId: string, tree: BehaviorTree = this.tree): BehaviorTreeNode[] {
+    const childIds = tree.edges.filter(edge => edge.source === nodeId).map(edge => edge.target);
 
     console.log(
       `[BT] getChildNodes(${nodeId}): ${childIds.length} child(ren) — edges:`,
-      this.tree.edges
+      tree.edges
         .filter(e => e.source === nodeId)
         .map(e => `${e.source}→${e.target}`)
         .join(', ')
@@ -373,32 +380,39 @@ export class BehaviorTreeExecutor {
 
     // Preserve the order edges were added (not the nodes-array order).
     return childIds
-      .map(id => this.tree.nodes.find(n => n.id === id))
+      .map(id => tree.nodes.find(n => n.id === id))
       .filter((n): n is BehaviorTreeNode => n !== undefined);
   }
 
   /**
    * Execute a single node
    */
-  private async executeNode(node: BehaviorTreeNode): Promise<ExecutionStatus> {
+  private async executeNode(
+    node: BehaviorTreeNode,
+    tree: BehaviorTree = this.tree,
+    treePath: string[] = this.rootPath
+  ): Promise<ExecutionStatus> {
     if (!this.isRunning) {
       return ExecutionStatus.Failure;
     }
 
-    this.setNodeStatus(node.id, ExecutionStatus.Running);
+    this.setNodeStatus(node.id, ExecutionStatus.Running, treePath);
 
     try {
       let result: ExecutionStatus;
 
       switch (node.type) {
         case BehaviorNodeType.Sequence:
-          result = await this.executeSequence(node);
+          result = await this.executeSequence(node, tree, treePath);
           break;
         case BehaviorNodeType.Selector:
-          result = await this.executeSelector(node);
+          result = await this.executeSelector(node, tree, treePath);
           break;
         case BehaviorNodeType.Parallel:
-          result = await this.executeParallel(node);
+          result = await this.executeParallel(node, tree, treePath);
+          break;
+        case BehaviorNodeType.Subtree:
+          result = await this.executeSubtreeNode(node, treePath);
           break;
         case BehaviorNodeType.Action:
           result = await this.executeActionNode(node);
@@ -414,11 +428,11 @@ export class BehaviorTreeExecutor {
           result = ExecutionStatus.Failure;
       }
 
-      this.setNodeStatus(node.id, result);
+      this.setNodeStatus(node.id, result, treePath);
       return result;
     } catch (error) {
       console.error(`Error executing node ${node.id}:`, error);
-      this.setNodeStatus(node.id, ExecutionStatus.Failure);
+      this.setNodeStatus(node.id, ExecutionStatus.Failure, treePath);
       return ExecutionStatus.Failure;
     }
   }
@@ -426,11 +440,15 @@ export class BehaviorTreeExecutor {
   /**
    * Execute sequence node (all children must succeed)
    */
-  private async executeSequence(node: BehaviorTreeNode): Promise<ExecutionStatus> {
-    const children = this.getChildNodes(node.id);
+  private async executeSequence(
+    node: BehaviorTreeNode,
+    tree: BehaviorTree = this.tree,
+    treePath: string[] = this.rootPath
+  ): Promise<ExecutionStatus> {
+    const children = this.getChildNodes(node.id, tree);
 
     for (const child of children) {
-      const result = await this.executeNode(child);
+      const result = await this.executeNode(child, tree, treePath);
 
       if (result === ExecutionStatus.Failure) {
         return ExecutionStatus.Failure;
@@ -447,11 +465,15 @@ export class BehaviorTreeExecutor {
   /**
    * Execute selector node (first child to succeed wins)
    */
-  private async executeSelector(node: BehaviorTreeNode): Promise<ExecutionStatus> {
-    const children = this.getChildNodes(node.id);
+  private async executeSelector(
+    node: BehaviorTreeNode,
+    tree: BehaviorTree = this.tree,
+    treePath: string[] = this.rootPath
+  ): Promise<ExecutionStatus> {
+    const children = this.getChildNodes(node.id, tree);
 
     for (const child of children) {
-      const result = await this.executeNode(child);
+      const result = await this.executeNode(child, tree, treePath);
 
       if (result === ExecutionStatus.Success) {
         return ExecutionStatus.Success;
@@ -468,14 +490,33 @@ export class BehaviorTreeExecutor {
   /**
    * Execute parallel node (all children execute simultaneously)
    */
-  private async executeParallel(node: BehaviorTreeNode): Promise<ExecutionStatus> {
-    const children = this.getChildNodes(node.id);
+  private async executeParallel(
+    node: BehaviorTreeNode,
+    tree: BehaviorTree = this.tree,
+    treePath: string[] = this.rootPath
+  ): Promise<ExecutionStatus> {
+    const children = this.getChildNodes(node.id, tree);
 
-    const results = await Promise.all(children.map(child => this.executeNode(child)));
+    const results = await Promise.all(children.map(child => this.executeNode(child, tree, treePath)));
 
     // Success if all children succeed
     const allSuccess = results.every(r => r === ExecutionStatus.Success);
     return allSuccess ? ExecutionStatus.Success : ExecutionStatus.Failure;
+  }
+
+  private async executeSubtreeNode(
+    node: BehaviorTreeNode,
+    treePath: string[] = this.rootPath
+  ): Promise<ExecutionStatus> {
+    const data = node.data as SubtreeNodeData;
+    const subtreeRoot = this.findRootNode(data.tree);
+
+    if (!subtreeRoot) {
+      console.warn(`[BT] Subtree "${data.label}" has no root node`);
+      return ExecutionStatus.Failure;
+    }
+
+    return this.executeNode(subtreeRoot, data.tree, [...treePath, node.id]);
   }
 
   /**
@@ -681,8 +722,8 @@ export class BehaviorTreeExecutor {
   /**
    * Set node status and emit event
    */
-  private setNodeStatus(nodeId: string, status: ExecutionStatus): void {
-    this.nodeStatuses.set(nodeId, status);
+  private setNodeStatus(nodeId: string, status: ExecutionStatus, treePath: string[] = this.rootPath): void {
+    this.nodeStatuses.set(this.getExecutionNodeKey(nodeId, treePath), status);
 
     let eventType: 'nodeRunning' | 'nodeSuccess' | 'nodeFailure' | 'nodeEntered';
 
@@ -704,7 +745,7 @@ export class BehaviorTreeExecutor {
       type: eventType,
       nodeId,
       timestamp: Date.now(),
-      data: { status },
+      data: { status, treePath },
     });
   }
 

--- a/src/features/behaviorTree/engine/executor.ts
+++ b/src/features/behaviorTree/engine/executor.ts
@@ -6,6 +6,7 @@ import {
   ExecutionEvent,
   ExecutionCallback,
   BehaviorNodeType,
+  ControlFlowNodeData,
   ROSActionNodeData,
   ROSServiceNodeData,
   SubtreeNodeData,
@@ -359,7 +360,9 @@ export class BehaviorTreeExecutor {
       n =>
         n.type === BehaviorNodeType.Sequence ||
         n.type === BehaviorNodeType.Selector ||
-        n.type === BehaviorNodeType.Parallel
+        n.type === BehaviorNodeType.Parallel ||
+        n.type === BehaviorNodeType.Retry ||
+        n.type === BehaviorNodeType.Repeat
     );
     return controlRoot ?? roots[0] ?? null;
   }
@@ -411,6 +414,12 @@ export class BehaviorTreeExecutor {
         case BehaviorNodeType.Parallel:
           result = await this.executeParallel(node, tree, treePath);
           break;
+        case BehaviorNodeType.Retry:
+          result = await this.executeRetry(node, tree, treePath);
+          break;
+        case BehaviorNodeType.Repeat:
+          result = await this.executeRepeat(node, tree, treePath);
+          break;
         case BehaviorNodeType.Subtree:
           result = await this.executeSubtreeNode(node, treePath);
           break;
@@ -460,6 +469,83 @@ export class BehaviorTreeExecutor {
     }
 
     return ExecutionStatus.Success;
+  }
+
+  private getIterationLimit(node: BehaviorTreeNode): number {
+    const limit = (node.data as ControlFlowNodeData).iterationLimit;
+    if (limit === -1) return -1;
+    if (typeof limit !== 'number' || !Number.isFinite(limit)) return 3;
+    return Math.max(1, Math.trunc(limit));
+  }
+
+  private async executeChildrenAsSequence(
+    children: BehaviorTreeNode[],
+    tree: BehaviorTree,
+    treePath: string[]
+  ): Promise<ExecutionStatus> {
+    if (children.length === 0) return ExecutionStatus.Failure;
+
+    for (const child of children) {
+      const result = await this.executeNode(child, tree, treePath);
+      if (result === ExecutionStatus.Failure || !this.isRunning) {
+        return ExecutionStatus.Failure;
+      }
+    }
+
+    return ExecutionStatus.Success;
+  }
+
+  private async yieldBetweenIterations(): Promise<void> {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+
+  /**
+   * Execute retry node. Children are executed as a sequence. If that sequence
+   * fails, retry until it succeeds or the iteration limit is exhausted.
+   */
+  private async executeRetry(
+    node: BehaviorTreeNode,
+    tree: BehaviorTree = this.tree,
+    treePath: string[] = this.rootPath
+  ): Promise<ExecutionStatus> {
+    const children = this.getChildNodes(node.id, tree);
+    const limit = this.getIterationLimit(node);
+    let attempt = 0;
+
+    while (this.isRunning && (limit === -1 || attempt < limit)) {
+      attempt += 1;
+      const result = await this.executeChildrenAsSequence(children, tree, treePath);
+      if (result === ExecutionStatus.Success) return ExecutionStatus.Success;
+      await this.yieldBetweenIterations();
+    }
+
+    return ExecutionStatus.Failure;
+  }
+
+  /**
+   * Execute repeat node. Children are executed as a sequence. If that sequence
+   * succeeds, repeat until the iteration limit is reached. A child failure fails
+   * the repeat node.
+   */
+  private async executeRepeat(
+    node: BehaviorTreeNode,
+    tree: BehaviorTree = this.tree,
+    treePath: string[] = this.rootPath
+  ): Promise<ExecutionStatus> {
+    const children = this.getChildNodes(node.id, tree);
+    const limit = this.getIterationLimit(node);
+    let completedRepeats = 0;
+
+    while (this.isRunning && (limit === -1 || completedRepeats < limit)) {
+      const result = await this.executeChildrenAsSequence(children, tree, treePath);
+      if (result === ExecutionStatus.Failure) return ExecutionStatus.Failure;
+      completedRepeats += 1;
+      if (limit === -1 || completedRepeats < limit) {
+        await this.yieldBetweenIterations();
+      }
+    }
+
+    return this.isRunning ? ExecutionStatus.Success : ExecutionStatus.Failure;
   }
 
   /**

--- a/src/features/behaviorTree/nodeSearch.ts
+++ b/src/features/behaviorTree/nodeSearch.ts
@@ -11,6 +11,7 @@ const NODE_TYPE_LABELS: Partial<Record<BehaviorNodeType, string>> = {
   [BehaviorNodeType.Sequence]: 'Sequence',
   [BehaviorNodeType.Selector]: 'Selector',
   [BehaviorNodeType.Parallel]: 'Parallel',
+  [BehaviorNodeType.Subtree]: 'Subtree',
   [BehaviorNodeType.Action]: 'Action',
   [BehaviorNodeType.Service]: 'Service',
   [BehaviorNodeType.Topic]: 'Topic',

--- a/src/features/behaviorTree/nodeSearch.ts
+++ b/src/features/behaviorTree/nodeSearch.ts
@@ -11,6 +11,8 @@ const NODE_TYPE_LABELS: Partial<Record<BehaviorNodeType, string>> = {
   [BehaviorNodeType.Sequence]: 'Sequence',
   [BehaviorNodeType.Selector]: 'Selector',
   [BehaviorNodeType.Parallel]: 'Parallel',
+  [BehaviorNodeType.Retry]: 'Retry',
+  [BehaviorNodeType.Repeat]: 'Repeat',
   [BehaviorNodeType.Subtree]: 'Subtree',
   [BehaviorNodeType.Action]: 'Action',
   [BehaviorNodeType.Service]: 'Service',

--- a/src/features/behaviorTree/nodeUtils.test.ts
+++ b/src/features/behaviorTree/nodeUtils.test.ts
@@ -43,6 +43,28 @@ describe('behavior tree node utilities', () => {
     });
   });
 
+  it('creates retry and repeat control nodes with editable iteration limits', () => {
+    const retry = createBehaviorTreeNode({
+      id: 'node-retry',
+      nodeType: BehaviorNodeType.Retry,
+      position: { x: 0, y: 0 },
+    });
+    const repeat = createBehaviorTreeNode({
+      id: 'node-repeat',
+      nodeType: BehaviorNodeType.Repeat,
+      position: { x: 100, y: 0 },
+    });
+
+    expect(retry).toMatchObject({
+      type: BehaviorNodeType.Retry,
+      data: { label: 'Retry', type: 'retry', iterationLimit: 3 },
+    });
+    expect(repeat).toMatchObject({
+      type: BehaviorNodeType.Repeat,
+      data: { label: 'Repeat', type: 'repeat', iterationLimit: 3 },
+    });
+  });
+
   it('uses the ROS action name as the default node name', () => {
     const node = createBehaviorTreeNode({
       id: 'node-8',

--- a/src/features/behaviorTree/nodeUtils.ts
+++ b/src/features/behaviorTree/nodeUtils.ts
@@ -67,6 +67,20 @@ export const createBehaviorNodeData = (
       return { label: 'Selector', type: 'selector' } as ControlFlowNodeData;
     case BehaviorNodeType.Parallel:
       return { label: 'Parallel', type: 'parallel' } as ControlFlowNodeData;
+    case BehaviorNodeType.Retry:
+      return {
+        label: 'Retry',
+        type: 'retry',
+        description: 'Retry children on failure',
+        iterationLimit: 3,
+      } as ControlFlowNodeData;
+    case BehaviorNodeType.Repeat:
+      return {
+        label: 'Repeat',
+        type: 'repeat',
+        description: 'Repeat children on success',
+        iterationLimit: 3,
+      } as ControlFlowNodeData;
     case BehaviorNodeType.Action:
       return {
         label: rosInfo?.name || 'Action',

--- a/src/features/behaviorTree/storage/treeStorage.ts
+++ b/src/features/behaviorTree/storage/treeStorage.ts
@@ -1,7 +1,13 @@
 import { BehaviorTree, SavedBehaviorTree } from '../types';
+import { syncReferencedSubtrees } from '../subtreeUtils';
 
 const STORAGE_KEY = 'robo-boy-behavior-trees';
 const STORAGE_VERSION = '1.0.0';
+export const BEHAVIOR_TREE_STORAGE_EVENT = 'robo-boy-behavior-trees-changed';
+
+const emitBehaviorTreeStorageChanged = (): void => {
+  window.dispatchEvent(new CustomEvent(BEHAVIOR_TREE_STORAGE_EVENT));
+};
 
 /**
  * Get all saved behavior trees from localStorage
@@ -46,9 +52,43 @@ export const saveBehaviorTree = (tree: BehaviorTree): boolean => {
     }
     
     localStorage.setItem(STORAGE_KEY, JSON.stringify(trees));
+    emitBehaviorTreeStorageChanged();
     return true;
   } catch (error) {
     console.error('Failed to save behavior tree:', error);
+    return false;
+  }
+};
+
+export const syncBehaviorTreeReferences = (sourceTree: BehaviorTree): boolean => {
+  try {
+    const trees = listBehaviorTrees();
+    let didChange = false;
+
+    const syncedTrees = trees.map((savedTree) => {
+      if (savedTree.tree.id === sourceTree.id) {
+        return savedTree;
+      }
+
+      const syncedTree = syncReferencedSubtrees(savedTree.tree, sourceTree);
+      if (syncedTree !== savedTree.tree) {
+        didChange = true;
+        return {
+          ...savedTree,
+          tree: syncedTree,
+        };
+      }
+
+      return savedTree;
+    });
+
+    if (!didChange) return true;
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(syncedTrees));
+    emitBehaviorTreeStorageChanged();
+    return true;
+  } catch (error) {
+    console.error('Failed to sync behavior tree references:', error);
     return false;
   }
 };
@@ -81,6 +121,7 @@ export const deleteBehaviorTree = (id: string): boolean => {
     }
     
     localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+    emitBehaviorTreeStorageChanged();
     return true;
   } catch (error) {
     console.error('Failed to delete behavior tree:', error);
@@ -129,7 +170,7 @@ export const importBehaviorTree = (file: File): Promise<BehaviorTree | null> => 
         if (!savedTree.tree || !savedTree.tree.id || !savedTree.tree.nodes) {
           throw new Error('Invalid behavior tree file format');
         }
-        
+
         resolve(savedTree.tree);
       } catch (error) {
         console.error('Failed to import behavior tree:', error);
@@ -152,6 +193,7 @@ export const importBehaviorTree = (file: File): Promise<BehaviorTree | null> => 
 export const clearAllBehaviorTrees = (): boolean => {
   try {
     localStorage.removeItem(STORAGE_KEY);
+    emitBehaviorTreeStorageChanged();
     return true;
   } catch (error) {
     console.error('Failed to clear behavior trees:', error);
@@ -176,4 +218,3 @@ export const getStorageInfo = (): { count: number; size: number } => {
     return { count: 0, size: 0 };
   }
 };
-

--- a/src/features/behaviorTree/subtreeUtils.test.ts
+++ b/src/features/behaviorTree/subtreeUtils.test.ts
@@ -1,0 +1,164 @@
+import { Edge } from 'reactflow';
+
+import {
+  cloneBehaviorTree,
+  getTreeAtPath,
+  isSubtreeNode,
+  replaceTreeAtPath,
+  wrapSelectionIntoSubtree,
+} from './subtreeUtils';
+import { BehaviorNodeType, BehaviorTree, BehaviorTreeNode } from './types';
+
+const makeNode = (id: string, type: BehaviorNodeType, label = id): BehaviorTreeNode => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data:
+    type === BehaviorNodeType.Sequence
+      ? { label, type: 'sequence' }
+      : type === BehaviorNodeType.Subtree
+        ? {
+            label,
+            tree: {
+              id: `${id}-tree`,
+              name: label,
+              nodes: [],
+              edges: [],
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          }
+        : {
+            label,
+            actionName: label,
+            actionType: 'example_msgs/action/Test',
+          },
+});
+
+describe('subtree utilities', () => {
+  it('reads and replaces a nested tree by path', () => {
+    const nested: BehaviorTree = {
+      id: 'nested',
+      name: 'Nested',
+      nodes: [makeNode('leaf', BehaviorNodeType.Action)],
+      edges: [],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const root: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [
+        {
+          ...makeNode('sub', BehaviorNodeType.Subtree, 'Sub'),
+          data: { label: 'Sub', tree: nested },
+        },
+      ],
+      edges: [],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    expect(getTreeAtPath(root, ['sub'])?.id).toBe('nested');
+
+    const replacement = replaceTreeAtPath(root, ['sub'], {
+      ...nested,
+      name: 'Updated',
+    });
+    expect(getTreeAtPath(replacement, ['sub'])?.name).toBe('Updated');
+  });
+
+  it('wraps consecutive sequence children into a subtree snapshot', () => {
+    const sequence = makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence');
+    const first = makeNode('first', BehaviorNodeType.Action, 'First');
+    const second = makeNode('second', BehaviorNodeType.Action, 'Second');
+    const trailing = makeNode('trailing', BehaviorNodeType.Action, 'Trailing');
+    const firstChild = makeNode('first-child', BehaviorNodeType.Action, 'Child');
+    const edges: Edge[] = [
+      { id: 'edge-0', source: 'sequence', target: 'first' },
+      { id: 'edge-1', source: 'sequence', target: 'second' },
+      { id: 'edge-2', source: 'sequence', target: 'trailing' },
+      { id: 'edge-3', source: 'first', target: 'first-child' },
+    ];
+
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [sequence, first, second, trailing, firstChild],
+      edges,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const result = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['first', 'second'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.tree.nodes.map((node) => node.id)).toContain('subtree-node');
+    expect(result.tree.nodes.map((node) => node.id)).not.toContain('first');
+    expect(result.tree.nodes.map((node) => node.id)).not.toContain('second');
+    expect(result.tree.nodes.map((node) => node.id)).not.toContain('first-child');
+    expect(result.tree.edges.filter((edge) => edge.source === 'sequence').map((edge) => edge.target)).toEqual([
+      'subtree-node',
+      'trailing',
+    ]);
+    expect(isSubtreeNode(result.subtreeNode)).toBe(true);
+    if (!isSubtreeNode(result.subtreeNode)) return;
+
+    expect(result.subtreeNode.data.tree.nodes.some((node) => node.id === 'first')).toBe(true);
+    expect(result.subtreeNode.data.tree.nodes.some((node) => node.id === 'second')).toBe(true);
+    expect(result.subtreeNode.data.tree.nodes.some((node) => node.id === 'first-child')).toBe(true);
+  });
+
+  it('rejects non-consecutive sequence selections', () => {
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [
+        makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence'),
+        makeNode('first', BehaviorNodeType.Action, 'First'),
+        makeNode('second', BehaviorNodeType.Action, 'Second'),
+        makeNode('third', BehaviorNodeType.Action, 'Third'),
+      ],
+      edges: [
+        { id: 'edge-0', source: 'sequence', target: 'first' },
+        { id: 'edge-1', source: 'sequence', target: 'second' },
+        { id: 'edge-2', source: 'sequence', target: 'third' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const result = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['first', 'third'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('clones behavior trees without mutating the source', () => {
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [makeNode('action', BehaviorNodeType.Action)],
+      edges: [],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const cloned = cloneBehaviorTree(tree);
+    cloned.name = 'Changed';
+    expect(tree.name).toBe('Root');
+  });
+});

--- a/src/features/behaviorTree/subtreeUtils.test.ts
+++ b/src/features/behaviorTree/subtreeUtils.test.ts
@@ -10,30 +10,40 @@ import {
 } from './subtreeUtils';
 import { BehaviorNodeType, BehaviorTree, BehaviorTreeNode } from './types';
 
+const makeNodeData = (id: string, type: BehaviorNodeType, label: string): BehaviorTreeNode['data'] => {
+  switch (type) {
+    case BehaviorNodeType.Sequence:
+      return { label, type: 'sequence' };
+    case BehaviorNodeType.Retry:
+      return { label, type: 'retry', iterationLimit: 3 };
+    case BehaviorNodeType.Repeat:
+      return { label, type: 'repeat', iterationLimit: 3 };
+    case BehaviorNodeType.Subtree:
+      return {
+        label,
+        tree: {
+          id: `${id}-tree`,
+          name: label,
+          nodes: [],
+          edges: [],
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      };
+    default:
+      return {
+        label,
+        actionName: label,
+        actionType: 'example_msgs/action/Test',
+      };
+  }
+};
+
 const makeNode = (id: string, type: BehaviorNodeType, label = id): BehaviorTreeNode => ({
   id,
   type,
   position: { x: 0, y: 0 },
-  data:
-    type === BehaviorNodeType.Sequence
-      ? { label, type: 'sequence' }
-      : type === BehaviorNodeType.Subtree
-        ? {
-            label,
-            tree: {
-              id: `${id}-tree`,
-              name: label,
-              nodes: [],
-              edges: [],
-              createdAt: 1,
-              updatedAt: 1,
-            },
-          }
-        : {
-            label,
-            actionName: label,
-            actionType: 'example_msgs/action/Test',
-          },
+  data: makeNodeData(id, type, label),
 });
 
 describe('subtree utilities', () => {
@@ -501,6 +511,39 @@ describe('subtree utilities', () => {
       .filter((edge) => edge.source === 'sequence')
       .map((edge) => exploded.tree.nodes.find((node) => node.id === edge.target)?.data.label);
     expect(childLabels).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('allows wrapping children of retry and repeat control nodes', () => {
+    [BehaviorNodeType.Retry, BehaviorNodeType.Repeat].forEach((controlType) => {
+      const parent = makeNode('parent', controlType, controlType);
+      const first = makeNode('first', BehaviorNodeType.Action, 'First');
+      const second = makeNode('second', BehaviorNodeType.Action, 'Second');
+      const tree: BehaviorTree = {
+        id: `root-${controlType}`,
+        name: `Root ${controlType}`,
+        nodes: [parent, first, second],
+        edges: [
+          { id: 'edge-0', source: 'parent', target: 'first' },
+          { id: 'edge-1', source: 'parent', target: 'second' },
+        ],
+        createdAt: 1,
+        updatedAt: 1,
+      };
+
+      const wrapped = wrapSelectionIntoSubtree({
+        tree,
+        selectedNodeIds: ['first', 'second'],
+        subtreeNodeId: 'subtree-node',
+        subtreeTreeId: 'subtree-tree',
+        subtreeLabel: 'Wrapped',
+      });
+
+      expect(wrapped.ok).toBe(true);
+      if (!wrapped.ok) return;
+      expect(wrapped.tree.edges.filter((edge) => edge.source === 'parent').map((edge) => edge.target)).toEqual([
+        'subtree-node',
+      ]);
+    });
   });
 
   it('restores wrapped node positions when an unchanged subtree is exploded', () => {

--- a/src/features/behaviorTree/subtreeUtils.test.ts
+++ b/src/features/behaviorTree/subtreeUtils.test.ts
@@ -2,6 +2,7 @@ import { Edge } from 'reactflow';
 
 import {
   cloneBehaviorTree,
+  explodeSubtreeNode,
   getTreeAtPath,
   isSubtreeNode,
   replaceTreeAtPath,
@@ -117,6 +118,143 @@ describe('subtree utilities', () => {
     expect(result.subtreeNode.data.tree.nodes.some((node) => node.id === 'first-child')).toBe(true);
   });
 
+  it('stores wrapped nodes in local subtree coordinates and restores them on explode', () => {
+    const sequence = {
+      ...makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence'),
+      position: { x: 100, y: 50 },
+    };
+    const first = {
+      ...makeNode('first', BehaviorNodeType.Action, 'First'),
+      position: { x: 20, y: 200 },
+    };
+    const second = {
+      ...makeNode('second', BehaviorNodeType.Action, 'Second'),
+      position: { x: 220, y: 200 },
+    };
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [sequence, first, second],
+      edges: [
+        { id: 'edge-0', source: 'sequence', target: 'first' },
+        { id: 'edge-1', source: 'sequence', target: 'second' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const wrapped = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['first', 'second'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(wrapped.ok).toBe(true);
+    if (!wrapped.ok) return;
+    expect(wrapped.subtreeNode.position).toEqual({ x: 120, y: 200 });
+    expect(isSubtreeNode(wrapped.subtreeNode)).toBe(true);
+    if (!isSubtreeNode(wrapped.subtreeNode)) return;
+
+    const embeddedNodes = wrapped.subtreeNode.data.tree.nodes;
+    const generatedRoot = embeddedNodes.find(
+      (node) => 'generatedBySubtreeWrap' in node.data && node.data.generatedBySubtreeWrap
+    );
+    expect(embeddedNodes.find((node) => node.id === 'first')?.position).toEqual({ x: -100, y: 0 });
+    expect(embeddedNodes.find((node) => node.id === 'second')?.position).toEqual({ x: 100, y: 0 });
+    expect(generatedRoot?.position).toEqual({ x: -20, y: -150 });
+
+    const exploded = explodeSubtreeNode({
+      tree: wrapped.tree,
+      subtreeNodeId: 'subtree-node',
+      startNodeIndex: 10,
+    });
+
+    expect(exploded.ok).toBe(true);
+    if (!exploded.ok) return;
+    expect(exploded.tree.nodes.find((node) => node.data.label === 'First')?.position).toEqual(first.position);
+    expect(exploded.tree.nodes.find((node) => node.data.label === 'Second')?.position).toEqual(second.position);
+  });
+
+  it('keeps nested subtree layouts local when a subtree is wrapped again', () => {
+    const sequence = {
+      ...makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence'),
+      position: { x: 0, y: 0 },
+    };
+    const first = {
+      ...makeNode('first', BehaviorNodeType.Action, 'First'),
+      position: { x: 0, y: 160 },
+    };
+    const second = {
+      ...makeNode('second', BehaviorNodeType.Action, 'Second'),
+      position: { x: 240, y: 160 },
+    };
+    const third = {
+      ...makeNode('third', BehaviorNodeType.Action, 'Third'),
+      position: { x: 480, y: 160 },
+    };
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [sequence, first, second, third],
+      edges: [
+        { id: 'edge-0', source: 'sequence', target: 'first' },
+        { id: 'edge-1', source: 'sequence', target: 'second' },
+        { id: 'edge-2', source: 'sequence', target: 'third' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const inner = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['first', 'second'],
+      subtreeNodeId: 'inner-subtree',
+      subtreeTreeId: 'inner-tree',
+      subtreeLabel: 'Inner',
+    });
+    expect(inner.ok).toBe(true);
+    if (!inner.ok) return;
+
+    const outer = wrapSelectionIntoSubtree({
+      tree: inner.tree,
+      selectedNodeIds: ['inner-subtree', 'third'],
+      subtreeNodeId: 'outer-subtree',
+      subtreeTreeId: 'outer-tree',
+      subtreeLabel: 'Outer',
+    });
+    expect(outer.ok).toBe(true);
+    if (!outer.ok) return;
+    expect(isSubtreeNode(outer.subtreeNode)).toBe(true);
+    if (!isSubtreeNode(outer.subtreeNode)) return;
+
+    const outerEmbeddedNodes = outer.subtreeNode.data.tree.nodes;
+    const embeddedInner = outerEmbeddedNodes.find((node) => node.id === 'inner-subtree');
+    const embeddedThird = outerEmbeddedNodes.find((node) => node.id === 'third');
+    expect(embeddedInner?.position).toEqual({ x: -180, y: 0 });
+    expect(embeddedThird?.position).toEqual({ x: 180, y: 0 });
+
+    const outerGeneratedRoot = outerEmbeddedNodes.find(
+      (node) => 'generatedBySubtreeWrap' in node.data && node.data.generatedBySubtreeWrap
+    );
+    const orderedOuterChildren = outer.subtreeNode.data.tree.edges
+      .filter((edge) => edge.source === outerGeneratedRoot?.id)
+      .map((edge) => edge.target);
+    expect(orderedOuterChildren).toEqual(['inner-subtree', 'third']);
+
+    expect(isSubtreeNode(embeddedInner)).toBe(true);
+    if (!isSubtreeNode(embeddedInner)) return;
+    expect(embeddedInner.data.tree.nodes.find((node) => node.id === 'first')?.position).toEqual({
+      x: -120,
+      y: 0,
+    });
+    expect(embeddedInner.data.tree.nodes.find((node) => node.id === 'second')?.position).toEqual({
+      x: 120,
+      y: 0,
+    });
+  });
+
   it('rejects non-consecutive sequence selections', () => {
     const tree: BehaviorTree = {
       id: 'root',
@@ -145,6 +283,273 @@ describe('subtree utilities', () => {
     });
 
     expect(result.ok).toBe(false);
+  });
+
+  it('wraps selected children when their parent is also partially selected', () => {
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [
+        makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence'),
+        makeNode('first', BehaviorNodeType.Action, 'First'),
+        makeNode('second', BehaviorNodeType.Action, 'Second'),
+        makeNode('third', BehaviorNodeType.Action, 'Third'),
+      ],
+      edges: [
+        { id: 'edge-0', source: 'sequence', target: 'first' },
+        { id: 'edge-1', source: 'sequence', target: 'second' },
+        { id: 'edge-2', source: 'sequence', target: 'third' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const result = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['sequence', 'first', 'second'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.tree.nodes.map((node) => node.id)).toContain('sequence');
+    expect(result.tree.edges.filter((edge) => edge.source === 'sequence').map((edge) => edge.target)).toEqual([
+      'subtree-node',
+      'third',
+    ]);
+  });
+
+  it('wraps the highest selected parent when all of its children are selected', () => {
+    const root = makeNode('root-sequence', BehaviorNodeType.Sequence, 'Root');
+    const childSequence = makeNode('child-sequence', BehaviorNodeType.Sequence, 'Child');
+    const first = makeNode('first', BehaviorNodeType.Action, 'First');
+    const second = makeNode('second', BehaviorNodeType.Action, 'Second');
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [root, childSequence, first, second],
+      edges: [
+        { id: 'edge-0', source: 'root-sequence', target: 'child-sequence' },
+        { id: 'edge-1', source: 'child-sequence', target: 'first' },
+        { id: 'edge-2', source: 'child-sequence', target: 'second' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const result = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['child-sequence', 'first', 'second'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.tree.nodes.map((node) => node.id)).not.toContain('child-sequence');
+    expect(result.tree.edges.filter((edge) => edge.source === 'root-sequence').map((edge) => edge.target)).toEqual([
+      'subtree-node',
+    ]);
+    expect(isSubtreeNode(result.subtreeNode)).toBe(true);
+    if (!isSubtreeNode(result.subtreeNode)) return;
+    expect(result.subtreeNode.data.tree.nodes.map((node) => node.id)).toContain('child-sequence');
+  });
+
+  it('wraps selected branches with descendants across multiple levels', () => {
+    const root = makeNode('root', BehaviorNodeType.Sequence, 'Root');
+    const firstBranch = makeNode('first-branch', BehaviorNodeType.Sequence, 'First Branch');
+    const secondBranch = makeNode('second-branch', BehaviorNodeType.Sequence, 'Second Branch');
+    const firstLeaf = makeNode('first-leaf', BehaviorNodeType.Action, 'First Leaf');
+    const secondLeaf = makeNode('second-leaf', BehaviorNodeType.Action, 'Second Leaf');
+    const firstGrandchild = makeNode('first-grandchild', BehaviorNodeType.Action, 'First Grandchild');
+    const secondGrandchild = makeNode('second-grandchild', BehaviorNodeType.Action, 'Second Grandchild');
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [
+        root,
+        firstBranch,
+        secondBranch,
+        firstLeaf,
+        secondLeaf,
+        firstGrandchild,
+        secondGrandchild,
+      ],
+      edges: [
+        { id: 'edge-0', source: 'root', target: 'first-branch' },
+        { id: 'edge-1', source: 'root', target: 'second-branch' },
+        { id: 'edge-2', source: 'first-branch', target: 'first-leaf' },
+        { id: 'edge-3', source: 'second-branch', target: 'second-leaf' },
+        { id: 'edge-4', source: 'first-leaf', target: 'first-grandchild' },
+        { id: 'edge-5', source: 'second-leaf', target: 'second-grandchild' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const result = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: [
+        'first-branch',
+        'second-branch',
+        'first-leaf',
+        'second-leaf',
+        'first-grandchild',
+        'second-grandchild',
+      ],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.selectedRootIds).toEqual(['first-branch', 'second-branch']);
+    expect(result.tree.edges.filter((edge) => edge.source === 'root').map((edge) => edge.target)).toEqual([
+      'subtree-node',
+    ]);
+  });
+
+  it('explodes generated wrap roots without recreating the wrapper sequence', () => {
+    const sequence = makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence');
+    const first = makeNode('first', BehaviorNodeType.Action, 'First');
+    const second = makeNode('second', BehaviorNodeType.Action, 'Second');
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [sequence, first, second],
+      edges: [
+        { id: 'edge-0', source: 'sequence', target: 'first' },
+        { id: 'edge-1', source: 'sequence', target: 'second' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const wrapped = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['first', 'second'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(wrapped.ok).toBe(true);
+    if (!wrapped.ok) return;
+
+    const exploded = explodeSubtreeNode({
+      tree: wrapped.tree,
+      subtreeNodeId: 'subtree-node',
+      startNodeIndex: 10,
+    });
+
+    expect(exploded.ok).toBe(true);
+    if (!exploded.ok) return;
+
+    const insertedSequences = exploded.tree.nodes.filter(
+      (node) => node.type === BehaviorNodeType.Sequence && node.id !== 'sequence'
+    );
+    expect(insertedSequences).toHaveLength(0);
+    expect(exploded.insertedNodeIds).toHaveLength(2);
+  });
+
+  it('preserves parent edge order when exploding a wrapped branch', () => {
+    const sequence = makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence');
+    const first = makeNode('first', BehaviorNodeType.Action, 'First');
+    const second = makeNode('second', BehaviorNodeType.Action, 'Second');
+    const third = makeNode('third', BehaviorNodeType.Action, 'Third');
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [sequence, first, second, third],
+      edges: [
+        { id: 'edge-0', source: 'sequence', target: 'first' },
+        { id: 'edge-1', source: 'sequence', target: 'second' },
+        { id: 'edge-2', source: 'sequence', target: 'third' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const wrapped = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['first', 'second'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(wrapped.ok).toBe(true);
+    if (!wrapped.ok) return;
+
+    const exploded = explodeSubtreeNode({
+      tree: wrapped.tree,
+      subtreeNodeId: 'subtree-node',
+      startNodeIndex: 10,
+    });
+
+    expect(exploded.ok).toBe(true);
+    if (!exploded.ok) return;
+
+    const childLabels = exploded.tree.edges
+      .filter((edge) => edge.source === 'sequence')
+      .map((edge) => exploded.tree.nodes.find((node) => node.id === edge.target)?.data.label);
+    expect(childLabels).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('restores wrapped node positions when an unchanged subtree is exploded', () => {
+    const sequence = {
+      ...makeNode('sequence', BehaviorNodeType.Sequence, 'Sequence'),
+      position: { x: 0, y: 0 },
+    };
+    const first = {
+      ...makeNode('first', BehaviorNodeType.Action, 'First'),
+      position: { x: 120, y: 160 },
+    };
+    const second = {
+      ...makeNode('second', BehaviorNodeType.Action, 'Second'),
+      position: { x: 420, y: 260 },
+    };
+    const tree: BehaviorTree = {
+      id: 'root',
+      name: 'Root',
+      nodes: [sequence, first, second],
+      edges: [
+        { id: 'edge-0', source: 'sequence', target: 'first' },
+        { id: 'edge-1', source: 'sequence', target: 'second' },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const wrapped = wrapSelectionIntoSubtree({
+      tree,
+      selectedNodeIds: ['first', 'second'],
+      subtreeNodeId: 'subtree-node',
+      subtreeTreeId: 'subtree-tree',
+      subtreeLabel: 'Wrapped',
+    });
+
+    expect(wrapped.ok).toBe(true);
+    if (!wrapped.ok) return;
+
+    const exploded = explodeSubtreeNode({
+      tree: wrapped.tree,
+      subtreeNodeId: 'subtree-node',
+      startNodeIndex: 10,
+    });
+
+    expect(exploded.ok).toBe(true);
+    if (!exploded.ok) return;
+
+    expect(exploded.tree.nodes.find((node) => node.data.label === 'First')?.position).toEqual(first.position);
+    expect(exploded.tree.nodes.find((node) => node.data.label === 'Second')?.position).toEqual(second.position);
   });
 
   it('clones behavior trees without mutating the source', () => {

--- a/src/features/behaviorTree/subtreeUtils.ts
+++ b/src/features/behaviorTree/subtreeUtils.ts
@@ -1,0 +1,555 @@
+import { Edge, Node, XYPosition } from 'reactflow';
+
+import { getNextBehaviorNodeId, getNodeCounterAfterNodes } from './nodeUtils';
+import {
+  BehaviorNodeType,
+  BehaviorTree,
+  BehaviorTreeNode,
+  ExecutionStatus,
+  SubtreeNodeData,
+} from './types';
+
+const deepClone = <T>(value: T): T => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+export const isSubtreeNode = (
+  node?: Pick<BehaviorTreeNode, 'type' | 'data'> | null
+): node is BehaviorTreeNode & { data: SubtreeNodeData } => {
+  return Boolean(node?.type === BehaviorNodeType.Subtree && node.data && 'tree' in node.data);
+};
+
+export const cloneBehaviorTree = (tree: BehaviorTree): BehaviorTree => deepClone(tree);
+
+export const areTreePathsEqual = (left: string[], right: string[]): boolean => {
+  if (left.length !== right.length) return false;
+  return left.every((segment, index) => segment === right[index]);
+};
+
+export const getTreeAtPath = (rootTree: BehaviorTree, path: string[]): BehaviorTree | null => {
+  let currentTree: BehaviorTree = rootTree;
+
+  for (const nodeId of path) {
+    const subtreeNode = currentTree.nodes.find((node) => node.id === nodeId);
+    if (!isSubtreeNode(subtreeNode)) return null;
+    currentTree = subtreeNode.data.tree;
+  }
+
+  return currentTree;
+};
+
+export const replaceTreeAtPath = (
+  rootTree: BehaviorTree,
+  path: string[],
+  nextTree: BehaviorTree
+): BehaviorTree => {
+  if (path.length === 0) {
+    return nextTree;
+  }
+
+  const [currentNodeId, ...remainingPath] = path;
+  return {
+    ...rootTree,
+    nodes: rootTree.nodes.map((node) => {
+      if (node.id !== currentNodeId || !isSubtreeNode(node)) return node;
+
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          tree: replaceTreeAtPath(node.data.tree, remainingPath, nextTree),
+        },
+      };
+    }),
+  };
+};
+
+export const updateTreeAtPath = (
+  rootTree: BehaviorTree,
+  path: string[],
+  updater: (tree: BehaviorTree) => BehaviorTree
+): BehaviorTree => {
+  const targetTree = path.length === 0 ? rootTree : getTreeAtPath(rootTree, path);
+  if (!targetTree) return rootTree;
+
+  const nextTree = updater(targetTree);
+  return path.length === 0 ? nextTree : replaceTreeAtPath(rootTree, path, nextTree);
+};
+
+export const resetBehaviorTreeExecutionState = (tree: BehaviorTree): BehaviorTree => ({
+  ...tree,
+  nodes: tree.nodes.map((node) => {
+    const baseNode = {
+      ...node,
+      data: {
+        ...node.data,
+        status: ExecutionStatus.Idle,
+      },
+    };
+
+    if (!isSubtreeNode(node)) return baseNode;
+
+    return {
+      ...baseNode,
+      data: {
+        ...baseNode.data,
+        tree: resetBehaviorTreeExecutionState(node.data.tree),
+      },
+    };
+  }),
+});
+
+export const syncReferencedSubtrees = (
+  tree: BehaviorTree,
+  sourceTree: BehaviorTree
+): BehaviorTree => {
+  let didChange = false;
+
+  const nextNodes = tree.nodes.map((node) => {
+    if (!isSubtreeNode(node)) return node;
+
+    const syncedNestedTree = syncReferencedSubtrees(node.data.tree, sourceTree);
+    const referencesSource = node.data.sourceTreeId === sourceTree.id;
+
+    if (referencesSource) {
+      didChange = true;
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          label: sourceTree.name,
+          sourceTreeId: sourceTree.id,
+          tree: cloneBehaviorTree(sourceTree),
+        },
+      };
+    }
+
+    if (syncedNestedTree !== node.data.tree) {
+      didChange = true;
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          tree: syncedNestedTree,
+        },
+      };
+    }
+
+    return node;
+  });
+
+  return didChange
+    ? {
+        ...tree,
+        nodes: nextNodes,
+        updatedAt: Date.now(),
+      }
+    : tree;
+};
+
+export interface ExplodeSubtreeNodeParams {
+  tree: BehaviorTree;
+  subtreeNodeId: string;
+  startNodeIndex?: number;
+}
+
+export type ExplodeSubtreeNodeResult = {
+  ok: true;
+  tree: BehaviorTree;
+  insertedNodeIds: string[];
+  nextNodeCounter: number;
+} | {
+  ok: false;
+  reason: string;
+};
+
+export const createSubtreeNode = ({
+  id,
+  label,
+  position,
+  tree,
+  sourceTreeId,
+}: {
+  id: string;
+  label: string;
+  position: XYPosition;
+  tree: BehaviorTree;
+  sourceTreeId?: string;
+}): BehaviorTreeNode => ({
+  id,
+  type: BehaviorNodeType.Subtree,
+  position,
+  data: {
+    label,
+    tree: cloneBehaviorTree(tree),
+    sourceTreeId,
+  },
+});
+
+const collectDescendantIds = (
+  tree: Pick<BehaviorTree, 'nodes' | 'edges'>,
+  rootIds: string[]
+): Set<string> => {
+  const ids = new Set(rootIds);
+  const queue = [...rootIds];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift();
+    if (!currentId) continue;
+
+    tree.edges
+      .filter((edge) => edge.source === currentId)
+      .forEach((edge) => {
+        if (ids.has(edge.target)) return;
+        ids.add(edge.target);
+        queue.push(edge.target);
+      });
+  }
+
+  return ids;
+};
+
+const averagePosition = (nodes: BehaviorTreeNode[]): XYPosition => {
+  if (nodes.length === 0) return { x: 0, y: 0 };
+
+  const { x, y } = nodes.reduce(
+    (acc, node) => ({
+      x: acc.x + node.position.x,
+      y: acc.y + node.position.y,
+    }),
+    { x: 0, y: 0 }
+  );
+
+  return {
+    x: x / nodes.length,
+    y: y / nodes.length,
+  };
+};
+
+export interface WrapSelectionIntoSubtreeParams {
+  tree: BehaviorTree;
+  selectedNodeIds: string[];
+  subtreeTreeId: string;
+  subtreeLabel: string;
+  subtreeNodeId: string;
+}
+
+export type WrapSelectionIntoSubtreeResult = {
+  ok: true;
+  tree: BehaviorTree;
+  subtreeNode: BehaviorTreeNode;
+  selectedRootIds: string[];
+} | {
+  ok: false;
+  reason: string;
+};
+
+export const wrapSelectionIntoSubtree = ({
+  tree,
+  selectedNodeIds,
+  subtreeTreeId,
+  subtreeLabel,
+  subtreeNodeId,
+}: WrapSelectionIntoSubtreeParams): WrapSelectionIntoSubtreeResult => {
+  if (selectedNodeIds.length < 2) {
+    return { ok: false, reason: 'Select at least two nodes to wrap them in a subtree.' };
+  }
+
+  const selectedIds = new Set(selectedNodeIds);
+  const selectedNodes = tree.nodes.filter((node) => selectedIds.has(node.id));
+  if (selectedNodes.length !== selectedIds.size) {
+    return { ok: false, reason: 'Some selected nodes could not be found.' };
+  }
+
+  const selectedRoots = selectedNodes.filter(
+    (node) => !tree.edges.some((edge) => selectedIds.has(edge.source) && edge.target === node.id)
+  );
+  if (selectedRoots.length < 2) {
+    return {
+      ok: false,
+      reason: 'Select sibling sequence items, not just nested nodes from one branch.',
+    };
+  }
+
+  const incomingParentEdges = selectedRoots.map((node) =>
+    tree.edges.find((edge) => edge.target === node.id)
+  );
+  if (incomingParentEdges.some((edge) => !edge)) {
+    return {
+      ok: false,
+      reason: 'Selected nodes must already be attached to the same sequence before wrapping.',
+    };
+  }
+
+  const parentIds = Array.from(new Set(incomingParentEdges.map((edge) => edge?.source)));
+  if (parentIds.length !== 1) {
+    return {
+      ok: false,
+      reason: 'Selected nodes must share the same parent sequence to wrap them.',
+    };
+  }
+
+  const parentNode = tree.nodes.find((node) => node.id === parentIds[0]);
+  if (!parentNode || parentNode.type !== BehaviorNodeType.Sequence) {
+    return {
+      ok: false,
+      reason: 'Only children of a sequence node can be wrapped into a subtree.',
+    };
+  }
+
+  const siblingEdges = tree.edges.filter((edge) => edge.source === parentNode.id);
+  const selectedSiblingIndexes = siblingEdges
+    .map((edge, index) => ({ edge, index }))
+    .filter(({ edge }) => selectedRoots.some((node) => node.id === edge.target))
+    .map(({ index }) => index);
+
+  const sortedIndexes = [...selectedSiblingIndexes].sort((a, b) => a - b);
+  const isContiguous = sortedIndexes.every((index, offset) => {
+    return offset === 0 || index === sortedIndexes[offset - 1] + 1;
+  });
+
+  if (!isContiguous) {
+    return {
+      ok: false,
+      reason: 'Wrap works on consecutive sequence items. Select neighboring children and try again.',
+    };
+  }
+
+  const includedIds = collectDescendantIds(tree, selectedRoots.map((node) => node.id));
+  const subtreeNodes = tree.nodes
+    .filter((node) => includedIds.has(node.id))
+    .map((node) => ({
+      ...deepClone(node),
+      selected: false,
+      dragging: false,
+      data: {
+        ...deepClone(node.data),
+        status: undefined,
+        isHighlighted: false,
+      },
+    }));
+
+  const internalEdges = tree.edges
+    .filter((edge) => includedIds.has(edge.source) && includedIds.has(edge.target))
+    .map((edge) => ({
+      ...deepClone(edge),
+      selected: false,
+    }));
+
+  const subtreeSequenceRootId = getNextBehaviorNodeId(
+    subtreeNodes as Array<Pick<Node, 'id'>>,
+    0
+  );
+  const subtreeSequenceRoot: BehaviorTreeNode = {
+    id: subtreeSequenceRootId,
+    type: BehaviorNodeType.Sequence,
+    position: averagePosition(selectedRoots),
+    data: {
+      label: subtreeLabel,
+      type: 'sequence',
+    },
+  };
+
+  const subtreeEdgeSeed = internalEdges.length;
+  const rootEdges: Edge[] = selectedRoots.map((node, index) => ({
+    id: `edge-subtree-${subtreeTreeId}-${subtreeEdgeSeed + index}`,
+    source: subtreeSequenceRoot.id,
+    target: node.id,
+    sourceHandle: null,
+    targetHandle: null,
+    selected: false,
+  }));
+
+  const embeddedTree: BehaviorTree = {
+    id: subtreeTreeId,
+    name: subtreeLabel,
+    nodes: [...subtreeNodes, subtreeSequenceRoot],
+    edges: [...rootEdges, ...internalEdges],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+
+  const subtreeNode = createSubtreeNode({
+    id: subtreeNodeId,
+    label: subtreeLabel,
+    position: averagePosition(selectedRoots),
+    tree: embeddedTree,
+  });
+
+  const nextNodes = [
+    ...tree.nodes.filter((node) => !includedIds.has(node.id)).map((node) => ({
+      ...node,
+      selected: false,
+      dragging: false,
+      data: {
+        ...node.data,
+        isHighlighted: false,
+      },
+    })),
+    subtreeNode,
+  ];
+
+  let insertedParentEdge = false;
+  const nextEdges = tree.edges.flatMap((edge) => {
+    if (includedIds.has(edge.source) || includedIds.has(edge.target)) {
+      if (
+        !insertedParentEdge &&
+        edge.source === parentNode.id &&
+        selectedRoots.some((node) => node.id === edge.target)
+      ) {
+        insertedParentEdge = true;
+        return [
+          {
+            id: `edge-parent-${subtreeNode.id}`,
+            source: parentNode.id,
+            target: subtreeNode.id,
+            sourceHandle: null,
+            targetHandle: null,
+            selected: false,
+          } satisfies Edge,
+        ];
+      }
+
+      return [];
+    }
+
+    return [{ ...edge, selected: false }];
+  });
+
+  return {
+    ok: true,
+    tree: {
+      ...tree,
+      nodes: nextNodes,
+      edges: nextEdges,
+      updatedAt: Date.now(),
+    },
+    subtreeNode,
+    selectedRootIds: selectedRoots.map((node) => node.id),
+  };
+};
+
+export const explodeSubtreeNode = ({
+  tree,
+  subtreeNodeId,
+  startNodeIndex = 0,
+}: ExplodeSubtreeNodeParams): ExplodeSubtreeNodeResult => {
+  const subtreeNode = tree.nodes.find((node) => node.id === subtreeNodeId);
+  if (!isSubtreeNode(subtreeNode)) {
+    return {
+      ok: false,
+      reason: 'Select a subtree node to expand it back into the current tree.',
+    };
+  }
+
+  const embeddedTree = cloneBehaviorTree(subtreeNode.data.tree);
+  if (embeddedTree.nodes.length === 0) {
+    return {
+      ok: false,
+      reason: 'This subtree is empty, so there is nothing to expand.',
+    };
+  }
+
+  const nodesWithIncoming = new Set(embeddedTree.edges.map((edge) => edge.target));
+  const nodesWithOutgoing = new Set(embeddedTree.edges.map((edge) => edge.source));
+  const embeddedRoots = embeddedTree.nodes.filter((node) => !nodesWithIncoming.has(node.id));
+  const embeddedLeaves = embeddedTree.nodes.filter((node) => !nodesWithOutgoing.has(node.id));
+
+  if (embeddedRoots.length === 0) {
+    return {
+      ok: false,
+      reason: 'This subtree has no root node to reconnect.',
+    };
+  }
+
+  const anchor = averagePosition(embeddedRoots);
+  const allocationNodes: Array<Pick<Node, 'id'>> = tree.nodes.filter((node) => node.id !== subtreeNodeId);
+  let nextNodeCounter = getNodeCounterAfterNodes(allocationNodes, startNodeIndex);
+  const idMap = new Map<string, string>();
+
+  const clonedNodes = embeddedTree.nodes.map((node) => {
+    const nextId = getNextBehaviorNodeId(allocationNodes, nextNodeCounter);
+    nextNodeCounter = getNodeCounterAfterNodes([{ id: nextId }], nextNodeCounter);
+    allocationNodes.push({ id: nextId });
+    idMap.set(node.id, nextId);
+
+    return {
+      ...deepClone(node),
+      id: nextId,
+      position: {
+        x: subtreeNode.position.x + (node.position.x - anchor.x),
+        y: subtreeNode.position.y + (node.position.y - anchor.y),
+      },
+      selected: true,
+      dragging: false,
+      data: {
+        ...deepClone(node.data),
+        isHighlighted: true,
+      },
+    };
+  });
+
+  const internalEdges = embeddedTree.edges.map((edge) => ({
+    ...deepClone(edge),
+    id: `edge-expand-${subtreeNode.id}-${crypto.randomUUID()}`,
+    source: idMap.get(edge.source) ?? edge.source,
+    target: idMap.get(edge.target) ?? edge.target,
+    selected: false,
+  }));
+
+  const incomingEdges = tree.edges.filter((edge) => edge.target === subtreeNode.id);
+  const outgoingEdges = tree.edges.filter((edge) => edge.source === subtreeNode.id);
+  const reconnectedIncomingEdges = incomingEdges.flatMap((edge) =>
+    embeddedRoots.map((root) => ({
+      ...deepClone(edge),
+      id: `edge-expand-in-${subtreeNode.id}-${crypto.randomUUID()}`,
+      target: idMap.get(root.id) ?? root.id,
+      selected: false,
+    }))
+  );
+  const reconnectedOutgoingEdges = outgoingEdges.flatMap((edge) =>
+    embeddedLeaves.map((leaf) => ({
+      ...deepClone(edge),
+      id: `edge-expand-out-${subtreeNode.id}-${crypto.randomUUID()}`,
+      source: idMap.get(leaf.id) ?? leaf.id,
+      selected: false,
+    }))
+  );
+
+  const nextNodes = [
+    ...tree.nodes
+      .filter((node) => node.id !== subtreeNode.id)
+      .map((node) => ({
+        ...node,
+        selected: false,
+        dragging: false,
+        data: {
+          ...node.data,
+          isHighlighted: false,
+        },
+      })),
+    ...clonedNodes,
+  ];
+  const nextEdges = [
+    ...tree.edges.filter((edge) => edge.source !== subtreeNode.id && edge.target !== subtreeNode.id),
+    ...internalEdges,
+    ...reconnectedIncomingEdges,
+    ...reconnectedOutgoingEdges,
+  ];
+
+  return {
+    ok: true,
+    tree: {
+      ...tree,
+      nodes: nextNodes,
+      edges: nextEdges,
+      updatedAt: Date.now(),
+    },
+    insertedNodeIds: clonedNodes.map((node) => node.id),
+    nextNodeCounter,
+  };
+};

--- a/src/features/behaviorTree/subtreeUtils.ts
+++ b/src/features/behaviorTree/subtreeUtils.ts
@@ -239,7 +239,9 @@ const isControlFlowNode = (node?: BehaviorTreeNode | null): boolean => {
   return Boolean(
     node?.type === BehaviorNodeType.Sequence ||
       node?.type === BehaviorNodeType.Selector ||
-      node?.type === BehaviorNodeType.Parallel
+      node?.type === BehaviorNodeType.Parallel ||
+      node?.type === BehaviorNodeType.Retry ||
+      node?.type === BehaviorNodeType.Repeat
   );
 };
 

--- a/src/features/behaviorTree/subtreeUtils.ts
+++ b/src/features/behaviorTree/subtreeUtils.ts
@@ -230,6 +230,90 @@ const averagePosition = (nodes: BehaviorTreeNode[]): XYPosition => {
   };
 };
 
+const translatePosition = (position: XYPosition, origin: XYPosition): XYPosition => ({
+  x: position.x - origin.x,
+  y: position.y - origin.y,
+});
+
+const isControlFlowNode = (node?: BehaviorTreeNode | null): boolean => {
+  return Boolean(
+    node?.type === BehaviorNodeType.Sequence ||
+      node?.type === BehaviorNodeType.Selector ||
+      node?.type === BehaviorNodeType.Parallel
+  );
+};
+
+const getChildEdges = (tree: Pick<BehaviorTree, 'edges'>, nodeId: string): Edge[] => {
+  return tree.edges.filter((edge) => edge.source === nodeId);
+};
+
+const getIncomingEdge = (tree: Pick<BehaviorTree, 'edges'>, nodeId: string): Edge | undefined => {
+  return tree.edges.find((edge) => edge.target === nodeId);
+};
+
+const hasSelectedDirectChild = (
+  tree: Pick<BehaviorTree, 'edges'>,
+  nodeId: string,
+  selectedIds: Set<string>
+): boolean => {
+  return getChildEdges(tree, nodeId).some((edge) => selectedIds.has(edge.target));
+};
+
+const hasAllDirectChildrenSelected = (
+  tree: Pick<BehaviorTree, 'edges'>,
+  nodeId: string,
+  selectedIds: Set<string>
+): boolean => {
+  const childEdges = getChildEdges(tree, nodeId);
+  return childEdges.length > 0 && childEdges.every((edge) => selectedIds.has(edge.target));
+};
+
+const hasAbsorbingSelectedAncestor = (
+  tree: Pick<BehaviorTree, 'edges'>,
+  nodeId: string,
+  selectedIds: Set<string>
+): boolean => {
+  let currentId = nodeId;
+  let incomingEdge = getIncomingEdge(tree, currentId);
+
+  while (incomingEdge) {
+    const parentId = incomingEdge.source;
+    if (selectedIds.has(parentId) && hasAllDirectChildrenSelected(tree, parentId, selectedIds)) {
+      return true;
+    }
+
+    currentId = parentId;
+    incomingEdge = getIncomingEdge(tree, currentId);
+  }
+
+  return false;
+};
+
+const getWrapRootNodes = (
+  tree: BehaviorTree,
+  selectedNodes: BehaviorTreeNode[],
+  selectedIds: Set<string>
+): BehaviorTreeNode[] => {
+  return selectedNodes.filter((node) => {
+    if (hasAbsorbingSelectedAncestor(tree, node.id, selectedIds)) return false;
+
+    const hasSelectedChildren = hasSelectedDirectChild(tree, node.id, selectedIds);
+    if (hasSelectedChildren && !hasAllDirectChildrenSelected(tree, node.id, selectedIds)) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+const isGeneratedSubtreeRoot = (node: BehaviorTreeNode): boolean => {
+  return Boolean(
+    node.type === BehaviorNodeType.Sequence &&
+      'generatedBySubtreeWrap' in node.data &&
+      node.data.generatedBySubtreeWrap
+  );
+};
+
 export interface WrapSelectionIntoSubtreeParams {
   tree: BehaviorTree;
   selectedNodeIds: string[];
@@ -265,43 +349,44 @@ export const wrapSelectionIntoSubtree = ({
     return { ok: false, reason: 'Some selected nodes could not be found.' };
   }
 
-  const selectedRoots = selectedNodes.filter(
-    (node) => !tree.edges.some((edge) => selectedIds.has(edge.source) && edge.target === node.id)
+  const selectedRoots = getWrapRootNodes(tree, selectedNodes, selectedIds);
+  if (selectedRoots.length === 0) {
+    return {
+      ok: false,
+      reason: 'Select neighboring children, or select a parent together with all of its children.',
+    };
+  }
+
+  const incomingParentEdges = selectedRoots.map((node) => getIncomingEdge(tree, node.id));
+  const rootsWithoutParent = incomingParentEdges.filter((edge) => !edge).length;
+  if (rootsWithoutParent > 0 && rootsWithoutParent !== incomingParentEdges.length) {
+    return {
+      ok: false,
+      reason: 'Selected nodes must be attached to the same parent before wrapping.',
+    };
+  }
+
+  const parentIds = Array.from(
+    new Set(incomingParentEdges.map((edge) => edge?.source).filter(Boolean))
   );
-  if (selectedRoots.length < 2) {
+  if (parentIds.length > 1) {
     return {
       ok: false,
-      reason: 'Select sibling sequence items, not just nested nodes from one branch.',
+      reason: 'Selected nodes must share the same parent to wrap them.',
     };
   }
 
-  const incomingParentEdges = selectedRoots.map((node) =>
-    tree.edges.find((edge) => edge.target === node.id)
-  );
-  if (incomingParentEdges.some((edge) => !edge)) {
+  const parentNode = parentIds.length === 1
+    ? tree.nodes.find((node) => node.id === parentIds[0])
+    : null;
+  if (parentNode && !isControlFlowNode(parentNode)) {
     return {
       ok: false,
-      reason: 'Selected nodes must already be attached to the same sequence before wrapping.',
+      reason: 'Only children of a control-flow node can be wrapped into a subtree.',
     };
   }
 
-  const parentIds = Array.from(new Set(incomingParentEdges.map((edge) => edge?.source)));
-  if (parentIds.length !== 1) {
-    return {
-      ok: false,
-      reason: 'Selected nodes must share the same parent sequence to wrap them.',
-    };
-  }
-
-  const parentNode = tree.nodes.find((node) => node.id === parentIds[0]);
-  if (!parentNode || parentNode.type !== BehaviorNodeType.Sequence) {
-    return {
-      ok: false,
-      reason: 'Only children of a sequence node can be wrapped into a subtree.',
-    };
-  }
-
-  const siblingEdges = tree.edges.filter((edge) => edge.source === parentNode.id);
+  const siblingEdges = parentNode ? getChildEdges(tree, parentNode.id) : [];
   const selectedSiblingIndexes = siblingEdges
     .map((edge, index) => ({ edge, index }))
     .filter(({ edge }) => selectedRoots.some((node) => node.id === edge.target))
@@ -312,18 +397,26 @@ export const wrapSelectionIntoSubtree = ({
     return offset === 0 || index === sortedIndexes[offset - 1] + 1;
   });
 
-  if (!isContiguous) {
+  if (parentNode && !isContiguous) {
     return {
       ok: false,
       reason: 'Wrap works on consecutive sequence items. Select neighboring children and try again.',
     };
   }
 
-  const includedIds = collectDescendantIds(tree, selectedRoots.map((node) => node.id));
+  const orderedSelectedRoots = parentNode
+    ? siblingEdges
+        .map((edge) => selectedRoots.find((node) => node.id === edge.target))
+        .filter((node): node is BehaviorTreeNode => Boolean(node))
+    : selectedRoots;
+  const subtreeAnchor = averagePosition(orderedSelectedRoots);
+  const toEmbeddedPosition = (position: XYPosition) => translatePosition(position, subtreeAnchor);
+  const includedIds = collectDescendantIds(tree, orderedSelectedRoots.map((node) => node.id));
   const subtreeNodes = tree.nodes
     .filter((node) => includedIds.has(node.id))
     .map((node) => ({
       ...deepClone(node),
+      position: toEmbeddedPosition(node.position),
       selected: false,
       dragging: false,
       data: {
@@ -340,34 +433,39 @@ export const wrapSelectionIntoSubtree = ({
       selected: false,
     }));
 
-  const subtreeSequenceRootId = getNextBehaviorNodeId(
-    subtreeNodes as Array<Pick<Node, 'id'>>,
-    0
-  );
-  const subtreeSequenceRoot: BehaviorTreeNode = {
-    id: subtreeSequenceRootId,
-    type: BehaviorNodeType.Sequence,
-    position: averagePosition(selectedRoots),
-    data: {
-      label: subtreeLabel,
-      type: 'sequence',
-    },
-  };
+  const shouldCreateWrapperRoot = selectedRoots.length > 1;
+  const subtreeSequenceRootId = shouldCreateWrapperRoot
+    ? getNextBehaviorNodeId(subtreeNodes as Array<Pick<Node, 'id'>>, 0)
+    : null;
+  const subtreeSequenceRoot: BehaviorTreeNode | null = subtreeSequenceRootId
+    ? {
+        id: subtreeSequenceRootId,
+        type: BehaviorNodeType.Sequence,
+        position: parentNode ? toEmbeddedPosition(parentNode.position) : { x: 0, y: 0 },
+        data: {
+          label: subtreeLabel,
+          type: 'sequence',
+          generatedBySubtreeWrap: true,
+        },
+      }
+    : null;
 
   const subtreeEdgeSeed = internalEdges.length;
-  const rootEdges: Edge[] = selectedRoots.map((node, index) => ({
-    id: `edge-subtree-${subtreeTreeId}-${subtreeEdgeSeed + index}`,
-    source: subtreeSequenceRoot.id,
-    target: node.id,
-    sourceHandle: null,
-    targetHandle: null,
-    selected: false,
-  }));
+  const rootEdges: Edge[] = subtreeSequenceRoot
+    ? orderedSelectedRoots.map((node, index) => ({
+        id: `edge-subtree-${subtreeTreeId}-${subtreeEdgeSeed + index}`,
+        source: subtreeSequenceRoot.id,
+        target: node.id,
+        sourceHandle: null,
+        targetHandle: null,
+        selected: false,
+      }))
+    : [];
 
   const embeddedTree: BehaviorTree = {
     id: subtreeTreeId,
     name: subtreeLabel,
-    nodes: [...subtreeNodes, subtreeSequenceRoot],
+    nodes: subtreeSequenceRoot ? [...subtreeNodes, subtreeSequenceRoot] : subtreeNodes,
     edges: [...rootEdges, ...internalEdges],
     createdAt: Date.now(),
     updatedAt: Date.now(),
@@ -376,7 +474,7 @@ export const wrapSelectionIntoSubtree = ({
   const subtreeNode = createSubtreeNode({
     id: subtreeNodeId,
     label: subtreeLabel,
-    position: averagePosition(selectedRoots),
+    position: subtreeAnchor,
     tree: embeddedTree,
   });
 
@@ -398,8 +496,9 @@ export const wrapSelectionIntoSubtree = ({
     if (includedIds.has(edge.source) || includedIds.has(edge.target)) {
       if (
         !insertedParentEdge &&
+        parentNode &&
         edge.source === parentNode.id &&
-        selectedRoots.some((node) => node.id === edge.target)
+        orderedSelectedRoots.some((node) => node.id === edge.target)
       ) {
         insertedParentEdge = true;
         return [
@@ -429,7 +528,7 @@ export const wrapSelectionIntoSubtree = ({
       updatedAt: Date.now(),
     },
     subtreeNode,
-    selectedRootIds: selectedRoots.map((node) => node.id),
+    selectedRootIds: orderedSelectedRoots.map((node) => node.id),
   };
 };
 
@@ -455,23 +554,51 @@ export const explodeSubtreeNode = ({
   }
 
   const nodesWithIncoming = new Set(embeddedTree.edges.map((edge) => edge.target));
-  const nodesWithOutgoing = new Set(embeddedTree.edges.map((edge) => edge.source));
   const embeddedRoots = embeddedTree.nodes.filter((node) => !nodesWithIncoming.has(node.id));
-  const embeddedLeaves = embeddedTree.nodes.filter((node) => !nodesWithOutgoing.has(node.id));
+  const generatedRoot =
+    embeddedRoots.length === 1 && isGeneratedSubtreeRoot(embeddedRoots[0])
+      ? embeddedRoots[0]
+      : null;
+  const generatedRootChildIds = generatedRoot
+    ? new Set(
+        embeddedTree.edges
+          .filter((edge) => edge.source === generatedRoot.id)
+          .map((edge) => edge.target)
+      )
+    : new Set<string>();
+  const explodableNodes = generatedRoot
+    ? embeddedTree.nodes.filter((node) => node.id !== generatedRoot.id)
+    : embeddedTree.nodes;
+  const explodableNodeIds = new Set(explodableNodes.map((node) => node.id));
+  const explodableEdges = embeddedTree.edges.filter(
+    (edge) =>
+      explodableNodeIds.has(edge.source) &&
+      explodableNodeIds.has(edge.target) &&
+      edge.source !== generatedRoot?.id &&
+      edge.target !== generatedRoot?.id
+  );
+  const explodableNodesWithIncoming = new Set(explodableEdges.map((edge) => edge.target));
+  const explodableNodesWithOutgoing = new Set(explodableEdges.map((edge) => edge.source));
+  const rootsToReconnect = generatedRoot
+    ? explodableNodes.filter((node) => generatedRootChildIds.has(node.id))
+    : explodableNodes.filter((node) => !explodableNodesWithIncoming.has(node.id));
+  const leavesToReconnect = explodableNodes.filter(
+    (node) => !explodableNodesWithOutgoing.has(node.id)
+  );
 
-  if (embeddedRoots.length === 0) {
+  if (rootsToReconnect.length === 0) {
     return {
       ok: false,
       reason: 'This subtree has no root node to reconnect.',
     };
   }
 
-  const anchor = averagePosition(embeddedRoots);
+  const anchor = averagePosition(rootsToReconnect);
   const allocationNodes: Array<Pick<Node, 'id'>> = tree.nodes.filter((node) => node.id !== subtreeNodeId);
   let nextNodeCounter = getNodeCounterAfterNodes(allocationNodes, startNodeIndex);
   const idMap = new Map<string, string>();
 
-  const clonedNodes = embeddedTree.nodes.map((node) => {
+  const clonedNodes = explodableNodes.map((node) => {
     const nextId = getNextBehaviorNodeId(allocationNodes, nextNodeCounter);
     nextNodeCounter = getNodeCounterAfterNodes([{ id: nextId }], nextNodeCounter);
     allocationNodes.push({ id: nextId });
@@ -493,7 +620,7 @@ export const explodeSubtreeNode = ({
     };
   });
 
-  const internalEdges = embeddedTree.edges.map((edge) => ({
+  const internalEdges = explodableEdges.map((edge) => ({
     ...deepClone(edge),
     id: `edge-expand-${subtreeNode.id}-${crypto.randomUUID()}`,
     source: idMap.get(edge.source) ?? edge.source,
@@ -501,24 +628,20 @@ export const explodeSubtreeNode = ({
     selected: false,
   }));
 
-  const incomingEdges = tree.edges.filter((edge) => edge.target === subtreeNode.id);
-  const outgoingEdges = tree.edges.filter((edge) => edge.source === subtreeNode.id);
-  const reconnectedIncomingEdges = incomingEdges.flatMap((edge) =>
-    embeddedRoots.map((root) => ({
+  const makeReconnectedIncomingEdges = (edge: Edge): Edge[] =>
+    rootsToReconnect.map((root) => ({
       ...deepClone(edge),
       id: `edge-expand-in-${subtreeNode.id}-${crypto.randomUUID()}`,
       target: idMap.get(root.id) ?? root.id,
       selected: false,
-    }))
-  );
-  const reconnectedOutgoingEdges = outgoingEdges.flatMap((edge) =>
-    embeddedLeaves.map((leaf) => ({
+    }));
+  const makeReconnectedOutgoingEdges = (edge: Edge): Edge[] =>
+    leavesToReconnect.map((leaf) => ({
       ...deepClone(edge),
       id: `edge-expand-out-${subtreeNode.id}-${crypto.randomUUID()}`,
       source: idMap.get(leaf.id) ?? leaf.id,
       selected: false,
-    }))
-  );
+    }));
 
   const nextNodes = [
     ...tree.nodes
@@ -535,10 +658,18 @@ export const explodeSubtreeNode = ({
     ...clonedNodes,
   ];
   const nextEdges = [
-    ...tree.edges.filter((edge) => edge.source !== subtreeNode.id && edge.target !== subtreeNode.id),
+    ...tree.edges.flatMap((edge) => {
+      if (edge.target === subtreeNode.id) {
+        return makeReconnectedIncomingEdges(edge);
+      }
+
+      if (edge.source === subtreeNode.id) {
+        return makeReconnectedOutgoingEdges(edge);
+      }
+
+      return [edge];
+    }),
     ...internalEdges,
-    ...reconnectedIncomingEdges,
-    ...reconnectedOutgoingEdges,
   ];
 
   return {

--- a/src/features/behaviorTree/types.ts
+++ b/src/features/behaviorTree/types.ts
@@ -14,6 +14,8 @@ export enum BehaviorNodeType {
   Sequence = 'sequence',
   Selector = 'selector',
   Parallel = 'parallel',
+  Retry = 'retry',
+  Repeat = 'repeat',
   Subtree = 'subtree',
   
   // ROS nodes
@@ -77,9 +79,10 @@ export interface ROSTopicNodeData extends BaseNodeData {
 }
 
 export interface ControlFlowNodeData extends BaseNodeData {
-  type: 'sequence' | 'selector' | 'parallel';
+  type: 'sequence' | 'selector' | 'parallel' | 'retry' | 'repeat';
   description?: string;
   generatedBySubtreeWrap?: boolean;
+  iterationLimit?: number;
 }
 
 export interface SubtreeNodeData extends BaseNodeData {

--- a/src/features/behaviorTree/types.ts
+++ b/src/features/behaviorTree/types.ts
@@ -14,6 +14,7 @@ export enum BehaviorNodeType {
   Sequence = 'sequence',
   Selector = 'selector',
   Parallel = 'parallel',
+  Subtree = 'subtree',
   
   // ROS nodes
   Action = 'action',
@@ -51,6 +52,7 @@ export interface ROSDiscoveryResult {
 export interface BaseNodeData {
   label: string;
   status?: ExecutionStatus;
+  isHighlighted?: boolean;
 }
 
 export interface ROSActionNodeData extends BaseNodeData {
@@ -79,6 +81,11 @@ export interface ControlFlowNodeData extends BaseNodeData {
   description?: string;
 }
 
+export interface SubtreeNodeData extends BaseNodeData {
+  tree: BehaviorTree;
+  sourceTreeId?: string;
+}
+
 export interface ConditionNodeData extends BaseNodeData {
   condition: string;
   expectedValue?: any;
@@ -91,6 +98,7 @@ export type BehaviorNodeData =
   | ROSServiceNodeData
   | ROSTopicNodeData
   | ControlFlowNodeData
+  | SubtreeNodeData
   | ConditionNodeData;
 
 // Behavior tree node (extends React Flow Node)
@@ -132,7 +140,11 @@ export interface ExecutionEvent {
   type: ExecutionEventType;
   nodeId?: string;
   timestamp: number;
-  data?: any;
+  data?: {
+    status?: ExecutionStatus;
+    treePath?: string[];
+    [key: string]: unknown;
+  };
   error?: string;
 }
 
@@ -153,4 +165,3 @@ export interface NodePaletteItem {
   category: 'control' | 'ros' | 'utility';
   rosInfo?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo;
 }
-

--- a/src/features/behaviorTree/types.ts
+++ b/src/features/behaviorTree/types.ts
@@ -79,6 +79,7 @@ export interface ROSTopicNodeData extends BaseNodeData {
 export interface ControlFlowNodeData extends BaseNodeData {
   type: 'sequence' | 'selector' | 'parallel';
   description?: string;
+  generatedBySubtreeWrap?: boolean;
 }
 
 export interface SubtreeNodeData extends BaseNodeData {


### PR DESCRIPTION
## Summary

Adds major Behavior Tree editor improvements focused on subtree workflows, editing safety, and new control-flow decorators.

## Main Changes

- Added full subtree support:
  - Create subtree nodes
  - Wrap selected nodes into a subtree
  - Open/navigate into subtrees
  - Return to parent tree
  - Save subtrees as reusable saved trees
  - Explode subtrees back into the parent tree

- Added undo/redo support:
  - Toolbar undo/redo buttons
  - Keyboard shortcuts with `Ctrl/Cmd+Z` and redo
  - History handling for root trees and nested subtree paths
  - Safer undo behavior when loading/importing/creating trees or editing inside subtrees

- Added Retry and Repeat decorator/control-flow nodes:
  - New palette entries and node renderers
  - Configurable iteration count
  - Infinite mode via `-1`
  - Executor support for retry-on-failure and repeat-on-success behavior

- Improved editor interaction:
  - More reliable box selection
  - Ctrl/meta multi-selection improvements
  - Edge selection support
  - Contextual selection actions for rename, duplicate, wrap, open, save, explode, delete, and decorator count editing

- Improved Behavior Tree execution visualization:
  - Execution state propagation through nested trees
  - Retry/repeat executor behavior
  - Follow mode to track the currently running node

- Added and expanded test coverage:
  - Unit tests for subtree utilities, node creation, retry/repeat execution, palette behavior, undo/redo, selection, and subtree navigation
  - Playwright E2E coverage for subtree workflows, undo/redo edge cases, selection behavior, retry/repeat nodes, and editor controls

## Notes

This PR significantly expands the Behavior Tree editor from flat-tree editing into nested, reusable subtree workflows with safer history management and richer control-flow behavior.