### PR TITLE
improved bt edit duplicate rename popup in mobile

### DIFF
--- a/src/features/behaviorTree/components/BehaviorTreePanel.css
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.css
@@ -514,6 +514,27 @@
   color: #ffffff;
 }
 
+@media (pointer: coarse), (max-width: 768px) {
+  .bt-selection-actions {
+    max-width: min(340px, calc(100% - 20px));
+    gap: 6px;
+    padding: 7px;
+  }
+
+  .bt-selection-actions.placement-above {
+    transform: translate(-50%, -100%);
+  }
+
+  .bt-selection-actions.placement-below {
+    transform: translateX(-50%);
+  }
+
+  .bt-selection-action {
+    height: 40px;
+    padding: 0 12px;
+  }
+}
+
 .bt-subtree-parent-action {
   position: absolute;
   z-index: 24;

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -34,6 +34,19 @@ const createRect = (x: number, y: number, width: number, height: number): DOMRec
   toJSON: () => ({}),
 } as DOMRect);
 
+const createMatchMedia =
+  (matches: boolean) =>
+  (query: string): MediaQueryList => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  } as MediaQueryList);
+
 const firePointerEvent = (
   element: Element,
   type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
@@ -256,6 +269,7 @@ describe('BehaviorTreePanel', () => {
     reactFlowMock.setCenter.mockReset();
     reactFlowMock.fitView.mockReset();
     executorMock.instances = [];
+    window.matchMedia = createMatchMedia(false);
     window.confirm = vi.fn(() => true);
     localStorage.clear();
   });
@@ -288,6 +302,92 @@ describe('BehaviorTreePanel', () => {
     render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
 
     expect(screen.getByRole('button', { name: 'Arrange tree' })).toBeInTheDocument();
+  });
+
+  it('places contextual node actions below the selected node on mobile when there is room', async () => {
+    window.matchMedia = createMatchMedia(true);
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'mobile-actions-tree',
+            name: 'Mobile Actions Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+    reactFlowMock.nodeRects = {
+      'node-a': createRect(120, 140, 165, 82),
+    };
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    const canvas = document.querySelector('.bt-canvas') as HTMLElement;
+    canvas.getBoundingClientRect = () => createRect(0, 0, 375, 640);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Mobile Actions Tree'));
+
+    fireEvent.click(await screen.findByTestId('rf-node-node-a'));
+
+    const actions = await screen.findByTestId('bt-selection-actions');
+    expect(actions).toHaveClass('placement-below');
+    expect(parseFloat(actions.style.top)).toBe(236);
+  });
+
+  it('places contextual node actions above a selected node near the bottom on mobile', async () => {
+    window.matchMedia = createMatchMedia(true);
+    const now = Date.now();
+    localStorage.setItem(
+      'robo-boy-behavior-trees',
+      JSON.stringify([
+        {
+          version: '1.0.0',
+          tree: {
+            id: 'mobile-bottom-actions-tree',
+            name: 'Mobile Bottom Actions Tree',
+            nodes: [
+              {
+                id: 'node-a',
+                type: 'action',
+                position: { x: 0, y: 0 },
+                data: { label: 'Node A', actionName: '/a', actionType: 'example/A' },
+              },
+            ],
+            edges: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        },
+      ])
+    );
+    reactFlowMock.nodeRects = {
+      'node-a': createRect(120, 220, 165, 70),
+    };
+
+    render(<BehaviorTreePanel ros={null} isConnected={false} isActive />);
+    const canvas = document.querySelector('.bt-canvas') as HTMLElement;
+    canvas.getBoundingClientRect = () => createRect(0, 0, 375, 300);
+    fireEvent.click(screen.getByTestId('bt-menu-button'));
+    fireEvent.click(screen.getByText('Mobile Bottom Actions Tree'));
+
+    fireEvent.click(await screen.findByTestId('rf-node-node-a'));
+
+    const actions = await screen.findByTestId('bt-selection-actions');
+    expect(actions).toHaveClass('placement-above');
+    expect(parseFloat(actions.style.top)).toBe(206);
   });
 
   it('switches between pan and box-select canvas modes', () => {

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -150,9 +150,18 @@ interface ManualEdgeSelection {
   expiresAt: number;
 }
 
+interface SelectionActionAnchor {
+  x: number;
+  y: number;
+  placement: 'inline' | 'above' | 'below';
+}
+
 const MOBILE_BREAKPOINT = '(max-width: 768px)';
 const MAX_UNDO_HISTORY = 80;
 const SELECTION_ACTIONS_MAX_WIDTH = 360;
+const SELECTION_ACTIONS_MOBILE_MARGIN = 10;
+const SELECTION_ACTIONS_MOBILE_GAP = 14;
+const SELECTION_ACTIONS_MOBILE_ESTIMATED_HEIGHT = 110;
 const BOX_SELECTION_CLEAR_SUPPRESSION_MS = 120;
 const BOX_SELECTION_DRAG_THRESHOLD = 4;
 const PALETTE_ADD_NODE_X_GAP = 190;
@@ -206,6 +215,8 @@ const createViewportRect = (left: number, top: number, right: number, bottom: nu
   bottom,
   toJSON: () => ({}),
 } as DOMRect);
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 const findOpenPaletteAddPosition = (
   position: { x: number; y: number },
@@ -453,7 +464,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const [isPaletteCollapsed, setIsPaletteCollapsed] = useState(true);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
   const [selectedEdges, setSelectedEdges] = useState<Edge[]>([]);
-  const [selectionActionAnchor, setSelectionActionAnchor] = useState<{ x: number; y: number } | null>(null);
+  const [selectionActionAnchor, setSelectionActionAnchor] = useState<SelectionActionAnchor | null>(null);
   const [customBoxSelection, setCustomBoxSelection] = useState<CustomBoxSelectionBox | null>(null);
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
@@ -2276,6 +2287,38 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       },
       { left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity }
     );
+    if (window.matchMedia(MOBILE_BREAKPOINT).matches) {
+      const menuWidth = Math.min(
+        SELECTION_ACTIONS_MAX_WIDTH,
+        Math.max(canvasRect.width - SELECTION_ACTIONS_MOBILE_MARGIN * 2, 0)
+      );
+      const minCenterX = SELECTION_ACTIONS_MOBILE_MARGIN + menuWidth / 2;
+      const maxCenterX = Math.max(
+        canvasRect.width - SELECTION_ACTIONS_MOBILE_MARGIN - menuWidth / 2,
+        minCenterX
+      );
+      const belowSpace = canvasRect.bottom - selectionRect.bottom - SELECTION_ACTIONS_MOBILE_GAP;
+      const aboveSpace = selectionRect.top - canvasRect.top - SELECTION_ACTIONS_MOBILE_GAP;
+      const placement =
+        belowSpace >= SELECTION_ACTIONS_MOBILE_ESTIMATED_HEIGHT || belowSpace >= aboveSpace
+          ? 'below'
+          : 'above';
+
+      setSelectionActionAnchor({
+        x: clamp(
+          (selectionRect.left + selectionRect.right) / 2 - canvasRect.left,
+          minCenterX,
+          maxCenterX
+        ),
+        y:
+          placement === 'below'
+            ? selectionRect.bottom - canvasRect.top + SELECTION_ACTIONS_MOBILE_GAP
+            : selectionRect.top - canvasRect.top - SELECTION_ACTIONS_MOBILE_GAP,
+        placement,
+      });
+      return;
+    }
+
     setSelectionActionAnchor({
       x: Math.min(
         Math.max(selectionRect.right - canvasRect.left + 10, 8),
@@ -2285,6 +2328,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         Math.max(selectionRect.top - canvasRect.top, 8),
         Math.max(canvasRect.height - 48, 8)
       ),
+      placement: 'inline',
     });
   }, [edges, nodes, selectedEdges, selectedNodes]);
 
@@ -2647,7 +2691,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
           )}
           {selectionActionAnchor && (selectedNodes.length > 0 || selectedEdges.length > 0) && (
             <div
-              className="bt-selection-actions"
+              className={`bt-selection-actions placement-${selectionActionAnchor.placement}`}
               style={{
                 left: selectionActionAnchor.x,
                 top: selectionActionAnchor.y,


### PR DESCRIPTION
This PR improve the node popup menu in mobile interfaces which previously was overlapping with the node