### PR TITLE
Gennscar/tes-28 add pause button in bt panel and block user from editing when executing BT

### DIFF
--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -854,6 +854,19 @@ test.describe('Behavior Tree panel', () => {
 
     await page.getByRole('button', { name: 'Run' }).click();
     await expect(page.locator('.bt-node').filter({ hasText: 'Navigate' })).toHaveClass(/status-running/);
+    await expect(page.getByRole('button', { name: 'Pause' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Stop' })).toBeEnabled();
+    await expect(page.getByTestId('bt-menu-button')).toBeDisabled();
+    await expect(page.getByTestId('bt-palette-toggle')).toBeDisabled();
+
+    await page.getByRole('button', { name: 'Pause' }).click();
+    await expect(page.getByRole('button', { name: 'Resume' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Stop' })).toBeEnabled();
+    await expect(page.getByTestId('bt-menu-button')).toBeDisabled();
+
+    await page.getByRole('button', { name: 'Resume' }).click();
+    await expect(page.getByRole('button', { name: 'Pause' })).toBeVisible();
+
 
     await page.getByLabel('Switch to 3D View').click();
     const island = page.locator('.bt-execution-island');

--- a/e2e/behavior-tree.spec.ts
+++ b/e2e/behavior-tree.spec.ts
@@ -855,13 +855,13 @@ test.describe('Behavior Tree panel', () => {
     await page.getByRole('button', { name: 'Run' }).click();
     await expect(page.locator('.bt-node').filter({ hasText: 'Navigate' })).toHaveClass(/status-running/);
     await expect(page.getByRole('button', { name: 'Pause' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Stop' })).toBeEnabled();
+    await expect(page.getByTestId('bt-stop')).toBeEnabled();
     await expect(page.getByTestId('bt-menu-button')).toBeDisabled();
     await expect(page.getByTestId('bt-palette-toggle')).toBeDisabled();
 
     await page.getByRole('button', { name: 'Pause' }).click();
     await expect(page.getByRole('button', { name: 'Resume' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Stop' })).toBeEnabled();
+    await expect(page.getByTestId('bt-stop')).toBeEnabled();
     await expect(page.getByTestId('bt-menu-button')).toBeDisabled();
 
     await page.getByRole('button', { name: 'Resume' }).click();

--- a/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.test.tsx
@@ -17,6 +17,8 @@ const reactFlowMock = vi.hoisted(() => ({
 const executorMock = vi.hoisted(() => ({
   instances: [] as Array<{
     start: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
     stop: ReturnType<typeof vi.fn>;
     callback: (event: Record<string, unknown>) => void;
   }>,
@@ -94,6 +96,8 @@ vi.mock('../engine/executor', () => ({
     function MockBehaviorTreeExecutor(
       this: {
         start: ReturnType<typeof vi.fn>;
+        pause: ReturnType<typeof vi.fn>;
+        resume: ReturnType<typeof vi.fn>;
         stop: ReturnType<typeof vi.fn>;
         callback: (event: Record<string, unknown>) => void;
       },
@@ -103,11 +107,15 @@ vi.mock('../engine/executor', () => ({
     ) {
       const instance = {
         start: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn(),
         stop: vi.fn(),
         callback,
       };
       executorMock.instances.push(instance);
       this.start = instance.start;
+      this.pause = instance.pause;
+      this.resume = instance.resume;
       this.stop = instance.stop;
       this.callback = instance.callback;
       return instance;
@@ -476,6 +484,38 @@ describe('BehaviorTreePanel', () => {
         expect.objectContaining({ zoom: 1, duration: 360 })
       );
     });
+    expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeEnabled();
+    expect(screen.getByTestId('bt-menu-button')).toBeDisabled();
+    expect(screen.getByTestId('bt-palette-toggle')).toBeDisabled();
+    expect(reactFlowMock.render.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        nodesDraggable: false,
+        nodesConnectable: false,
+        deleteKeyCode: null,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+    expect(executorMock.instances[0].pause).toHaveBeenCalledOnce();
+    act(() => {
+      executorMock.instances[0].callback({ type: 'paused', timestamp: Date.now() });
+    });
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume' }));
+    expect(executorMock.instances[0].resume).toHaveBeenCalledOnce();
+    act(() => {
+      executorMock.instances[0].callback({ type: 'resumed', timestamp: Date.now() });
+    });
+    expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    expect(executorMock.instances[0].stop).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeDisabled();
+    expect(screen.getByTestId('bt-menu-button')).toBeEnabled();
+
   });
 
   it('handles an edge click without crashing', () => {

--- a/src/features/behaviorTree/components/BehaviorTreePanel.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreePanel.tsx
@@ -99,10 +99,11 @@ interface BehaviorTreePanelProps {
 
 export interface BehaviorTreeExecutionSnapshot {
   isExecuting: boolean;
+  isPaused?: boolean;
   treeName: string;
   activeNodeId?: string;
   activeNodeLabel?: string;
-  status?: ExecutionStatus | 'completed' | 'stopped' | 'error';
+  status?: ExecutionStatus | 'paused' | 'completed' | 'stopped' | 'error';
   startedAt?: number;
 }
 
@@ -461,6 +462,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const [rootTree, setRootTree] = useState<BehaviorTree | null>(null);
   const [treePath, setTreePath] = useState<string[]>([]);
   const [isExecuting, setIsExecuting] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   const [isPaletteCollapsed, setIsPaletteCollapsed] = useState(true);
   const [selectedNodes, setSelectedNodes] = useState<Node[]>([]);
   const [selectedEdges, setSelectedEdges] = useState<Edge[]>([]);
@@ -852,9 +854,10 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
   const onConnect = useCallback(
     (connection: Connection) => {
+      if (isExecuting) return;
       persistEditorTree(nodes, addEdge(normalizeEdge(connection), edges));
     },
-    [edges, nodes, persistEditorTree]
+    [edges, isExecuting, nodes, persistEditorTree]
   );
 
   const getCurrentSelectionRect = useCallback((): DOMRect | null => {
@@ -1035,6 +1038,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         return;
       }
 
+      if (isExecuting) return;
       persistEditorTree(nextNodes, edges);
     },
     [
@@ -1043,6 +1047,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       getManualEdgeSelectionOverride,
       getBoxSelectionEdgeIds,
       getBoxSelectionNodeIds,
+      isExecuting,
       nodes,
       persistEditorTree,
       shouldIgnoreRecentBoxSelectionReduction,
@@ -1069,6 +1074,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         return;
       }
 
+      if (isExecuting) return;
       persistEditorTree(nodes, nextEdges);
     },
     [
@@ -1076,6 +1082,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       edges,
       getManualEdgeSelectionOverride,
       getBoxSelectionEdgeIds,
+      isExecuting,
       nodes,
       persistEditorTree,
       shouldIgnoreRecentBoxSelectionReduction,
@@ -1090,6 +1097,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   const onDrop = useCallback(
     (event: React.DragEvent) => {
       event.preventDefault();
+      if (isExecuting) return;
 
       const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
       if (!reactFlowBounds) return;
@@ -1113,7 +1121,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
       addNodeAtPosition(data.nodeType, position, data.item);
     },
-    [addNodeAtPosition, screenToFlowPosition]
+    [addNodeAtPosition, isExecuting, screenToFlowPosition]
   );
 
   const onNodesDelete = useCallback(
@@ -1302,18 +1310,20 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
   }, [nodes, openSubtreeNode, selectedNodes]);
 
   const openNodeEditor = useCallback((node: Node) => {
-    if (node.type === BehaviorNodeType.Action) {
+    if (isSubtreeNode(node as BehaviorTreeNode)) {
+      openSubtreeNode(node.id);
+    } else if (isExecuting) {
+      return;
+    } else if (node.type === BehaviorNodeType.Action) {
       setEditingAction({ nodeId: node.id, data: node.data as ROSActionNodeData });
     } else if (node.type === BehaviorNodeType.Service) {
       setEditingService({ nodeId: node.id, data: node.data as ROSServiceNodeData });
-    } else if (isSubtreeNode(node as BehaviorTreeNode)) {
-      openSubtreeNode(node.id);
     } else if (isIteratingControlNode(node)) {
       setEditingIterationNodeId(node.id);
     } else if (isOrderedControlNode(node as BehaviorTreeNode)) {
       setOrderingParentId(node.id);
     }
-  }, [openSubtreeNode]);
+  }, [isExecuting, openSubtreeNode]);
 
   const onNodeDoubleClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
@@ -1644,18 +1654,37 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       }
 
       if (event.type === 'started') {
+        setIsPaused(false);
         setExecutionSnapshot((prev) => ({
           ...prev,
           isExecuting: true,
           status: ExecutionStatus.Running,
           startedAt: executionStartedAt.current,
         }));
+      } else if (event.type === 'paused') {
+        setIsPaused(true);
+        setExecutionSnapshot((prev) => ({
+          ...prev,
+          isExecuting: true,
+          isPaused: true,
+          status: 'paused',
+        }));
+      } else if (event.type === 'resumed') {
+        setIsPaused(false);
+        setExecutionSnapshot((prev) => ({
+          ...prev,
+          isExecuting: true,
+          isPaused: false,
+          status: ExecutionStatus.Running,
+        }));
       } else if (event.type === 'completed' || event.type === 'stopped' || event.type === 'error') {
         const status = event.type;
         setIsExecuting(false);
+        setIsPaused(false);
         setExecutionSnapshot((prev) => ({
           ...prev,
           isExecuting: false,
+          isPaused: false,
           status,
         }));
         setTimeout(() => {
@@ -1709,8 +1738,10 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     executionStartedAt.current = Date.now();
     executorRef.current = new BehaviorTreeExecutor(treeToExecute, ros, handleExecutionEvent);
     setIsExecuting(true);
+    setIsPaused(false);
     setExecutionSnapshot({
       isExecuting: true,
+      isPaused: false,
       treeName: treeToExecute.name,
       activeNodeLabel: 'Starting',
       status: ExecutionStatus.Running,
@@ -1719,9 +1750,18 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     executorRef.current.start();
   }, [ros, isConnected, currentTree, nodes, edges, handleExecutionEvent]);
 
+  const handlePause = useCallback(() => {
+    executorRef.current?.pause();
+  }, []);
+
+  const handleResume = useCallback(() => {
+    executorRef.current?.resume();
+  }, []);
+
   const handleStop = useCallback(() => {
     if (executorRef.current) executorRef.current.stop();
     setIsExecuting(false);
+    setIsPaused(false);
     setRootTree((previousRootTree) => {
       if (!previousRootTree) return previousRootTree;
 
@@ -1750,6 +1790,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
     setExecutionSnapshot((prev) => ({
       ...prev,
       isExecuting: false,
+      isPaused: false,
       status: 'stopped',
     }));
   }, [resetTransientEdgeState, resetTransientNodeState]);
@@ -1814,7 +1855,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
       if (isEditableTarget) return;
 
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+      if (!isExecuting && (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
         event.preventDefault();
         if (event.shiftKey) {
           handleRedo();
@@ -1826,7 +1867,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleRedo, handleUndo]);
+  }, [handleRedo, handleUndo, isExecuting]);
 
   useEffect(() => {
     onExecutionControlsChange?.({ stop: handleStop });
@@ -1936,6 +1977,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       nodeType: BehaviorNodeType,
       item?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo | BehaviorTree
     ) => {
+      if (isExecuting) return;
       const bounds = reactFlowWrapper.current?.getBoundingClientRect();
       if (!bounds) return;
 
@@ -1951,7 +1993,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         setIsPaletteCollapsed(true);
       }
     },
-    [addNodeAtPosition, screenToFlowPosition]
+    [addNodeAtPosition, isExecuting, screenToFlowPosition]
   );
 
   const behaviorNodes = useMemo(() => nodes as BehaviorTreeNode[], [nodes]);
@@ -2525,6 +2567,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
       <BehaviorTreeToolbar
         currentTree={currentTree}
         isExecuting={isExecuting}
+        isPaused={isPaused}
+        isEditingLocked={isExecuting}
         isPaletteCollapsed={isPaletteCollapsed}
         nodeCount={nodes.length}
         canUndo={canUndo}
@@ -2535,6 +2579,8 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
         onLoad={handleLoad}
         onNew={handleNew}
         onExecute={handleExecute}
+        onPause={handlePause}
+        onResume={handleResume}
         onStop={handleStop}
         onExport={handleExport}
         onArrange={handleArrange}
@@ -2600,6 +2646,7 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
           ros={ros}
           isConnected={isConnected}
           isCollapsed={isPaletteCollapsed}
+          isDisabled={isExecuting}
           onToggleCollapse={() => setIsPaletteCollapsed((collapsed) => !collapsed)}
           onAddNode={handleAddNode}
         />
@@ -2634,13 +2681,15 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
             connectionMode={ConnectionMode.Loose}
             selectionMode={SelectionMode.Partial}
             multiSelectionKeyCode={['Control', 'Meta']}
+            nodesDraggable={!isExecuting}
+            nodesConnectable={!isExecuting}
             panOnDrag={canvasInteractionMode === 'pan'}
             selectionOnDrag={false}
             connectionRadius={48}
             fitView
             minZoom={0.1}
             maxZoom={2}
-            deleteKeyCode={['Backspace', 'Delete']}
+            deleteKeyCode={isExecuting ? null : ['Backspace', 'Delete']}
             defaultEdgeOptions={{
               animated: true,
               style: { stroke: 'var(--primary-color, #4285f4)', strokeWidth: 2 },
@@ -2689,7 +2738,9 @@ const BehaviorTreePanelInner: React.FC<BehaviorTreePanelProps> = ({
               <span>Parent</span>
             </button>
           )}
-          {selectionActionAnchor && (selectedNodes.length > 0 || selectedEdges.length > 0) && (
+          {!isExecuting &&
+            selectionActionAnchor &&
+            (selectedNodes.length > 0 || selectedEdges.length > 0) && (
             <div
               className={`bt-selection-actions placement-${selectionActionAnchor.placement}`}
               style={{

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.css
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.css
@@ -167,6 +167,7 @@
 .bt-float-actions > * { pointer-events: auto; }
 
 .bt-float-run-btn,
+.bt-float-pause-btn,
 .bt-float-stop-btn {
   display: flex;
   align-items: center;
@@ -192,6 +193,15 @@
 .bt-float-run-btn:hover  { filter: brightness(1.08); transform: translateY(-1px); }
 .bt-float-run-btn:active { transform: scale(0.96); }
 
+.bt-float-pause-btn {
+  background: #f59e0b;
+  color: #fff;
+  box-shadow: 0 3px 12px rgba(245, 158, 11, 0.35);
+}
+
+.bt-float-pause-btn:hover { filter: brightness(1.06); transform: translateY(-1px); }
+.bt-float-pause-btn:active { transform: scale(0.96); }
+
 .bt-float-stop-btn {
   background: var(--error-color, #f44336);
   color: #fff;
@@ -200,6 +210,16 @@
 
 .bt-float-stop-btn:hover  { filter: brightness(1.08); }
 .bt-float-stop-btn:active { transform: scale(0.96); }
+
+.bt-float-stop-btn:disabled,
+.bt-float-menu-btn:disabled,
+.bt-palette-toggle:disabled {
+  cursor: default;
+  opacity: 0.45;
+  filter: none;
+  transform: none;
+  box-shadow: none;
+}
 
 .bt-float-delete-btn,
 .bt-float-duplicate-btn,
@@ -704,6 +724,7 @@
   .bt-float-btn-label { display: none; }
 
   .bt-float-run-btn,
+  .bt-float-pause-btn,
   .bt-float-stop-btn {
     width: 36px;
     padding: 0;

--- a/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
+++ b/src/features/behaviorTree/components/BehaviorTreeToolbar.tsx
@@ -14,6 +14,8 @@ export type BehaviorTreeInteractionMode = 'pan' | 'select';
 interface BehaviorTreeToolbarProps {
   currentTree: BehaviorTree | null;
   isExecuting: boolean;
+  isPaused: boolean;
+  isEditingLocked: boolean;
   isPaletteCollapsed: boolean;
   nodeCount: number;
   canUndo: boolean;
@@ -24,6 +26,8 @@ interface BehaviorTreeToolbarProps {
   onLoad: (tree: BehaviorTree) => void;
   onNew: () => void;
   onExecute: () => void;
+  onPause: () => void;
+  onResume: () => void;
   onStop: () => void;
   onExport: () => void;
   onArrange: () => void;
@@ -38,6 +42,8 @@ interface BehaviorTreeToolbarProps {
 const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   currentTree,
   isExecuting,
+  isPaused,
+  isEditingLocked,
   isPaletteCollapsed,
   nodeCount,
   canUndo,
@@ -48,6 +54,8 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   onLoad,
   onNew,
   onExecute,
+  onPause,
+  onResume,
   onStop,
   onExport,
   onArrange,
@@ -68,6 +76,12 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
   useEffect(() => {
     setNameValue(currentTree?.name ?? '');
   }, [currentTree?.id, currentTree?.name]);
+
+  useEffect(() => {
+    if (!isEditingLocked) return;
+    setPendingDelete(null);
+    setMenuOpen(false);
+  }, [isEditingLocked]);
 
   useEffect(() => {
     const handleSavedTreesChanged = () => setSavedTrees(listBehaviorTrees());
@@ -158,6 +172,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
         <button
           className="bt-float-menu-btn"
           onClick={openMenu}
+          disabled={isEditingLocked}
           title="Menu: save, load, rename"
           aria-label="Open menu"
           data-testid="bt-menu-button"
@@ -174,6 +189,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
         <button
           className={`bt-float-icon-btn bt-palette-toggle${isPaletteCollapsed ? '' : ' active'}`}
           onClick={onTogglePalette}
+          disabled={isEditingLocked}
           title={isPaletteCollapsed ? 'Show node palette' : 'Hide node palette'}
           aria-label="Toggle node palette"
           data-testid="bt-palette-toggle"
@@ -184,7 +200,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
         <button
           className="bt-float-icon-btn bt-arrange-tree-btn"
           onClick={onArrange}
-          disabled={nodeCount === 0}
+          disabled={isEditingLocked || nodeCount === 0}
           title="Arrange tree"
           aria-label="Arrange tree"
           data-testid="bt-arrange-tree"
@@ -228,7 +244,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
         <button
           className="bt-float-icon-btn bt-undo-tree-btn"
           onClick={onUndo}
-          disabled={!canUndo}
+          disabled={isEditingLocked || !canUndo}
           title="Undo last behavior tree change"
           aria-label="Undo last behavior tree change"
           data-testid="bt-undo"
@@ -241,7 +257,7 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
         <button
           className="bt-float-icon-btn bt-redo-tree-btn"
           onClick={onRedo}
-          disabled={!canRedo}
+          disabled={isEditingLocked || !canRedo}
           title="Redo last behavior tree change"
           aria-label="Redo last behavior tree change"
           data-testid="bt-redo"
@@ -269,21 +285,40 @@ const BehaviorTreeToolbar: React.FC<BehaviorTreeToolbarProps> = ({
             <path d="M12 2.8v3M12 18.2v3M2.8 12h3M18.2 12h3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
           </svg>
         </button>
-        {isExecuting ? (
-          <button className="bt-float-stop-btn" onClick={onStop} title="Stop execution">
-            <svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor" aria-hidden="true">
-              <rect x="0" y="0" width="11" height="11" rx="2"/>
+        <button
+          className={isExecuting && !isPaused ? 'bt-float-pause-btn' : 'bt-float-run-btn'}
+          onClick={isExecuting ? (isPaused ? onResume : onPause) : onExecute}
+          title={isExecuting ? (isPaused ? 'Resume execution' : 'Pause execution') : 'Execute tree'}
+          aria-label={isExecuting ? (isPaused ? 'Resume' : 'Pause') : 'Run'}
+          data-testid="bt-run-pause"
+        >
+          {isExecuting && !isPaused ? (
+            <svg width="11" height="13" viewBox="0 0 11 13" fill="currentColor" aria-hidden="true">
+              <rect x="1" y="1" width="3" height="11" rx="1"/>
+              <rect x="7" y="1" width="3" height="11" rx="1"/>
             </svg>
-            <span className="bt-float-btn-label">Stop</span>
-          </button>
-        ) : (
-          <button className="bt-float-run-btn" onClick={onExecute} title="Execute tree">
+          ) : (
             <svg width="11" height="13" viewBox="0 0 11 13" fill="currentColor" aria-hidden="true">
               <path d="M1 1l9 5.5L1 12V1z"/>
             </svg>
-            <span className="bt-float-btn-label">Run</span>
-          </button>
-        )}
+          )}
+          <span className="bt-float-btn-label">
+            {isExecuting ? (isPaused ? 'Resume' : 'Pause') : 'Run'}
+          </span>
+        </button>
+        <button
+          className="bt-float-stop-btn"
+          onClick={onStop}
+          disabled={!isExecuting}
+          title="Stop execution"
+          aria-label="Stop"
+          data-testid="bt-stop"
+        >
+          <svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor" aria-hidden="true">
+            <rect x="0" y="0" width="11" height="11" rx="2"/>
+          </svg>
+          <span className="bt-float-btn-label">Stop</span>
+        </button>
       </div>
 
       {/* ── Slide-in menu panel ──────────────────────────────────── */}

--- a/src/features/behaviorTree/components/NodePalette.css
+++ b/src/features/behaviorTree/components/NodePalette.css
@@ -17,6 +17,12 @@
   transform-origin: top left;
 }
 
+.node-palette.disabled .palette-node {
+  cursor: default;
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 .palette-body {
   flex: 1;
   min-height: 0;

--- a/src/features/behaviorTree/components/NodePalette.tsx
+++ b/src/features/behaviorTree/components/NodePalette.tsx
@@ -139,6 +139,7 @@ interface NodePaletteProps {
   ros: Ros | null;
   isConnected: boolean;
   isCollapsed: boolean;
+  isDisabled?: boolean;
   onToggleCollapse: () => void;
   onAddNode?: (
     type: BehaviorNodeType,
@@ -162,6 +163,7 @@ const NodePalette: React.FC<NodePaletteProps> = ({
   ros,
   isConnected,
   isCollapsed,
+  isDisabled = false,
   onToggleCollapse,
   onAddNode,
 }) => {
@@ -371,6 +373,10 @@ const NodePalette: React.FC<NodePaletteProps> = ({
     nodeType: BehaviorNodeType,
     item?: ROSActionInfo | ROSServiceInfo | ROSTopicInfo | BehaviorTree
   ) => {
+    if (isDisabled) {
+      e.preventDefault();
+      return;
+    }
     e.dataTransfer.setData('application/reactflow', JSON.stringify({ nodeType, item }));
     e.dataTransfer.effectAllowed = 'move';
   };
@@ -387,9 +393,10 @@ const NodePalette: React.FC<NodePaletteProps> = ({
 
   return (
     <div
-      className={`node-palette${isMobile ? ' mobile-sheet' : ''}`}
+      className={`node-palette${isMobile ? ' mobile-sheet' : ''}${isDisabled ? ' disabled' : ''}`}
       ref={paletteRef}
       data-testid="bt-node-palette"
+      aria-disabled={isDisabled}
       style={isMobile && sheetHeight !== null ? { height: sheetHeight } : undefined}
     >
       {isMobile && (
@@ -467,9 +474,9 @@ const NodePalette: React.FC<NodePaletteProps> = ({
               <div
                 key={node.type}
                 className="palette-node"
-                draggable
+                draggable={!isDisabled}
                 onDragStart={(e) => handleDragStart(e, node.type)}
-                onClick={() => onAddNode?.(node.type, undefined)}
+                onClick={() => !isDisabled && onAddNode?.(node.type, undefined)}
               >
                 <span className="palette-node-icon">{CONTROL_ICONS[node.label]}</span>
                 <span className="palette-node-label">{node.label}</span>
@@ -496,9 +503,9 @@ const NodePalette: React.FC<NodePaletteProps> = ({
                 <div
                   key={tree.id}
                   className="palette-node palette-node-ros"
-                  draggable
+                  draggable={!isDisabled}
                   onDragStart={(e) => handleDragStart(e, BehaviorNodeType.Subtree, tree)}
-                  onClick={() => onAddNode?.(BehaviorNodeType.Subtree, tree)}
+                  onClick={() => !isDisabled && onAddNode?.(BehaviorNodeType.Subtree, tree)}
                   title={`Insert "${tree.name}" as a subtree`}
                 >
                   <span className="palette-node-icon">
@@ -544,9 +551,9 @@ const NodePalette: React.FC<NodePaletteProps> = ({
                   <div
                     key={`${action.name}-${index}`}
                     className="palette-node palette-node-ros"
-                    draggable
+                    draggable={!isDisabled}
                     onDragStart={(e) => handleDragStart(e, BehaviorNodeType.Action, action)}
-                    onClick={() => onAddNode?.(BehaviorNodeType.Action, action)}
+                    onClick={() => !isDisabled && onAddNode?.(BehaviorNodeType.Action, action)}
                     title={`${action.name} (${action.type})`}
                   >
                     <span className="palette-node-icon">
@@ -591,9 +598,9 @@ const NodePalette: React.FC<NodePaletteProps> = ({
                 <div
                   key={`${service.name}-${index}`}
                   className="palette-node palette-node-ros"
-                  draggable
+                  draggable={!isDisabled}
                   onDragStart={(e) => handleDragStart(e, BehaviorNodeType.Service, service)}
-                  onClick={() => onAddNode?.(BehaviorNodeType.Service, service)}
+                  onClick={() => !isDisabled && onAddNode?.(BehaviorNodeType.Service, service)}
                   title={`${service.name} (${service.type})`}
                 >
                   <span className="palette-node-icon">
@@ -638,9 +645,9 @@ const NodePalette: React.FC<NodePaletteProps> = ({
                 <div
                   key={`${topic.name}-${index}`}
                   className="palette-node palette-node-ros"
-                  draggable
+                  draggable={!isDisabled}
                   onDragStart={(e) => handleDragStart(e, BehaviorNodeType.Topic, topic)}
-                  onClick={() => onAddNode?.(BehaviorNodeType.Topic, topic)}
+                  onClick={() => !isDisabled && onAddNode?.(BehaviorNodeType.Topic, topic)}
                   title={`${topic.name} (${topic.type})`}
                 >
                   <span className="palette-node-icon">

--- a/src/features/behaviorTree/engine/executor.test.ts
+++ b/src/features/behaviorTree/engine/executor.test.ts
@@ -86,6 +86,27 @@ const treeWithControl = (root: BehaviorTreeNode, child: BehaviorTreeNode): Behav
   updatedAt: 1,
 });
 
+const sequenceTree = (): BehaviorTree => ({
+  id: 'sequence-tree',
+  name: 'Sequence Tree',
+  nodes: [
+    {
+      id: 'sequence',
+      type: BehaviorNodeType.Sequence,
+      position: { x: 0, y: 0 },
+      data: { label: 'Sequence', type: 'sequence' },
+    },
+    topicNode('topic-one'),
+    topicNode('topic-two'),
+  ],
+  edges: [
+    { id: 'edge-one', source: 'sequence', target: 'topic-one' },
+    { id: 'edge-two', source: 'sequence', target: 'topic-two' },
+  ],
+  createdAt: 1,
+  updatedAt: 1,
+});
+
 const executeTree = async (tree: BehaviorTree) => {
   const events: ExecutionEvent[] = [];
   const executor = new BehaviorTreeExecutor(tree, {} as Ros, (event) => {
@@ -195,5 +216,50 @@ describe('BehaviorTreeExecutor retry and repeat nodes', () => {
       type: 'completed',
       data: { result: ExecutionStatus.Failure },
     });
+  });
+});
+
+describe('BehaviorTreeExecutor pause and resume', () => {
+  beforeEach(() => {
+    roslibMocks.topicPublish.mockReset();
+    roslibMocks.topicUnadvertise.mockReset();
+  });
+
+  it('does not advance to the next node until resumed', async () => {
+    const events: ExecutionEvent[] = [];
+    let executor!: BehaviorTreeExecutor;
+    executor = new BehaviorTreeExecutor(sequenceTree(), {} as Ros, (event) => {
+      events.push(event);
+      if (event.type === 'nodeSuccess' && event.nodeId === 'topic-one') executor.pause();
+    });
+
+    const execution = executor.start();
+    await vi.waitFor(() => expect(roslibMocks.topicPublish).toHaveBeenCalledTimes(1));
+    expect(events.some((event) => event.type === 'paused')).toBe(true);
+
+    executor.resume();
+    await execution;
+
+    expect(roslibMocks.topicPublish).toHaveBeenCalledTimes(2);
+    expect(events.some((event) => event.type === 'resumed')).toBe(true);
+    expect(events[events.length - 1]).toMatchObject({ type: 'completed' });
+  });
+
+  it('stops cleanly while paused without advancing', async () => {
+    const events: ExecutionEvent[] = [];
+    let executor!: BehaviorTreeExecutor;
+    executor = new BehaviorTreeExecutor(sequenceTree(), {} as Ros, (event) => {
+      events.push(event);
+      if (event.type === 'nodeSuccess' && event.nodeId === 'topic-one') executor.pause();
+    });
+
+    const execution = executor.start();
+    await vi.waitFor(() => expect(events.some((event) => event.type === 'paused')).toBe(true));
+    executor.stop();
+    await execution;
+
+    expect(roslibMocks.topicPublish).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === 'stopped')).toBe(true);
+    expect(events.some((event) => event.type === 'completed')).toBe(false);
   });
 });

--- a/src/features/behaviorTree/engine/executor.ts
+++ b/src/features/behaviorTree/engine/executor.ts
@@ -236,10 +236,13 @@ export class BehaviorTreeExecutor {
   private tree: BehaviorTree;
   private nodeStatuses: Map<string, ExecutionStatus>;
   private isRunning: boolean;
+  private isPaused: boolean;
   private callback: ExecutionCallback;
   private abortController: AbortController | null;
   private activeActions: Map<string, ActiveAction>;
   private readonly rootPath: string[];
+  private pausePromise: Promise<void> | null;
+  private resolvePause: (() => void) | null;
 
   constructor(tree: BehaviorTree, ros: Ros, callback: ExecutionCallback) {
     this.tree = tree;
@@ -247,9 +250,12 @@ export class BehaviorTreeExecutor {
     this.callback = callback;
     this.nodeStatuses = new Map();
     this.isRunning = false;
+    this.isPaused = false;
     this.abortController = null;
     this.activeActions = new Map();
     this.rootPath = [];
+    this.pausePromise = null;
+    this.resolvePause = null;
 
     // Initialize all nodes to idle status
     tree.nodes.forEach(node => {
@@ -267,6 +273,7 @@ export class BehaviorTreeExecutor {
     }
 
     this.isRunning = true;
+    this.isPaused = false;
     this.abortController = new AbortController();
 
     this.emitEvent({
@@ -284,11 +291,13 @@ export class BehaviorTreeExecutor {
       // Execute from root
       const result = await this.executeNode(rootNode, this.tree, this.rootPath);
 
-      this.emitEvent({
-        type: 'completed',
-        timestamp: Date.now(),
-        data: { result },
-      });
+      if (this.isRunning) {
+        this.emitEvent({
+          type: 'completed',
+          timestamp: Date.now(),
+          data: { result },
+        });
+      }
     } catch (error) {
       this.emitEvent({
         type: 'error',
@@ -297,6 +306,8 @@ export class BehaviorTreeExecutor {
       });
     } finally {
       this.isRunning = false;
+      this.isPaused = false;
+      this.releasePauseWaiters();
       this.abortController = null;
     }
   }
@@ -318,11 +329,43 @@ export class BehaviorTreeExecutor {
     }
 
     this.isRunning = false;
+    this.isPaused = false;
+    this.releasePauseWaiters();
 
     this.emitEvent({
       type: 'stopped',
       timestamp: Date.now(),
     });
+  }
+
+  public pause(): void {
+    if (!this.isRunning || this.isPaused) return;
+
+    this.isPaused = true;
+    this.pausePromise = new Promise<void>((resolve) => {
+      this.resolvePause = resolve;
+    });
+    this.emitEvent({ type: 'paused', timestamp: Date.now() });
+  }
+
+  public resume(): void {
+    if (!this.isRunning || !this.isPaused) return;
+
+    this.isPaused = false;
+    this.releasePauseWaiters();
+    this.emitEvent({ type: 'resumed', timestamp: Date.now() });
+  }
+
+  private releasePauseWaiters(): void {
+    this.resolvePause?.();
+    this.resolvePause = null;
+    this.pausePromise = null;
+  }
+
+  private async waitWhilePaused(): Promise<void> {
+    if (this.isPaused && this.pausePromise) {
+      await this.pausePromise;
+    }
   }
 
   /**
@@ -395,6 +438,7 @@ export class BehaviorTreeExecutor {
     tree: BehaviorTree = this.tree,
     treePath: string[] = this.rootPath
   ): Promise<ExecutionStatus> {
+    await this.waitWhilePaused();
     if (!this.isRunning) {
       return ExecutionStatus.Failure;
     }
@@ -437,6 +481,8 @@ export class BehaviorTreeExecutor {
           result = ExecutionStatus.Failure;
       }
 
+      await this.waitWhilePaused();
+      if (!this.isRunning) return ExecutionStatus.Failure;
       this.setNodeStatus(node.id, result, treePath);
       return result;
     } catch (error) {
@@ -668,7 +714,11 @@ export class BehaviorTreeExecutor {
               ? normalizeActionGoalPayload(rawGoal, details.fields, details.defaults)
               : rawGoal;
 
-          if (settled || !this.isRunning) return;
+          await this.waitWhilePaused();
+          if (settled || !this.isRunning) {
+            settle(ExecutionStatus.Failure);
+            return;
+          }
 
           console.log(`[BT] send_action_goal payload for "${data.actionName}":`, JSON.stringify(goal));
 

--- a/src/features/behaviorTree/types.ts
+++ b/src/features/behaviorTree/types.ts
@@ -132,6 +132,8 @@ export interface ExecutionContext {
 // Event types for execution engine
 export type ExecutionEventType = 
   | 'started'
+  | 'paused'
+  | 'resumed'
   | 'nodeEntered'
   | 'nodeSuccess'
   | 'nodeFailure'


### PR DESCRIPTION
This PR adds pause and resume support for behavior tree execution, including UI controls and executor state handling.
It locks behavior tree editing while execution is active, disabling node dragging, connecting, deletion, palette actions, menu actions, undo, redo, and arrangement.
It also updates tests to verify pause, resume, stop behavior, and locked editing states across unit and end to end coverage. 
