### PR TITLE
Franceschiniric/tes 18 resiable node window in bigger screens than mobile

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+ignore:
+  - "coverage/**"
+  - "e2e/**"
+  - "src/**/*.test.ts"
+  - "src/**/*.test.tsx"
+  - "src/**/*.spec.ts"
+  - "src/**/*.spec.tsx"

--- a/src/components/AddPanelMenu.test.tsx
+++ b/src/components/AddPanelMenu.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AddPanelMenu from './AddPanelMenu';
+
+const deleteCustomGamepad = vi.fn();
+const downloadGamepadLayout = vi.fn();
+const importGamepadFile = vi.fn();
+const loadGamepadLibrary = vi.fn();
+
+vi.mock('../features/customGamepad/gamepadStorage', () => ({
+  deleteCustomGamepad: (...args: unknown[]) => deleteCustomGamepad(...args),
+  downloadGamepadLayout: (...args: unknown[]) => downloadGamepadLayout(...args),
+  importGamepadFile: (...args: unknown[]) => importGamepadFile(...args),
+  loadGamepadLibrary: (...args: unknown[]) => loadGamepadLibrary(...args),
+}));
+
+const library = [
+  {
+    id: 'template-drive',
+    name: 'Drive Template',
+    description: 'Template description',
+    layout: { id: 'template-layout' },
+    isDefault: true,
+  },
+  {
+    id: 'custom-arm',
+    name: 'Arm Console',
+    description: 'Custom description',
+    layout: { id: 'custom-layout' },
+    isDefault: false,
+  },
+];
+
+const createButtonRef = () => {
+  const button = document.createElement('button');
+  button.getBoundingClientRect = vi.fn(() => ({
+    top: 100,
+    left: 240,
+    right: 300,
+    bottom: 132,
+    width: 60,
+    height: 32,
+    x: 240,
+    y: 100,
+    toJSON: () => {},
+  }));
+  document.body.appendChild(button);
+  return { current: button } as React.RefObject<HTMLButtonElement>;
+};
+
+describe('AddPanelMenu', () => {
+  const onSelectLayout = vi.fn();
+  const onClose = vi.fn();
+  const onOpenCustomEditor = vi.fn();
+  const onOpenTemplate = vi.fn();
+  const onCustomGamepadDeleted = vi.fn();
+  const onGamepadLibraryChanged = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadGamepadLibrary.mockReturnValue(library);
+    downloadGamepadLayout.mockReturnValue(true);
+    importGamepadFile.mockResolvedValue({ success: true, imported: 1, errors: [] });
+    Object.defineProperty(window, 'innerWidth', { value: 1024, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 768, configurable: true });
+  });
+
+  const renderMenu = (isOpen = true) =>
+    render(
+      <AddPanelMenu
+        isOpen={isOpen}
+        onSelectLayout={onSelectLayout}
+        onClose={onClose}
+        onOpenCustomEditor={onOpenCustomEditor}
+        onOpenTemplate={onOpenTemplate}
+        addButtonRef={createButtonRef()}
+        onCustomGamepadDeleted={onCustomGamepadDeleted}
+        onGamepadLibraryChanged={onGamepadLibraryChanged}
+      />
+    );
+
+  it('renders nothing when closed', () => {
+    renderMenu(false);
+
+    expect(screen.queryByText('Templates')).not.toBeInTheDocument();
+  });
+
+  it('renders templates and custom layouts from storage', () => {
+    renderMenu();
+
+    expect(loadGamepadLibrary).toHaveBeenCalled();
+    expect(screen.getByText('Templates')).toBeInTheDocument();
+    expect(screen.getByText('Drive Template')).toBeInTheDocument();
+    expect(screen.getByText('Custom Layouts')).toBeInTheDocument();
+    expect(screen.getByText('Arm Console')).toBeInTheDocument();
+  });
+
+  it('routes template, custom, edit, and delete actions', () => {
+    renderMenu();
+
+    fireEvent.click(screen.getByText('Drive Template'));
+    expect(onOpenTemplate).toHaveBeenCalledWith('template-drive');
+
+    fireEvent.click(screen.getByText('Arm Console'));
+    expect(onSelectLayout).toHaveBeenCalledWith('custom-arm');
+
+    fireEvent.click(screen.getByLabelText('Edit'));
+    expect(onOpenCustomEditor).toHaveBeenCalledWith('custom-arm');
+
+    fireEvent.click(screen.getByLabelText('Delete'));
+    expect(deleteCustomGamepad).toHaveBeenCalledWith('custom-arm');
+    expect(onCustomGamepadDeleted).toHaveBeenCalledWith('custom-arm');
+  });
+
+  it('exports custom layouts and reports success', () => {
+    renderMenu();
+
+    fireEvent.click(screen.getByLabelText('Export Arm Console'));
+
+    expect(downloadGamepadLayout).toHaveBeenCalledWith('custom-arm');
+    expect(screen.getByRole('status')).toHaveTextContent('Gamepad exported');
+  });
+
+  it('imports a gamepad file and refreshes the library', async () => {
+    renderMenu();
+
+    fireEvent.click(screen.getByText('Import Gamepad'));
+    fireEvent.change(document.querySelector('input[type="file"]')!, {
+      target: {
+        files: [new File(['{}'], 'pad.json', { type: 'application/json' })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(importGamepadFile).toHaveBeenCalledWith(expect.any(File));
+      expect(onGamepadLibraryChanged).toHaveBeenCalled();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Imported 1 gamepad');
+  });
+
+  it('closes on outside clicks but ignores clicks on the add button', () => {
+    const addButtonRef = createButtonRef();
+    render(
+      <AddPanelMenu
+        isOpen
+        onSelectLayout={onSelectLayout}
+        onClose={onClose}
+        onOpenCustomEditor={onOpenCustomEditor}
+        onOpenTemplate={onOpenTemplate}
+        addButtonRef={addButtonRef}
+      />
+    );
+
+    fireEvent.mouseDown(addButtonRef.current!);
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/AddVisualizationModal.test.tsx
+++ b/src/components/AddVisualizationModal.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AddVisualizationModal from './AddVisualizationModal';
+
+const topics = [
+  { name: '/points', type: 'sensor_msgs/msg/PointCloud2' },
+  { name: '/pose', type: 'geometry_msgs/msg/PoseStamped' },
+  { name: '/robot_description', type: 'std_msgs/String' },
+];
+
+describe('AddVisualizationModal', () => {
+  const onClose = vi.fn();
+  const onAddVisualization = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('returns null when closed', () => {
+    const { container } = render(
+      <AddVisualizationModal isOpen={false} onClose={onClose} onAddVisualization={onAddVisualization} allTopics={topics} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('quick-adds visualizations from compatible topics', () => {
+    render(<AddVisualizationModal isOpen onClose={onClose} onAddVisualization={onAddVisualization} allTopics={topics} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /pointcloud/i }));
+
+    expect(onAddVisualization).toHaveBeenCalledWith({ type: 'pointcloud', topic: '/points', options: {} });
+  });
+
+  it('supports advanced manual topic entry', () => {
+    render(<AddVisualizationModal isOpen onClose={onClose} onAddVisualization={onAddVisualization} allTopics={topics} />);
+
+    fireEvent.click(screen.getByText('Advanced (customize options)'));
+    fireEvent.change(screen.getByLabelText('Visualization Type:'), { target: { value: 'posestamped' } });
+    fireEvent.click(screen.getByText('Enter topic manually'));
+    fireEvent.change(screen.getByPlaceholderText(/enter posestamped topic/i), { target: { value: '/manual_pose' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Visualization' }));
+
+    expect(onAddVisualization).toHaveBeenCalledWith({ type: 'posestamped', topic: '/manual_pose', options: {} });
+  });
+
+  it('closes from the backdrop and close button without closing inner clicks', () => {
+    const { container } = render(
+      <AddVisualizationModal isOpen onClose={onClose} onAddVisualization={onAddVisualization} allTopics={topics} />
+    );
+
+    fireEvent.click(screen.getByRole('heading', { name: 'Add Visualization' }));
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(container.querySelector('.modal-overlay')!);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/CameraView.tsx
+++ b/src/components/CameraView.tsx
@@ -15,6 +15,7 @@ interface CameraViewProps {
   // Add new props for topic selection
   availableTopics: string[];
   onTopicChange: (newTopic: string) => void;
+  selectId?: string;
 }
 
 const CameraView: React.FC<CameraViewProps> = ({
@@ -27,6 +28,7 @@ const CameraView: React.FC<CameraViewProps> = ({
   // Destructure new props
   availableTopics,
   onTopicChange,
+  selectId = 'camera-topic-select',
 }) => {
   const [streamUrl, setStreamUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -83,7 +85,7 @@ const CameraView: React.FC<CameraViewProps> = ({
           <div className="camera-topic-selector overlay">
             {/* <label htmlFor="camera-topic-select">Topic:</label> */}
             <select
-              id="camera-topic-select"
+              id={selectId}
               value={cameraTopic} // Use current cameraTopic prop
               onChange={(e) => onTopicChange(e.target.value)} // Use handler prop
             >

--- a/src/components/ControlPanelTabs.tsx
+++ b/src/components/ControlPanelTabs.tsx
@@ -14,7 +14,8 @@ interface ControlPanelTabsProps {
   onSelectPanel: (id: string) => void;
   onAddPanelToggle: () => void; // Simple toggle handler
   onRemovePanel: (id: string) => void;
-  addButtonRef: RefObject<HTMLButtonElement>; // Need the ref prop
+  addButtonRef?: RefObject<HTMLButtonElement>; // Need the ref prop
+  showAddButton?: boolean;
 }
 
 const ControlPanelTabs: React.FC<ControlPanelTabsProps> = ({
@@ -24,6 +25,7 @@ const ControlPanelTabs: React.FC<ControlPanelTabsProps> = ({
   onAddPanelToggle, // Simple toggle
   onRemovePanel,
   addButtonRef, // Use the ref
+  showAddButton = true,
 }) => {
 
   const handleRemoveClick = (e: React.MouseEvent<HTMLButtonElement>, id: string) => {
@@ -55,15 +57,17 @@ const ControlPanelTabs: React.FC<ControlPanelTabsProps> = ({
             </button>
           </div>
         ))}
-        <button 
-          ref={addButtonRef} // Attach the ref
-          className="tab-add-button" 
-          onClick={onAddPanelToggle} // Call the toggle
-          aria-label="Add Panel"
-          title="Add Panel"
-        >
-          <IconAdd />
-        </button>
+        {showAddButton && (
+          <button
+            ref={addButtonRef} // Attach the ref
+            className="tab-add-button"
+            onClick={onAddPanelToggle} // Call the toggle
+            aria-label="Add Panel"
+            title="Add Panel"
+          >
+            <IconAdd />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/MainControlView.css
+++ b/src/components/MainControlView.css
@@ -380,6 +380,11 @@
     color: #fff;
 }
 
+.workspace-tile-button.active {
+    background: var(--primary-color, #4285f4);
+    color: #fff;
+}
+
 .workspace-add-button,
 .workspace-tile-button,
 .workspace-split-button {
@@ -759,6 +764,61 @@ body.no-scroll {
     flex: 1 1 0;
 }
 
+.workspace-empty-drop-zone {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    border: 1px dashed color-mix(in srgb, var(--primary-color) 44%, var(--border-color));
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--background-secondary) 54%, transparent);
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.desktop-workspace.is-drop-active .workspace-empty-drop-zone {
+    border-color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 10%, var(--background-secondary));
+}
+
+.workspace-empty-drop-line {
+    width: 36px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--primary-color);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--primary-color) 14%, transparent);
+}
+
+.workspace-drop-indicator {
+    flex: 0 0 8px;
+    align-self: stretch;
+    min-height: 40px;
+    border-radius: 999px;
+    background: var(--primary-color);
+    box-shadow:
+        0 0 0 4px color-mix(in srgb, var(--primary-color) 18%, transparent),
+        0 0 18px color-mix(in srgb, var(--primary-color) 36%, transparent);
+    animation: workspace-drop-indicator-pop 150ms ease-out;
+}
+
+.workspace-drop-indicator-end {
+    margin-left: 0;
+}
+
+@keyframes workspace-drop-indicator-pop {
+    from {
+        transform: scaleX(0.58);
+        opacity: 0.42;
+    }
+    to {
+        transform: scaleX(1);
+        opacity: 1;
+    }
+}
+
 .workspace-card {
     position: relative;
     flex: 1 1 0;
@@ -930,26 +990,66 @@ body.no-scroll {
     flex: 0 0 auto;
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px;
+    gap: 6px;
+    min-height: 34px;
+    padding: 4px 6px;
     border-bottom: 1px solid var(--border-color);
     background: var(--background-secondary);
 }
 
 .workspace-pad-selector label {
     color: var(--text-secondary);
-    font-size: 0.78rem;
+    font-size: 0.72rem;
     font-weight: 700;
+    line-height: 1;
 }
 
 .workspace-pad-selector select {
     min-width: 0;
     flex: 1 1 auto;
-    height: 30px;
+    height: 26px;
+    padding: 0 6px;
     border: 1px solid var(--border-color);
     border-radius: 6px;
     background: var(--background-color);
     color: var(--text-color);
+    font-size: 0.78rem;
+}
+
+.workspace-pad-selector-empty {
+    min-width: 0;
+    flex: 1 1 auto;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.workspace-pad-create-button {
+    width: 26px;
+    height: 26px;
+    min-width: 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--background-color);
+    color: var(--text-color);
+    cursor: pointer;
+}
+
+.workspace-pad-create-button:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+.workspace-pad-create-button svg {
+    width: 14px;
+    height: 14px;
 }
 
 .workspace-pad-body {

--- a/src/components/MainControlView.css
+++ b/src/components/MainControlView.css
@@ -747,6 +747,77 @@ body.no-scroll {
     outline-offset: -5px;
 }
 
+.workspace-snap-assistant {
+    position: absolute;
+    top: 14px;
+    left: 50%;
+    z-index: 25;
+    max-width: calc(100% - 36px);
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    padding: 8px;
+    border: 1px solid color-mix(in srgb, var(--border-color) 78%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--card-bg) 88%, transparent);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(14px);
+    transform: translateX(-50%);
+}
+
+.workspace-snap-template {
+    width: 88px;
+    min-width: 88px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.workspace-snap-template-title {
+    min-width: 0;
+    color: var(--text-secondary);
+    font-size: 0.68rem;
+    font-weight: 700;
+    line-height: 1;
+    overflow: hidden;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.workspace-snap-template-grid {
+    height: 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.workspace-snap-template-row {
+    min-height: 0;
+    display: flex;
+    gap: 3px;
+}
+
+.workspace-snap-zone {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    padding: 0;
+    border: 1px solid color-mix(in srgb, var(--primary-color) 32%, var(--border-color));
+    border-radius: 5px;
+    background: color-mix(in srgb, var(--primary-color) 8%, var(--background-secondary));
+    cursor: copy;
+    transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
+}
+
+.workspace-snap-zone:hover,
+.workspace-snap-zone.active {
+    border-color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 42%, var(--background-secondary));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-color) 50%, transparent);
+    transform: scale(1.04);
+}
+
 .workspace-grid {
     width: 100%;
     height: 100%;

--- a/src/components/MainControlView.css
+++ b/src/components/MainControlView.css
@@ -1270,43 +1270,59 @@ body.no-scroll {
 
 .workspace-pad-selector {
     flex: 0 0 auto;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    min-height: 42px;
-    padding: 6px 8px;
-    border-bottom: 1px solid var(--border-color);
-    background: var(--background-secondary);
-}
-
-.workspace-pad-select-field {
-    min-width: 0;
-    flex: 1 1 auto;
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr) 34px;
     align-items: center;
-    gap: 8px;
+    column-gap: 10px;
+    min-height: 48px;
+    padding: 7px 10px;
+    border-bottom: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--background-secondary) 84%, transparent);
 }
 
-.workspace-pad-select-field label {
+.workspace-pad-selector label {
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    transform: translateY(2px);
     color: var(--text-secondary);
-    font-size: 0.72rem;
-    font-weight: 700;
-    line-height: 1;
+    font-size: 0.68rem;
+    font-weight: 800;
+    line-height: 34px;
+    text-transform: uppercase;
     white-space: nowrap;
 }
 
-.workspace-pad-select-field select {
+.workspace-pad-selector select {
+    appearance: none;
     min-width: 0;
     width: 100%;
-    height: 30px;
-    padding: 0 28px 0 8px;
+    height: 34px;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0 30px 0 10px;
     border: 1px solid var(--border-color);
     border-radius: 6px;
-    background: var(--background-color);
+    background:
+        linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%) calc(100% - 17px) 14px / 5px 5px no-repeat,
+        linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%) calc(100% - 12px) 14px / 5px 5px no-repeat,
+        var(--background-color);
     color: var(--text-color);
     font-size: 0.78rem;
     font-weight: 700;
+    line-height: normal;
+    cursor: pointer;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
+
+.workspace-pad-selector select:hover {
+    border-color: color-mix(in srgb, var(--primary-color) 58%, var(--border-color));
+}
+
+.workspace-pad-selector select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color) 18%, transparent);
 }
 
 .workspace-pad-selector-empty {
@@ -1321,9 +1337,11 @@ body.no-scroll {
 }
 
 .workspace-pad-create-button {
-    width: 30px;
-    height: 30px;
-    min-width: 30px;
+    width: 34px;
+    height: 34px;
+    min-width: 34px;
+    flex: 0 0 34px;
+    box-sizing: border-box;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1331,9 +1349,9 @@ body.no-scroll {
     border: 1px solid var(--border-color);
     border-radius: 6px;
     background: var(--background-color);
-    color: var(--text-color);
+    color: var(--text-secondary);
     cursor: pointer;
-    transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+    transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
 
 .workspace-pad-create-button:hover {
@@ -1342,9 +1360,16 @@ body.no-scroll {
     color: var(--primary-color);
 }
 
+.workspace-pad-create-button:focus-visible {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color) 18%, transparent);
+}
+
 .workspace-pad-create-button svg {
-    width: 14px;
-    height: 14px;
+    display: block;
+    width: 15px;
+    height: 15px;
 }
 
 .workspace-pad-body {

--- a/src/components/MainControlView.css
+++ b/src/components/MainControlView.css
@@ -834,6 +834,10 @@ body.no-scroll {
     transition: flex 0.22s ease, box-shadow 0.18s ease, transform 0.18s ease;
 }
 
+.desktop-workspace.is-resizing .workspace-card {
+    transition: none;
+}
+
 .workspace-card.is-settling {
     animation: workspace-card-settle 360ms cubic-bezier(0.2, 1.42, 0.36, 1);
 }

--- a/src/components/MainControlView.css
+++ b/src/components/MainControlView.css
@@ -163,6 +163,20 @@
     position: relative;
 }
 
+.standard-stack-layout {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.standard-stack-layout-embedded {
+    height: 100%;
+}
+
 .pad-empty-state {
     width: 100%;
     height: 100%;
@@ -320,6 +334,119 @@
     background: rgba(255, 255, 255, 0.12);
     border-radius: 9px;
     padding: 3px;
+}
+
+.layout-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    flex: 0 0 auto;
+}
+
+.workspace-add-control {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.workspace-add-button,
+.workspace-tile-button,
+.workspace-split-button {
+    background: transparent;
+    border: 0;
+    color: rgba(255, 255, 255, 0.62);
+    padding: 4px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.workspace-add-button svg,
+.workspace-tile-button svg,
+.workspace-split-button svg {
+    width: 18px;
+    height: 18px;
+}
+
+.workspace-add-button:hover:not(:disabled),
+.workspace-tile-button:hover,
+.workspace-split-button:hover {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+}
+
+.workspace-add-button,
+.workspace-tile-button,
+.workspace-split-button {
+    height: 32px;
+    min-width: 32px;
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.workspace-add-button:disabled {
+    opacity: 0.42;
+    cursor: not-allowed;
+}
+
+.workspace-add-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    width: min(320px, calc(100vw - 24px));
+    max-height: min(520px, calc(100vh - 64px));
+    overflow: auto;
+    z-index: 1200;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--card-bg);
+    color: var(--text-color);
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.32);
+}
+
+.workspace-add-menu-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.workspace-add-menu-section + .workspace-add-menu-section {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border-color);
+}
+
+.workspace-add-menu-title {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.workspace-add-menu button {
+    width: 100%;
+    min-height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--background-secondary);
+    color: var(--text-color);
+    text-align: left;
+}
+
+.workspace-add-menu button svg {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 16px;
 }
 
 .top-bar .connection-status-icon {
@@ -589,6 +716,314 @@ body.no-scroll {
     height: 100%;
 }
 
+/* Desktop Workspace Layout */
+.main-content-area.workspace-mode {
+    display: block;
+}
+
+.desktop-workspace {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    box-sizing: border-box;
+    position: relative;
+    display: flex;
+    padding: 8px;
+    background-image:
+        linear-gradient(var(--background-secondary-transparent) 1px, transparent 1px),
+        linear-gradient(90deg, var(--background-secondary-transparent) 1px, transparent 1px);
+    background-size: 24px 24px;
+    background-position: -1px -1px;
+}
+
+.desktop-workspace.is-drop-active {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 72%, transparent);
+    outline-offset: -5px;
+}
+
+.workspace-grid {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.workspace-tile-row {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex: 1 1 0;
+}
+
+.workspace-card {
+    position: relative;
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid var(--card-border);
+    border-radius: 8px;
+    background: var(--card-bg);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+    transition: flex 0.22s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.workspace-card.is-settling {
+    animation: workspace-card-settle 360ms cubic-bezier(0.2, 1.42, 0.36, 1);
+}
+
+.workspace-card-view,
+.workspace-card-pads {
+    background: transparent;
+}
+
+.workspace-card-content-view {
+    position: relative;
+    padding: 0;
+}
+
+.workspace-card-content-view .view-panel {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+@keyframes workspace-card-settle {
+    0% {
+        transform: scale(0.96);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color) 64%, transparent);
+    }
+    72% {
+        transform: scale(1.012);
+    }
+    100% {
+        transform: scale(1);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+    }
+}
+
+.workspace-card-header {
+    min-height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 6px 8px 6px 10px;
+    border-bottom: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--background-secondary) 78%, transparent);
+    flex: 0 0 auto;
+    user-select: none;
+}
+
+.workspace-card-header[draggable="true"] {
+    cursor: grab;
+}
+
+.workspace-card-header[draggable="true"]:active {
+    cursor: grabbing;
+}
+
+.workspace-card-title {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-color);
+    font-size: 0.88rem;
+    font-weight: 700;
+}
+
+.workspace-card-title span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.workspace-card-dot {
+    width: 8px;
+    height: 8px;
+    flex: 0 0 8px;
+    border-radius: 999px;
+    background: var(--primary-color);
+}
+
+.workspace-card-dot-camera {
+    background: #37a2ff;
+}
+
+.workspace-card-dot-3d {
+    background: var(--primary-color);
+}
+
+.workspace-card-dot-pad {
+    background: #f59f00;
+}
+
+.workspace-card-dot-behaviorTree {
+    background: #a78bfa;
+}
+
+.workspace-card-dot-view {
+    background: #22c55e;
+}
+
+.workspace-card-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: 0 0 auto;
+}
+
+.workspace-card-actions button {
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-secondary);
+}
+
+.workspace-card-actions button:hover {
+    background: var(--background-dark-transparent);
+    color: var(--text-color);
+}
+
+.workspace-card-actions button svg {
+    width: 16px;
+    height: 16px;
+}
+
+.workspace-card-content {
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+    display: flex;
+    overflow: hidden;
+    padding: 0;
+}
+
+.workspace-card-content > .control-panel-container {
+    flex: 1 1 auto;
+    height: 100%;
+}
+
+.workspace-pad-component {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.workspace-pad-selector {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--background-secondary);
+}
+
+.workspace-pad-selector label {
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.workspace-pad-selector select {
+    min-width: 0;
+    flex: 1 1 auto;
+    height: 30px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--background-color);
+    color: var(--text-color);
+}
+
+.workspace-pad-body {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+}
+
+.workspace-row-resize-handle,
+.workspace-column-resize-handle {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    touch-action: none;
+}
+
+.workspace-row-resize-handle {
+    height: 16px;
+    cursor: row-resize;
+}
+
+.workspace-column-resize-handle {
+    width: 16px;
+    cursor: col-resize;
+}
+
+.workspace-resize-handle-bar {
+    border-radius: 999px;
+    background: var(--border-color, #ccc);
+    transition: background 0.16s ease, transform 0.16s ease;
+}
+
+.workspace-row-resize-handle .workspace-resize-handle-bar {
+    width: 70px;
+    height: 3px;
+}
+
+.workspace-column-resize-handle .workspace-resize-handle-bar {
+    width: 3px;
+    height: 58px;
+}
+
+.workspace-row-resize-handle:hover .workspace-resize-handle-bar,
+.workspace-column-resize-handle:hover .workspace-resize-handle-bar {
+    background: var(--primary-color, #4285f4);
+}
+
+.workspace-row-resize-handle:hover .workspace-resize-handle-bar {
+    transform: scaleX(1.12);
+}
+
+.workspace-column-resize-handle:hover .workspace-resize-handle-bar {
+    transform: scaleY(1.12);
+}
+
+.workspace-card-content .camera-view,
+.workspace-card-content .visualization-panel {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
+.workspace-card-content .camera-view {
+    padding: 0;
+}
+
+.workspace-card-content .custom-gamepad-layout {
+    padding: 0;
+}
 
 /* Responsive Adjustments for new layout */
 @media (max-width: 768px) { 
@@ -618,6 +1053,12 @@ body.no-scroll {
     /* Adjust control panel to ensure it fits */
     .control-panel {
         padding: 0px; /* Reduce padding on mobile */
+    }
+}
+
+@media (max-width: 1023px) {
+    .layout-controls {
+        display: none;
     }
 }
 

--- a/src/components/MainControlView.css
+++ b/src/components/MainControlView.css
@@ -356,6 +356,22 @@
     align-items: center;
 }
 
+.workspace-active-layout-name {
+    max-width: 180px;
+    min-width: 0;
+    overflow: hidden;
+    color: rgba(255, 255, 255, 0.74);
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 32px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.workspace-active-layout-name.dirty {
+    color: #fff;
+}
+
 .workspace-add-button,
 .workspace-template-button,
 .workspace-tile-button,
@@ -475,6 +491,11 @@
     cursor: not-allowed;
 }
 
+.workspace-template-item button:disabled {
+    opacity: 0.42;
+    cursor: not-allowed;
+}
+
 .workspace-template-form-row button svg,
 .workspace-template-item button svg,
 .workspace-template-transfer-row button svg {
@@ -520,7 +541,28 @@
     gap: 8px;
 }
 
-.workspace-template-item span {
+.workspace-template-item .workspace-template-load-row {
+    flex: 1 1 auto;
+    width: auto;
+    height: 34px;
+    min-height: 34px;
+    min-width: 0;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 0 9px;
+    text-align: left;
+}
+
+.workspace-template-item .workspace-template-load-row:hover {
+    border-color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 10%, var(--background-secondary));
+}
+
+.workspace-template-item.active .workspace-template-load-row {
+    border-color: color-mix(in srgb, var(--primary-color) 72%, var(--border-color));
+}
+
+.workspace-template-title {
     min-width: 0;
     flex: 1 1 auto;
     overflow: hidden;
@@ -529,6 +571,27 @@
     font-weight: 700;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.workspace-template-current {
+    flex: 0 0 auto;
+    color: var(--text-secondary);
+    font-size: 0.68rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.workspace-template-delete-button {
+    flex: 0 0 32px;
+}
+
+.workspace-template-empty {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    font-weight: 700;
 }
 
 .workspace-add-menu {
@@ -1008,6 +1071,13 @@ body.no-scroll {
     animation: workspace-drop-indicator-pop 150ms ease-out;
 }
 
+.workspace-drop-indicator-row {
+    width: 100%;
+    min-height: 8px;
+    flex-basis: 8px;
+    align-self: auto;
+}
+
 .workspace-drop-indicator-end {
     margin-left: 0;
 }
@@ -1094,6 +1164,10 @@ body.no-scroll {
 }
 
 .workspace-card-header[draggable="true"]:active {
+    cursor: grabbing;
+}
+
+.desktop-workspace.is-drop-active .workspace-card-header[draggable="true"] {
     cursor: grabbing;
 }
 
@@ -1198,30 +1272,41 @@ body.no-scroll {
     flex: 0 0 auto;
     display: flex;
     align-items: center;
-    gap: 6px;
-    min-height: 34px;
-    padding: 4px 6px;
+    gap: 8px;
+    min-height: 42px;
+    padding: 6px 8px;
     border-bottom: 1px solid var(--border-color);
     background: var(--background-secondary);
 }
 
-.workspace-pad-selector label {
+.workspace-pad-select-field {
+    min-width: 0;
+    flex: 1 1 auto;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+}
+
+.workspace-pad-select-field label {
     color: var(--text-secondary);
     font-size: 0.72rem;
     font-weight: 700;
     line-height: 1;
+    white-space: nowrap;
 }
 
-.workspace-pad-selector select {
+.workspace-pad-select-field select {
     min-width: 0;
-    flex: 1 1 auto;
-    height: 26px;
-    padding: 0 6px;
+    width: 100%;
+    height: 30px;
+    padding: 0 28px 0 8px;
     border: 1px solid var(--border-color);
     border-radius: 6px;
     background: var(--background-color);
     color: var(--text-color);
     font-size: 0.78rem;
+    font-weight: 700;
 }
 
 .workspace-pad-selector-empty {
@@ -1236,9 +1321,9 @@ body.no-scroll {
 }
 
 .workspace-pad-create-button {
-    width: 26px;
-    height: 26px;
-    min-width: 26px;
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1248,10 +1333,12 @@ body.no-scroll {
     background: var(--background-color);
     color: var(--text-color);
     cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
 }
 
 .workspace-pad-create-button:hover {
     border-color: var(--primary-color);
+    background: color-mix(in srgb, var(--primary-color) 10%, var(--background-color));
     color: var(--primary-color);
 }
 

--- a/src/components/MainControlView.css
+++ b/src/components/MainControlView.css
@@ -350,7 +350,14 @@
     align-items: center;
 }
 
+.workspace-template-control {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
 .workspace-add-button,
+.workspace-template-button,
 .workspace-tile-button,
 .workspace-split-button {
     background: transparent;
@@ -367,6 +374,7 @@
 }
 
 .workspace-add-button svg,
+.workspace-template-button svg,
 .workspace-tile-button svg,
 .workspace-split-button svg {
     width: 18px;
@@ -374,6 +382,7 @@
 }
 
 .workspace-add-button:hover:not(:disabled),
+.workspace-template-button:hover,
 .workspace-tile-button:hover,
 .workspace-split-button:hover {
     background: rgba(255, 255, 255, 0.18);
@@ -386,6 +395,7 @@
 }
 
 .workspace-add-button,
+.workspace-template-button,
 .workspace-tile-button,
 .workspace-split-button {
     height: 32px;
@@ -396,6 +406,129 @@
 .workspace-add-button:disabled {
     opacity: 0.42;
     cursor: not-allowed;
+}
+
+.workspace-template-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    width: min(320px, calc(100vw - 24px));
+    max-height: min(520px, calc(100vh - 64px));
+    overflow: auto;
+    z-index: 1200;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--card-bg);
+    color: var(--text-color);
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.32);
+}
+
+.workspace-template-form {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.workspace-template-form label {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.workspace-template-form-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.workspace-template-form-row input {
+    min-width: 0;
+    flex: 1 1 auto;
+    height: 32px;
+    padding: 0 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--background-secondary);
+    color: var(--text-color);
+}
+
+.workspace-template-form-row button,
+.workspace-template-item button,
+.workspace-template-transfer-row button {
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--background-secondary);
+    color: var(--text-color);
+}
+
+.workspace-template-form-row button:disabled {
+    opacity: 0.42;
+    cursor: not-allowed;
+}
+
+.workspace-template-form-row button svg,
+.workspace-template-item button svg,
+.workspace-template-transfer-row button svg {
+    width: 15px;
+    height: 15px;
+}
+
+.workspace-template-transfer-row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    margin-top: 8px;
+}
+
+.workspace-template-transfer-row button {
+    width: 100%;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.workspace-template-transfer-row button:disabled {
+    opacity: 0.42;
+    cursor: not-allowed;
+}
+
+.workspace-template-transfer-row input {
+    display: none;
+}
+
+.workspace-template-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-color);
+}
+
+.workspace-template-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.workspace-template-item span {
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+    color: var(--text-color);
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .workspace-add-menu {

--- a/src/components/MainControlView.test.tsx
+++ b/src/components/MainControlView.test.tsx
@@ -1,0 +1,361 @@
+import React, { useEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MainControlView from './MainControlView';
+
+const connect = vi.fn();
+const disconnect = vi.fn();
+const getTopics = vi.fn();
+const mockRos = { getTopics };
+const stopBehaviorTree = vi.fn();
+const loadGamepadLibrary = vi.fn();
+const getGamepadLayout = vi.fn();
+const cloneGamepadTemplate = vi.fn();
+const saveGamepadFromEditor = vi.fn();
+
+vi.mock('../hooks/useRos', () => ({
+  useRos: () => ({
+    ros: mockRos,
+    isConnected: true,
+    connect,
+    disconnect,
+  }),
+}));
+
+vi.mock('../hooks/useResizablePanels', () => ({
+  useResizablePanels: () => ({
+    topHeight: 60,
+    bottomHeight: 40,
+    handleMouseDown: vi.fn(),
+    handleTouchStart: vi.fn(),
+    containerRef: { current: null },
+    isDragging: false,
+  }),
+}));
+
+vi.mock('animejs', () => ({
+  default: {
+    timeline: vi.fn(() => ({
+      add: vi.fn((options) => {
+        options?.complete?.();
+        return undefined;
+      }),
+    })),
+  },
+}));
+
+vi.mock('../features/customGamepad/gamepadStorage', () => ({
+  loadGamepadLibrary: () => loadGamepadLibrary(),
+  getGamepadLayout: (layoutId: string) => getGamepadLayout(layoutId),
+  cloneGamepadTemplate: (layoutId: string) => cloneGamepadTemplate(layoutId),
+}));
+
+vi.mock('./CameraView', () => ({
+  default: ({ cameraTopic, availableTopics, onTopicChange, selectId }: any) => (
+    <div data-testid="camera-view">
+      <span>{cameraTopic}</span>
+      <select
+        aria-label="Camera topic"
+        id={selectId}
+        value={cameraTopic}
+        onChange={(event) => onTopicChange(event.target.value)}
+      >
+        {availableTopics.map((topic: string) => (
+          <option key={topic} value={topic}>{topic}</option>
+        ))}
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock('./VisualizationPanel', () => ({
+  default: ({ storageKey }: any) => (
+    <div data-testid="visualization-panel">{storageKey || 'base-visualization'}</div>
+  ),
+}));
+
+vi.mock('./gamepads/custom/CustomGamepadWrapper', () => ({
+  default: ({ layoutId }: any) => <div data-testid="custom-gamepad">{layoutId}</div>,
+}));
+
+vi.mock('./AddPanelMenu', () => ({
+  default: ({ isOpen, onSelectLayout, onOpenTemplate, onOpenCustomEditor }: any) => (
+    isOpen ? (
+      <div data-testid="add-panel-menu">
+        <button type="button" onClick={() => onSelectLayout('custom-drive')}>Add custom drive</button>
+        <button type="button" onClick={() => onOpenTemplate('template-drive')}>Open template</button>
+        <button type="button" onClick={() => onOpenCustomEditor()}>Open editor</button>
+      </div>
+    ) : null
+  ),
+}));
+
+vi.mock('../features/customGamepad/components/GamepadEditor', () => ({
+  default: ({ onSave, onClose, initialLayout }: any) => (
+    <div data-testid="gamepad-editor">
+      <span>{initialLayout?.name || 'New pad'}</span>
+      <button
+        type="button"
+        onClick={() => {
+          saveGamepadFromEditor();
+          onSave({
+            id: 'saved-pad',
+            name: 'Saved Pad',
+            description: '',
+            gridSize: { width: 4, height: 4 },
+            cellSize: 80,
+            components: [],
+            rosConfig: { defaultTopic: '/joy', defaultMessageType: 'sensor_msgs/msg/Joy' },
+            metadata: { created: '', modified: '', version: '1.0.0' },
+          });
+        }}
+      >
+        Save pad
+      </button>
+      <button type="button" onClick={onClose}>Close editor</button>
+    </div>
+  ),
+}));
+
+vi.mock('../features/behaviorTree/components/BehaviorTreePanel', () => ({
+  default: ({ onExecutionChange, onExecutionControlsChange, isActive }: any) => {
+    useEffect(() => {
+      onExecutionControlsChange?.({ stop: stopBehaviorTree });
+    }, []);
+
+    return (
+      <div data-testid="behavior-tree-panel">
+        <span>{isActive ? 'active behavior tree' : 'inactive behavior tree'}</span>
+        <button
+          type="button"
+          onClick={() => onExecutionChange?.({
+            isExecuting: true,
+            treeName: 'Inspect Tree',
+            activeNodeLabel: 'Move arm',
+          })}
+        >
+          Start mocked tree
+        </button>
+      </div>
+    );
+  },
+}));
+
+const workspacePanelsKey = 'robo-boy-desktop-workspace-panels-v1';
+const workspaceLayoutKey = 'robo-boy-desktop-workspace-layout-v1';
+const workspaceTileOrderKey = 'robo-boy-desktop-workspace-tile-order-v1';
+const workspaceSavedLayoutsKey = 'robo-boy-desktop-workspace-saved-layouts-v1';
+const workspaceActiveLayoutKey = 'robo-boy-desktop-workspace-active-layout-v1';
+const workspaceOpenKey = 'robo-boy-desktop-workspace-open-v1';
+const customTemplatesKey = 'robo-boy-desktop-workspace-custom-templates-v1';
+
+const connectionParams = {
+  ip: '127.0.0.1',
+  port: 9090,
+  ros2Option: 'domain' as const,
+  ros2Value: '0',
+};
+
+const makePanel = (id: string, type: 'camera' | '3d' | 'pad' | 'behaviorTree', title: string) => ({
+  id,
+  type,
+  title,
+  cameraTopic: type === 'camera' ? '/camera/image_raw' : undefined,
+  layoutId: type === 'pad' ? 'custom-drive' : undefined,
+});
+
+const renderMainControlView = () => (
+  render(<MainControlView connectionParams={connectionParams} onDisconnect={vi.fn()} />)
+);
+
+describe('MainControlView desktop workspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    loadGamepadLibrary.mockReturnValue([
+      { id: 'custom-drive', name: 'Drive Pad', layout: { id: 'custom-drive' }, isDefault: false },
+    ]);
+    getGamepadLayout.mockReturnValue({ id: 'custom-drive', name: 'Drive Pad', layout: { id: 'custom-drive', name: 'Drive Pad' } });
+    cloneGamepadTemplate.mockReturnValue({ id: 'template-copy', name: 'Template Copy' });
+    getTopics.mockImplementation((success: any) => {
+      success({
+        topics: ['/camera/image_raw', '/status'],
+        types: ['sensor_msgs/Image', 'std_msgs/String'],
+      });
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn((query: string) => ({
+        matches: query.includes('1024px'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('opens the grid workspace and adds each workspace panel type', async () => {
+    renderMainControlView();
+
+    await screen.findByTestId('camera-view');
+    fireEvent.click(screen.getByLabelText('Open grid workspace'));
+
+    expect(screen.getByLabelText('Desktop workspace')).toBeInTheDocument();
+    expect(screen.getByTitle('Unsaved workspace layout')).toHaveTextContent('Unsaved layout');
+    expect(screen.getByLabelText('View component')).toBeInTheDocument();
+    expect(screen.getByLabelText('Pad controls component')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Add workspace panel'));
+    fireEvent.click(screen.getByText('Camera'));
+    expect(await screen.findByLabelText('Camera')).toBeInTheDocument();
+    expect(screen.getAllByTestId('camera-view')).toHaveLength(2);
+
+    fireEvent.click(screen.getByLabelText('Add workspace panel'));
+    fireEvent.click(screen.getByText('3D panel'));
+    expect(await screen.findByLabelText('3D view')).toBeInTheDocument();
+    expect(screen.getByTestId('visualization-panel')).toHaveTextContent('roboboy_3d_visualization_state_');
+
+    fireEvent.click(screen.getByLabelText('Add workspace panel'));
+    fireEvent.click(screen.getByText('Behavior tree'));
+    expect(await screen.findByLabelText('Behavior tree')).toBeInTheDocument();
+    expect(screen.getByTestId('behavior-tree-panel')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Add workspace panel'));
+    fireEvent.click(screen.getByRole('button', { name: 'Pad controls' }));
+    expect(await screen.findByLabelText('Pad controls')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-gamepad')).toHaveTextContent('custom-drive');
+  });
+
+  it('saves, loads, deletes, imports, and exports workspace layouts', async () => {
+    const savedLayout = {
+      id: 'layout-one',
+      title: 'Inspection layout',
+      panels: [makePanel('panel-camera', 'camera', 'Camera')],
+      tileOrder: ['base-view', 'panel-camera', 'base-pads'],
+      layout: { rowSizes: [2, 1], rowRatios: [1, 1], columnRatiosByRow: { 0: [1, 1], 1: [1] } },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    localStorage.setItem(workspaceOpenKey, 'true');
+    localStorage.setItem(workspaceSavedLayoutsKey, JSON.stringify([savedLayout]));
+    localStorage.setItem(workspaceActiveLayoutKey, 'layout-one');
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:workspace');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    renderMainControlView();
+
+    await screen.findByLabelText('Desktop workspace');
+    fireEvent.click(screen.getByLabelText('Manage workspace layouts'));
+
+    expect(screen.getByLabelText('Load Inspection layout')).toBeInTheDocument();
+    expect(screen.getByText('Edited')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Layout name'), { target: { value: 'Updated layout' } });
+    fireEvent.click(screen.getByLabelText('Update current layout'));
+    expect(screen.getAllByText('Updated layout')[0]).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Layout name'), { target: { value: 'Copy layout' } });
+    fireEvent.click(screen.getByLabelText('Save as new layout'));
+    expect(screen.getAllByText('Copy layout')[0]).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Export layouts'));
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:workspace');
+
+    const imported = {
+      ...savedLayout,
+      id: 'imported',
+      title: 'Imported layout',
+    };
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File([JSON.stringify({ layouts: [imported] })], 'layouts.json', { type: 'application/json' })],
+      },
+    });
+    expect(await screen.findByLabelText('Load Imported layout')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Delete Updated layout'));
+    expect(screen.queryByLabelText('Load Updated layout')).not.toBeInTheDocument();
+
+    createObjectURL.mockRestore();
+    revokeObjectURL.mockRestore();
+    clickSpy.mockRestore();
+  });
+
+  it('loads persisted workspace panels, removes tiles, and returns to split view', async () => {
+    localStorage.setItem(workspaceOpenKey, 'true');
+    localStorage.setItem(workspacePanelsKey, JSON.stringify([
+      makePanel('panel-camera', 'camera', 'Camera'),
+      makePanel('panel-pad', 'pad', 'Pad controls'),
+      { bad: 'panel' },
+    ]));
+    localStorage.setItem(workspaceTileOrderKey, JSON.stringify(['base-view', 'panel-camera', 'panel-pad', 'base-pads']));
+    localStorage.setItem(workspaceLayoutKey, JSON.stringify({ rowSizes: [2, 2], rowRatios: [2, 1], columnRatiosByRow: { 0: [2, 1], 1: [1, 1] } }));
+    localStorage.setItem(customTemplatesKey, JSON.stringify([
+      { id: 'custom-layout', title: 'Custom snap', rowSizes: [2], rowRatios: [1], columnRatiosByRow: { 0: [1, 1] } },
+      { id: 'bad-layout', title: 'Bad', rowSizes: [] },
+    ]));
+
+    renderMainControlView();
+
+    await screen.findByLabelText('Desktop workspace');
+    expect(screen.getByLabelText('Camera')).toBeInTheDocument();
+    expect(screen.getByLabelText('Pad controls')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Remove Camera'));
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Camera')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Remove view tile'));
+    expect(screen.queryByLabelText('View component')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Return to split view'));
+    expect(screen.getByLabelText('Open grid workspace')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Desktop workspace')).not.toBeInTheDocument();
+  });
+
+  it('opens standard pad flows and stops running behavior trees', async () => {
+    renderMainControlView();
+
+    await screen.findByTestId('camera-view');
+    fireEvent.click(screen.getByLabelText('Add Panel'));
+    expect(screen.getByTestId('add-panel-menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Add custom drive'));
+    expect(screen.getByRole('tab', { name: /Drive Pad/ })).toBeInTheDocument();
+    expect(screen.getByTestId('custom-gamepad')).toHaveTextContent('custom-drive');
+
+    fireEvent.click(screen.getByLabelText('Add Panel'));
+    fireEvent.click(screen.getByText('Open template'));
+    expect(screen.getByTestId('gamepad-editor')).toHaveTextContent('Template Copy');
+    fireEvent.click(screen.getByText('Save pad'));
+    expect(saveGamepadFromEditor).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('Switch to Behavior Tree'));
+    fireEvent.click(await screen.findByText('Start mocked tree'));
+    expect(await screen.findByText('Move arm')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Stop behavior tree'));
+    expect(stopBehaviorTree).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('Disconnect'));
+    expect(stopBehaviorTree).toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('renders connection placeholders and handles topic fetch failures', async () => {
+    getTopics.mockImplementation((_success: any, failure: any) => failure(new Error('no rosapi')));
+    renderMainControlView();
+
+    await waitFor(() => {
+      expect(screen.getByText('No camera topics found')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { ConnectionParams } from '../App'; // Import types
 import { useRos } from '../hooks/useRos'; // Import the hook
 import { useResizablePanels } from '../hooks/useResizablePanels'; // Import the resizable panels hook
@@ -13,7 +13,7 @@ import AddPanelMenu from './AddPanelMenu'; // Import the AddPanelMenu component
 import { GamepadType } from './gamepads/GamepadInterface';
 import GamepadEditor from '../features/customGamepad/components/GamepadEditor';
 import { CustomGamepadLayout } from '../features/customGamepad/types';
-import { cloneGamepadTemplate, getGamepadLayout } from '../features/customGamepad/gamepadStorage';
+import { cloneGamepadTemplate, getGamepadLayout, loadGamepadLibrary } from '../features/customGamepad/gamepadStorage';
 import { applySavedGamepadToPanels, GamepadSaveMode } from '../features/customGamepad/gamepadPanelState';
 import BehaviorTreePanel, {
   BehaviorTreeExecutionControls,
@@ -69,6 +69,38 @@ const IconMCVStop = () => (
     <rect x="7" y="7" width="10" height="10" rx="2"/>
   </svg>
 );
+const IconMCVAdd = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <path d="M12 5v14M5 12h14"/>
+  </svg>
+);
+const IconMCVTrash = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/>
+  </svg>
+);
+const IconMCVGrip = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <circle cx="9" cy="9" r="1.4"/>
+    <circle cx="15" cy="9" r="1.4"/>
+    <circle cx="9" cy="15" r="1.4"/>
+    <circle cx="15" cy="15" r="1.4"/>
+  </svg>
+);
+const IconMCVTile = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="8" height="8" rx="1.5"/>
+    <rect x="13" y="3" width="8" height="8" rx="1.5"/>
+    <rect x="3" y="13" width="8" height="8" rx="1.5"/>
+    <rect x="13" y="13" width="8" height="8" rx="1.5"/>
+  </svg>
+);
+const IconMCVSplit = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="4" y="4" width="16" height="8" rx="1.5"/>
+    <rect x="4" y="14" width="16" height="6" rx="1.5"/>
+  </svg>
+);
 // --- End Top Bar Icons ---
 
 // Use Icon components
@@ -80,6 +112,11 @@ const icons = {
   disconnected: <IconMCVUnlink />,
   disconnect: <IconMCVDisconnect />,
   stop: <IconMCVStop />,
+  add: <IconMCVAdd />,
+  trash: <IconMCVTrash />,
+  grip: <IconMCVGrip />,
+  tile: <IconMCVTile />,
+  split: <IconMCVSplit />,
 };
 
 // Define Panel Types
@@ -97,13 +134,210 @@ interface MainControlViewProps {
 }
 
 type ViewMode = 'camera' | '3d' | 'behaviorTree';
+type WorkspacePanelType = 'camera' | '3d' | 'pad' | 'behaviorTree';
 type GamepadEditorSession = {
   mode: GamepadSaveMode;
   initialLayout: CustomGamepadLayout | null;
 };
 
+interface WorkspacePanel {
+  id: string;
+  type: WorkspacePanelType;
+  title: string;
+  cameraTopic?: string;
+  layoutId?: string;
+}
+
+type WorkspaceTile =
+  | { kind: 'view'; id: 'base-view' }
+  | { kind: 'pads'; id: 'base-pads' }
+  | { kind: 'panel'; id: string; panel: WorkspacePanel };
+
+const WORKSPACE_PANELS_KEY = 'robo-boy-desktop-workspace-panels-v1';
+const WORKSPACE_LAYOUT_KEY = 'robo-boy-desktop-workspace-layout-v1';
+const WORKSPACE_TILE_ORDER_KEY = 'robo-boy-desktop-workspace-tile-order-v1';
+const DESKTOP_WORKSPACE_QUERY = '(min-width: 1024px)';
+const WORKSPACE_DRAG_FORMAT = 'application/x-robo-boy-workspace-panel';
+const WORKSPACE_TILE_DRAG_FORMAT = 'application/x-robo-boy-workspace-tile';
+const MIN_WORKSPACE_TILE_RATIO = 0.24;
+
+type WorkspaceDraft = {
+  type: WorkspacePanelType;
+};
+
+type WorkspaceInteraction =
+  | {
+    mode: 'row';
+    index: number;
+    startClientX: number;
+    startClientY: number;
+    containerSize: number;
+    startRatios: number[];
+  }
+  | {
+    mode: 'column';
+    rowIndex: number;
+    index: number;
+    startClientX: number;
+    startClientY: number;
+    containerSize: number;
+    startRatios: number[];
+  };
+
+const clamp = (value: number, min: number, max: number) => {
+  return Math.max(min, Math.min(max, value));
+};
+
+const getWorkspaceTitle = (type: WorkspacePanelType) => {
+  if (type === 'camera') return 'Camera';
+  if (type === '3d') return '3D view';
+  if (type === 'behaviorTree') return 'Behavior tree';
+  return 'Pad controls';
+};
+
+const createWorkspacePanel = (
+  draft: WorkspaceDraft,
+  options: {
+    cameraTopic?: string;
+    layoutId?: string;
+  }
+): WorkspacePanel => {
+  return {
+    id: generateUniqueId('workspace-panel'),
+    title: getWorkspaceTitle(draft.type),
+    type: draft.type,
+    cameraTopic: draft.type === 'camera' ? options.cameraTopic : undefined,
+    layoutId: draft.type === 'pad' ? options.layoutId : undefined,
+  };
+};
+
+const normalizeWorkspacePanel = (panel: unknown): WorkspacePanel | null => {
+  if (!panel || typeof panel !== 'object') return null;
+  const candidate = panel as Partial<WorkspacePanel>;
+  if (
+    typeof candidate.id !== 'string' ||
+    !['camera', '3d', 'pad', 'behaviorTree'].includes(candidate.type || '') ||
+    typeof candidate.title !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    id: candidate.id,
+    type: candidate.type as WorkspacePanelType,
+    title: candidate.type === 'pad' ? getWorkspaceTitle('pad') : candidate.title,
+    cameraTopic: candidate.cameraTopic,
+    layoutId: candidate.layoutId,
+  };
+};
+
+const isWorkspacePanel = (panel: unknown): panel is WorkspacePanel => {
+  return normalizeWorkspacePanel(panel) !== null;
+};
+
+const loadWorkspacePanels = (): WorkspacePanel[] => {
+  try {
+    const stored = localStorage.getItem(WORKSPACE_PANELS_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed)
+      ? parsed.map(panel => normalizeWorkspacePanel(panel)).filter(isWorkspacePanel)
+      : [];
+  } catch (error) {
+    console.error('Failed to load desktop workspace panels:', error);
+    return [];
+  }
+};
+
+type WorkspaceLayoutState = {
+  rowRatios: number[];
+  columnRatiosByRow: Record<number, number[]>;
+};
+
+const normalizeRatios = (ratios: unknown, length: number): number[] => {
+  if (length <= 0) return [];
+  if (!Array.isArray(ratios) || ratios.length !== length) {
+    return Array.from({ length }, () => 1);
+  }
+
+  const numericRatios = ratios.map(value => (
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 1
+  ));
+  const minRatio = MIN_WORKSPACE_TILE_RATIO;
+  const clampedRatios = numericRatios.map(value => Math.max(minRatio, value));
+  const total = clampedRatios.reduce((sum, value) => sum + value, 0);
+  return total > 0 ? clampedRatios.map(value => value / total) : Array.from({ length }, () => 1);
+};
+
+const loadWorkspaceLayout = (): WorkspaceLayoutState => {
+  try {
+    const stored = localStorage.getItem(WORKSPACE_LAYOUT_KEY);
+    if (!stored) return { rowRatios: [], columnRatiosByRow: {} };
+
+    const parsed = JSON.parse(stored) as Partial<WorkspaceLayoutState>;
+    return {
+      rowRatios: Array.isArray(parsed.rowRatios) ? parsed.rowRatios : [],
+      columnRatiosByRow: parsed.columnRatiosByRow && typeof parsed.columnRatiosByRow === 'object'
+        ? parsed.columnRatiosByRow
+        : {},
+    };
+  } catch (error) {
+    console.error('Failed to load desktop workspace layout:', error);
+    return { rowRatios: [], columnRatiosByRow: {} };
+  }
+};
+
+const BASE_WORKSPACE_TILE_IDS = ['base-view', 'base-pads'];
+
+const loadWorkspaceTileOrder = (): string[] => {
+  try {
+    const stored = localStorage.getItem(WORKSPACE_TILE_ORDER_KEY);
+    if (!stored) return BASE_WORKSPACE_TILE_IDS;
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed.filter(item => typeof item === 'string') : BASE_WORKSPACE_TILE_IDS;
+  } catch (error) {
+    console.error('Failed to load desktop workspace tile order:', error);
+    return BASE_WORKSPACE_TILE_IDS;
+  }
+};
+
+const normalizeWorkspaceTileOrder = (order: string[], panelIds: string[]) => {
+  const validIds = [...BASE_WORKSPACE_TILE_IDS, ...panelIds];
+  const orderedIds = order.filter((id, index) => (
+    validIds.includes(id) && order.indexOf(id) === index
+  ));
+  const missingIds = validIds.filter(id => !orderedIds.includes(id));
+  return [...orderedIds, ...missingIds];
+};
+
+const getWorkspaceColumnCount = (panelCount: number) => {
+  if (panelCount <= 1) return 1;
+  if (panelCount === 2) return 2;
+  return Math.ceil(Math.sqrt(panelCount));
+};
+
+const buildWorkspaceRows = <T,>(items: T[]) => {
+  const columnCount = getWorkspaceColumnCount(items.length);
+  const rows: T[][] = [];
+  for (let index = 0; index < items.length; index += columnCount) {
+    rows.push(items.slice(index, index + columnCount));
+  }
+  return rows;
+};
+
 const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onDisconnect }) => {
   const [viewMode, setViewMode] = useState<ViewMode>('camera');
+  const [isWorkspaceOpen, setIsWorkspaceOpen] = useState(false);
+  const [workspacePanels, setWorkspacePanels] = useState<WorkspacePanel[]>(loadWorkspacePanels);
+  const [workspaceLayout, setWorkspaceLayout] = useState<WorkspaceLayoutState>(loadWorkspaceLayout);
+  const [workspaceTileOrder, setWorkspaceTileOrder] = useState<string[]>(loadWorkspaceTileOrder);
+  const [isWorkspaceAddMenuOpen, setIsWorkspaceAddMenuOpen] = useState(false);
+  const [isWorkspaceDragActive, setIsWorkspaceDragActive] = useState(false);
+  const [lastAddedWorkspacePanelId, setLastAddedWorkspacePanelId] = useState<string | null>(null);
+  const [isLargeScreen, setIsLargeScreen] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return true;
+    return window.matchMedia(DESKTOP_WORKSPACE_QUERY).matches;
+  });
   // Once BT panel mounts, keep it alive (preserves nodes/executor state)
   const [btEverMounted, setBtEverMounted] = useState(false);
   const [btExecution, setBtExecution] = useState<BehaviorTreeExecutionSnapshot>({
@@ -122,6 +356,10 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const [editorSession, setEditorSession] = useState<GamepadEditorSession | null>(null);
   // State to trigger refresh of custom gamepads in AddPanelMenu
   const [customGamepadRefreshKey, setCustomGamepadRefreshKey] = useState(0);
+  const gamepadLibrary = useMemo(
+    () => loadGamepadLibrary(),
+    [customGamepadRefreshKey]
+  );
   // Ref for the Add Panel button (+) 
   const addButtonRef = useRef<HTMLButtonElement>(null);
   // --- End New State ---
@@ -130,7 +368,35 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const _isConnecting = useRef(false);
 
   const viewPanelRef = useRef<HTMLDivElement>(null);
+  const workspaceRef = useRef<HTMLDivElement>(null);
+  const workspaceInteractionRef = useRef<WorkspaceInteraction | null>(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const isDesktopWorkspace = isLargeScreen && isWorkspaceOpen;
+  const normalizedWorkspaceTileOrder = useMemo(
+    () => normalizeWorkspaceTileOrder(workspaceTileOrder, workspacePanels.map(panel => panel.id)),
+    [workspacePanels, workspaceTileOrder]
+  );
+  const workspaceTiles = useMemo<WorkspaceTile[]>(() => {
+    const panelById = new Map(workspacePanels.map(panel => [panel.id, panel]));
+    return normalizedWorkspaceTileOrder.flatMap<WorkspaceTile>(id => {
+      if (id === 'base-view') return [{ kind: 'view' as const, id }];
+      if (id === 'base-pads') return [{ kind: 'pads' as const, id }];
+      const panel = panelById.get(id);
+      return panel ? [{ kind: 'panel' as const, id, panel }] : [];
+    });
+  }, [normalizedWorkspaceTileOrder, workspacePanels]);
+  const workspaceRows = useMemo(() => buildWorkspaceRows(workspaceTiles), [workspaceTiles]);
+  const workspaceRowRatios = useMemo(
+    () => normalizeRatios(workspaceLayout.rowRatios, workspaceRows.length),
+    [workspaceLayout.rowRatios, workspaceRows.length]
+  );
+  const workspaceColumnRatiosByRow = useMemo(() => (
+    workspaceRows.map((row, rowIndex) => normalizeRatios(
+      workspaceLayout.columnRatiosByRow[rowIndex],
+      row.length
+    ))
+  ), [workspaceLayout.columnRatiosByRow, workspaceRows]);
 
   // Resizable panels hook
   const { topHeight, bottomHeight, handleMouseDown, handleTouchStart, containerRef, isDragging } = useResizablePanels({
@@ -139,6 +405,42 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     minBottomHeight: 20,
     storageKey: 'robo-boy-panel-split',
   });
+
+  useEffect(() => {
+    localStorage.setItem(WORKSPACE_PANELS_KEY, JSON.stringify(workspacePanels));
+  }, [workspacePanels]);
+
+  useEffect(() => {
+    localStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(workspaceLayout));
+  }, [workspaceLayout]);
+
+  useEffect(() => {
+    const normalizedOrder = normalizeWorkspaceTileOrder(
+      workspaceTileOrder,
+      workspacePanels.map(panel => panel.id)
+    );
+    if (normalizedOrder.join('|') !== workspaceTileOrder.join('|')) {
+      setWorkspaceTileOrder(normalizedOrder);
+      return;
+    }
+    localStorage.setItem(WORKSPACE_TILE_ORDER_KEY, JSON.stringify(normalizedOrder));
+  }, [workspacePanels, workspaceTileOrder]);
+
+  useEffect(() => {
+    if (!window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia(DESKTOP_WORKSPACE_QUERY);
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      setIsLargeScreen(event.matches);
+    };
+
+    setIsLargeScreen(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleMediaChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleMediaChange);
+    };
+  }, []);
 
   // Fetch topics when connected
   useEffect(() => {
@@ -318,6 +620,282 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   };
   // --- End Panel Handlers ---
 
+  const resetWorkspaceLayout = () => {
+    setWorkspaceLayout({ rowRatios: [], columnRatiosByRow: {} });
+  };
+
+  const handleAddWorkspacePanel = (type: WorkspacePanelType, insertIndex?: number) => {
+    setIsWorkspaceOpen(true);
+    setWorkspacePanels(prev => {
+      const selectedPadPanel = selectedPanelId
+        ? activePanels.find(panel => panel.id === selectedPanelId)
+        : null;
+      const newPanel = createWorkspacePanel(
+        { type },
+        {
+          cameraTopic: selectedCameraTopic || availableCameraTopics[0],
+          layoutId: selectedPadPanel?.layoutId || gamepadLibrary[0]?.id,
+        }
+      );
+      const nextPanels = [...prev];
+      nextPanels.push(newPanel);
+      setWorkspaceTileOrder(prevOrder => {
+        const nextOrder = normalizeWorkspaceTileOrder(prevOrder, prev.map(panel => panel.id));
+        nextOrder.splice(
+          typeof insertIndex === 'number' ? clamp(insertIndex, 0, nextOrder.length) : nextOrder.length,
+          0,
+          newPanel.id
+        );
+        return nextOrder;
+      });
+      setLastAddedWorkspacePanelId(newPanel.id);
+      return nextPanels;
+    });
+    resetWorkspaceLayout();
+    setIsWorkspaceAddMenuOpen(false);
+  };
+
+  const handleReturnToSplitView = () => {
+    setIsWorkspaceOpen(false);
+    setIsWorkspaceAddMenuOpen(false);
+  };
+
+  const handleWorkspaceDragStart = (
+    event: React.DragEvent<HTMLButtonElement>,
+    type: WorkspacePanelType
+  ) => {
+    const payload: WorkspaceDraft = { type };
+    event.dataTransfer.setData(WORKSPACE_DRAG_FORMAT, JSON.stringify(payload));
+    event.dataTransfer.effectAllowed = 'copy';
+    setIsWorkspaceOpen(true);
+    setIsWorkspaceDragActive(true);
+  };
+
+  const handleWorkspaceTileDragStart = (
+    event: React.DragEvent<HTMLElement>,
+    tileId: string
+  ) => {
+    event.dataTransfer.setData(WORKSPACE_TILE_DRAG_FORMAT, tileId);
+    event.dataTransfer.effectAllowed = 'move';
+    setIsWorkspaceDragActive(true);
+  };
+
+  const handleWorkspaceDragEnd = () => {
+    setIsWorkspaceDragActive(false);
+  };
+
+  const handleWorkspaceDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (
+      event.dataTransfer.types.includes(WORKSPACE_DRAG_FORMAT) ||
+      event.dataTransfer.types.includes(WORKSPACE_TILE_DRAG_FORMAT)
+    ) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = event.dataTransfer.types.includes(WORKSPACE_TILE_DRAG_FORMAT) ? 'move' : 'copy';
+    }
+  };
+
+  const getWorkspaceDropIndex = (clientX: number, clientY: number) => {
+    if (!workspaceRef.current) return workspaceTiles.length;
+
+    const cards = Array.from(workspaceRef.current.querySelectorAll<HTMLElement>('.workspace-card'));
+    for (let index = 0; index < cards.length; index += 1) {
+      const rect = cards[index].getBoundingClientRect();
+      const isAboveCardCenter = clientY < rect.top + rect.height / 2;
+      const isWithinCardRow = clientY >= rect.top && clientY <= rect.bottom;
+      const isBeforeCardCenter = clientX < rect.left + rect.width / 2;
+
+      if (isAboveCardCenter || (isWithinCardRow && isBeforeCardCenter)) {
+        return index;
+      }
+    }
+
+    return workspaceTiles.length;
+  };
+
+  const handleWorkspaceDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    const movedTileId = event.dataTransfer.getData(WORKSPACE_TILE_DRAG_FORMAT);
+    if (movedTileId) {
+      event.preventDefault();
+      setIsWorkspaceDragActive(false);
+      const dropIndex = getWorkspaceDropIndex(event.clientX, event.clientY);
+      setWorkspaceTileOrder(prevOrder => {
+        const currentOrder = normalizeWorkspaceTileOrder(prevOrder, workspacePanels.map(panel => panel.id));
+        const fromIndex = currentOrder.indexOf(movedTileId);
+        if (fromIndex === -1) return currentOrder;
+
+        const nextOrder = [...currentOrder];
+        const [movedId] = nextOrder.splice(fromIndex, 1);
+        const adjustedDropIndex = dropIndex > fromIndex ? dropIndex - 1 : dropIndex;
+        nextOrder.splice(clamp(adjustedDropIndex, 0, nextOrder.length), 0, movedId);
+        return nextOrder;
+      });
+      resetWorkspaceLayout();
+      return;
+    }
+
+    const payload = event.dataTransfer.getData(WORKSPACE_DRAG_FORMAT);
+    if (!payload) return;
+
+    event.preventDefault();
+    setIsWorkspaceDragActive(false);
+    try {
+      const draft = JSON.parse(payload) as WorkspaceDraft;
+      if (!['camera', '3d', 'pad', 'behaviorTree'].includes(draft.type)) return;
+
+      const tileIndex = getWorkspaceDropIndex(event.clientX, event.clientY);
+      handleAddWorkspacePanel(draft.type, tileIndex);
+    } catch (error) {
+      console.error('Failed to add dropped workspace panel:', error);
+    }
+  };
+
+  const updateAdjacentRatios = (
+    ratios: number[],
+    index: number,
+    deltaPixels: number,
+    containerSize: number
+  ) => {
+    if (index < 0 || index >= ratios.length - 1 || containerSize <= 0) return ratios;
+
+    const nextRatios = [...ratios];
+    const combinedRatio = nextRatios[index] + nextRatios[index + 1];
+    const minRatio = Math.min(MIN_WORKSPACE_TILE_RATIO, combinedRatio / 2);
+    const deltaRatio = deltaPixels / containerSize;
+    const leftRatio = clamp(nextRatios[index] + deltaRatio, minRatio, combinedRatio - minRatio);
+    nextRatios[index] = leftRatio;
+    nextRatios[index + 1] = combinedRatio - leftRatio;
+    return nextRatios;
+  };
+
+  const handleWorkspaceRowResizeStart = (
+    event: React.PointerEvent<HTMLDivElement>,
+    index: number
+  ) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    workspaceInteractionRef.current = {
+      mode: 'row',
+      index,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      containerSize: workspaceRef.current?.clientHeight || 1,
+      startRatios: workspaceRowRatios,
+    };
+  };
+
+  const handleWorkspaceColumnResizeStart = (
+    event: React.PointerEvent<HTMLDivElement>,
+    rowIndex: number,
+    index: number
+  ) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const rowElement = event.currentTarget.closest<HTMLElement>('.workspace-tile-row');
+    workspaceInteractionRef.current = {
+      mode: 'column',
+      rowIndex,
+      index,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      containerSize: rowElement?.clientWidth || 1,
+      startRatios: workspaceColumnRatiosByRow[rowIndex] || [],
+    };
+  };
+
+  const updateWorkspaceInteraction = useCallback((clientX: number, clientY: number) => {
+    const interaction = workspaceInteractionRef.current;
+    if (!interaction) return;
+
+    const deltaX = clientX - interaction.startClientX;
+    const deltaY = clientY - interaction.startClientY;
+
+    if (interaction.mode === 'row') {
+      setWorkspaceLayout(prev => ({
+        ...prev,
+        rowRatios: updateAdjacentRatios(
+          interaction.startRatios,
+          interaction.index,
+          deltaY,
+          interaction.containerSize
+        ),
+      }));
+      return;
+    }
+
+    setWorkspaceLayout(prev => ({
+      ...prev,
+      columnRatiosByRow: {
+        ...prev.columnRatiosByRow,
+        [interaction.rowIndex]: updateAdjacentRatios(
+          interaction.startRatios,
+          interaction.index,
+          deltaX,
+          interaction.containerSize
+        ),
+      },
+    }));
+  }, []);
+
+  const handleWorkspacePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    updateWorkspaceInteraction(event.clientX, event.clientY);
+  };
+
+  const handleWorkspacePointerEnd = () => {
+    workspaceInteractionRef.current = null;
+  };
+
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent) => {
+      updateWorkspaceInteraction(event.clientX, event.clientY);
+    };
+    const handleMouseMove = (event: MouseEvent) => {
+      updateWorkspaceInteraction(event.clientX, event.clientY);
+    };
+    const handlePointerEnd = () => {
+      workspaceInteractionRef.current = null;
+    };
+
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerEnd);
+    document.addEventListener('pointercancel', handlePointerEnd);
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handlePointerEnd);
+
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerEnd);
+      document.removeEventListener('pointercancel', handlePointerEnd);
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handlePointerEnd);
+    };
+  }, [updateWorkspaceInteraction]);
+
+  const handleRemoveWorkspacePanel = (panelId: string) => {
+    setWorkspacePanels(prev => prev.filter(panel => panel.id !== panelId));
+    setWorkspaceTileOrder(prev => prev.filter(id => id !== panelId));
+    resetWorkspaceLayout();
+  };
+
+  const handleWorkspaceCameraTopicChange = (panelId: string, cameraTopic: string) => {
+    setWorkspacePanels(prev => prev.map(panel =>
+      panel.id === panelId ? { ...panel, cameraTopic } : panel
+    ));
+  };
+
+  const handleWorkspacePadLayoutChange = (panelId: string, layoutId: string) => {
+    setWorkspacePanels(prev => prev.map(panel =>
+      panel.id === panelId ? { ...panel, layoutId } : panel
+    ));
+  };
+
+  const handleAutoTileWorkspacePanels = () => {
+    if (workspacePanels.length > 0) {
+      setIsWorkspaceOpen(true);
+    }
+    resetWorkspaceLayout();
+    setIsWorkspaceAddMenuOpen(false);
+  };
+
   // Memoize the selected panel component to prevent unnecessary re-renders
   const SelectedPanelComponent = useMemo(() => {
     if (!selectedPanelId) return null;
@@ -397,10 +975,247 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     btExecutionControls.current?.stop();
   };
 
+  const renderPadControls = (showPadAddButton: boolean, style?: React.CSSProperties) => (
+    <div className="control-panel-container" style={style}>
+      <ControlPanelTabs
+        panels={activePanels}
+        selectedPanelId={selectedPanelId}
+        onSelectPanel={handleSelectPanel}
+        onAddPanelToggle={handleAddPanelToggle}
+        onRemovePanel={handleRemovePanel}
+        addButtonRef={showPadAddButton ? addButtonRef : undefined}
+        showAddButton={showPadAddButton}
+      />
+      <div className="control-panel card">
+        {isConnected && ros ? (
+          SelectedPanelComponent ?? (
+            <div className="pad-empty-state">
+              <div className="pad-empty-state-content">
+                <span className="pad-empty-state-kicker">Custom controls</span>
+                <h2>Start by creating your pad</h2>
+                <p>Build one from scratch or begin with a ready-made template.</p>
+                <button type="button" onClick={() => handleOpenCustomEditor()}>
+                  Create your pad
+                </button>
+              </div>
+            </div>
+          )
+        ) : (
+          <div>Connecting to ROS...</div>
+        )}
+      </div>
+    </div>
+  );
+
+  const renderViewContent = () => (
+    <div className="view-panel card" ref={viewPanelRef}>
+      {viewMode === 'camera' ? (
+        isConnected && ros && selectedCameraTopic ? (
+          <CameraView
+            ros={ros}
+            cameraTopic={selectedCameraTopic}
+            availableTopics={availableCameraTopics}
+            onTopicChange={setSelectedCameraTopic}
+          />
+        ) : (
+          <div className="placeholder">
+            {isConnected ? (availableCameraTopics.length > 0 ? 'Select a camera topic' : 'No camera topics found') : 'Connecting to ROS...'}
+          </div>
+        )
+      ) : viewMode === '3d' ? (
+        isConnected && ros ? (
+          <VisualizationPanel ros={ros} key="visualization-panel" />
+        ) : (
+          <div className="placeholder">Connecting to ROS...</div>
+        )
+      ) : null}
+      {btEverMounted && (
+        <div className="view-slot" style={viewMode !== 'behaviorTree' ? { display: 'none' } : undefined}>
+          {isConnected && ros ? (
+            <BehaviorTreePanel
+              ros={ros}
+              isConnected={isConnected}
+              isActive={viewMode === 'behaviorTree'}
+              onExecutionChange={setBtExecution}
+              onExecutionControlsChange={(controls) => {
+                btExecutionControls.current = controls;
+              }}
+            />
+          ) : (
+            <div className="placeholder">Connect to ROS to use Behavior Trees</div>
+          )}
+        </div>
+      )}
+      {viewMode === 'behaviorTree' && !btEverMounted && (
+        <div className="placeholder">Loading...</div>
+      )}
+    </div>
+  );
+
+  const renderWorkspacePadControls = (panel: WorkspacePanel) => {
+    const selectedLayoutId = panel.layoutId || gamepadLibrary[0]?.id || '';
+
+    return (
+      <div className="workspace-pad-component">
+        {gamepadLibrary.length > 0 ? (
+          <div className="workspace-pad-selector">
+            <label htmlFor={`workspace-pad-select-${panel.id}`}>Pad</label>
+            <select
+              id={`workspace-pad-select-${panel.id}`}
+              value={selectedLayoutId}
+              onChange={(event) => handleWorkspacePadLayoutChange(panel.id, event.target.value)}
+            >
+              {gamepadLibrary.map(item => (
+                <option key={item.id} value={item.id}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+        <div className="workspace-pad-body">
+          {isConnected && ros && selectedLayoutId ? (
+            <CustomGamepadWrapper ros={ros} layoutId={selectedLayoutId} />
+          ) : (
+            <div className="pad-empty-state">
+              <div className="pad-empty-state-content">
+                <span className="pad-empty-state-kicker">Custom controls</span>
+                <h2>No pads available</h2>
+                <p>Create a pad from the main pad controls.</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const renderWorkspacePanelContent = (panel: WorkspacePanel) => {
+    if (!isConnected || !ros) {
+      return <div className="placeholder">Connecting to ROS...</div>;
+    }
+
+    if (panel.type === 'camera') {
+      const cameraTopic = panel.cameraTopic || selectedCameraTopic || availableCameraTopics[0] || '';
+      return cameraTopic ? (
+        <CameraView
+          ros={ros}
+          cameraTopic={cameraTopic}
+          availableTopics={availableCameraTopics}
+          onTopicChange={(newTopic) => handleWorkspaceCameraTopicChange(panel.id, newTopic)}
+          selectId={`camera-topic-select-${panel.id}`}
+        />
+      ) : (
+        <div className="placeholder">
+          {availableCameraTopics.length > 0 ? 'Select a camera topic' : 'No camera topics found'}
+        </div>
+      );
+    }
+
+    if (panel.type === '3d') {
+      return (
+        <VisualizationPanel
+          ros={ros}
+          storageKey={`roboboy_3d_visualization_state_${panel.id}`}
+        />
+      );
+    }
+
+    if (panel.type === 'behaviorTree') {
+      return (
+        <BehaviorTreePanel
+          ros={ros}
+          isConnected={isConnected}
+          isActive={isDesktopWorkspace}
+          onExecutionChange={setBtExecution}
+          onExecutionControlsChange={(controls) => {
+            btExecutionControls.current = controls;
+          }}
+        />
+      );
+    }
+
+    if (panel.type === 'pad') {
+      return renderWorkspacePadControls(panel);
+    }
+
+    return <div className="placeholder">Choose a component</div>;
+  };
+
+  const renderWorkspaceAddMenu = () => {
+    if (!isWorkspaceAddMenuOpen) return null;
+
+    return (
+      <div className="workspace-add-menu" role="menu">
+        <div className="workspace-add-menu-section">
+          <span className="workspace-add-menu-title">Components</span>
+          <button
+            type="button"
+            draggable
+            onDragStart={(event) => handleWorkspaceDragStart(event, 'camera')}
+            onDragEnd={handleWorkspaceDragEnd}
+            onClick={() => handleAddWorkspacePanel('camera')}
+          >
+            {icons.camera}
+            <span>Camera</span>
+          </button>
+          <button
+            type="button"
+            draggable
+            onDragStart={(event) => handleWorkspaceDragStart(event, '3d')}
+            onDragEnd={handleWorkspaceDragEnd}
+            onClick={() => handleAddWorkspacePanel('3d')}
+          >
+            {icons.view3d}
+            <span>3D panel</span>
+          </button>
+          <button
+            type="button"
+            draggable
+            onDragStart={(event) => handleWorkspaceDragStart(event, 'behaviorTree')}
+            onDragEnd={handleWorkspaceDragEnd}
+            onClick={() => handleAddWorkspacePanel('behaviorTree')}
+          >
+            {icons.bt}
+            <span>Behavior tree</span>
+          </button>
+          <button
+            type="button"
+            draggable
+            onDragStart={(event) => handleWorkspaceDragStart(event, 'pad')}
+            onDragEnd={handleWorkspaceDragEnd}
+            onClick={() => handleAddWorkspacePanel('pad')}
+          >
+            {icons.grip}
+            <span>Pad controls</span>
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  const renderStandardSplitLayout = (className = 'standard-stack-layout') => (
+    <div className={className} ref={containerRef}>
+      <div className="view-panel-container" style={{ height: `calc(${topHeight}% - 8px)` }}>
+        {renderViewContent()}
+      </div>
+
+      <div
+        className={`resize-handle ${isDragging ? 'dragging' : ''}`}
+        onMouseDown={handleMouseDown}
+        onTouchStart={handleTouchStart}
+      >
+        <div className="resize-handle-bar" />
+      </div>
+
+      {renderPadControls(true, { height: `calc(${bottomHeight}% - 8px)` })}
+    </div>
+  );
+
   return (
     <div className="main-control-view">
       {/* Unified Top Bar */}
-      <div className={`top-bar ${btExecution.isExecuting ? 'bt-running' : ''}`}>
+      <div className={`top-bar ${btExecution.isExecuting ? 'bt-running' : ''} ${isDesktopWorkspace ? 'workspace-active' : ''}`}>
         <div className="view-toggle">
           <button
             onClick={() => handleViewToggle('camera')}
@@ -461,6 +1276,42 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
             </button>
           )}
         </div>
+        <div className="layout-controls">
+          {isDesktopWorkspace && (
+            <>
+              <button
+                type="button"
+                className="workspace-split-button"
+                onClick={handleReturnToSplitView}
+                title="Return to split view"
+                aria-label="Return to split view"
+              >
+                {icons.split}
+              </button>
+              <button
+                type="button"
+                className="workspace-tile-button"
+                onClick={handleAutoTileWorkspacePanels}
+                title="Auto-arrange workspace panels"
+                aria-label="Auto-arrange workspace panels"
+              >
+                {icons.tile}
+              </button>
+            </>
+          )}
+          <div className="workspace-add-control">
+            <button
+              type="button"
+              className="workspace-add-button"
+              onClick={() => setIsWorkspaceAddMenuOpen(prev => !prev)}
+              title="Add workspace panel"
+              aria-label="Add workspace panel"
+            >
+              {icons.add}
+            </button>
+            {renderWorkspaceAddMenu()}
+          </div>
+        </div>
         <div className="status-controls">
           <div
             className={`connection-status-icon ${isConnected ? 'connected' : 'disconnected'}`}
@@ -482,91 +1333,139 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       </div>
 
       {/* Main Content Area - ensure it starts below the top bar */}
-      <div className="main-content-area" ref={containerRef}>
-        <div className="view-panel-container" style={{ height: `calc(${topHeight}% - 8px)` }}>
-          <div className="view-panel card" ref={viewPanelRef}>
-            {viewMode === 'camera' ? (
-              isConnected && ros && selectedCameraTopic ? (
-                <CameraView
-                  ros={ros}
-                  cameraTopic={selectedCameraTopic}
-                  availableTopics={availableCameraTopics}
-                  onTopicChange={setSelectedCameraTopic}
-                />
-              ) : (
-                <div className="placeholder">
-                  {isConnected ? (availableCameraTopics.length > 0 ? 'Select a camera topic' : 'No camera topics found') : 'Connecting to ROS...'}
-                </div>
-              )
-            ) : viewMode === '3d' ? (
-              isConnected && ros ? (
-                <VisualizationPanel ros={ros} key="visualization-panel" />
-              ) : (
-                <div className="placeholder">Connecting to ROS...</div>
-              )
-            ) : null}
-            {/* BT: lazy-mount once, kept alive with display:none to preserve nodes/executor */}
-            {btEverMounted && (
-              <div className="view-slot" style={viewMode !== 'behaviorTree' ? { display: 'none' } : undefined}>
-                {isConnected && ros ? (
-                  <BehaviorTreePanel
-                    ros={ros}
-                    isConnected={isConnected}
-                    isActive={viewMode === 'behaviorTree'}
-                    onExecutionChange={setBtExecution}
-                    onExecutionControlsChange={(controls) => {
-                      btExecutionControls.current = controls;
-                    }}
-                  />
-                ) : (
-                  <div className="placeholder">Connect to ROS to use Behavior Trees</div>
-                )}
-              </div>
-            )}
-            {viewMode === 'behaviorTree' && !btEverMounted && (
-              <div className="placeholder">Loading…</div>
-            )}
-          </div>
-        </div>
+      <div className={`main-content-area ${isDesktopWorkspace ? 'workspace-mode' : 'stack-mode'}`}>
+        {!isDesktopWorkspace && renderStandardSplitLayout()}
 
-        {/* Resizable Handle */}
-        <div
-          className={`resize-handle ${isDragging ? 'dragging' : ''}`}
-          onMouseDown={handleMouseDown}
-          onTouchStart={handleTouchStart}
-        >
-          <div className="resize-handle-bar" />
-        </div>
-
-        <div className="control-panel-container" style={{ height: `calc(${bottomHeight}% - 8px)` }}>
-          <ControlPanelTabs
-            panels={activePanels}
-            selectedPanelId={selectedPanelId}
-            onSelectPanel={handleSelectPanel}
-            onAddPanelToggle={handleAddPanelToggle}
-            onRemovePanel={handleRemovePanel}
-            addButtonRef={addButtonRef}
-          />
-          <div className="control-panel card">
-            {/* Render the selected panel component */}
-            {isConnected && ros ? (
-              SelectedPanelComponent ?? (
-                <div className="pad-empty-state">
-                  <div className="pad-empty-state-content">
-                    <span className="pad-empty-state-kicker">Custom controls</span>
-                    <h2>Start by creating your pad</h2>
-                    <p>Build one from scratch or begin with a ready-made template.</p>
-                    <button type="button" onClick={() => handleOpenCustomEditor()}>
-                      Create your pad
-                    </button>
+        {isDesktopWorkspace && (
+          <div
+            className={`desktop-workspace ${isWorkspaceDragActive ? 'is-drop-active' : ''}`}
+            aria-label="Desktop workspace"
+            ref={workspaceRef}
+            onDragOver={handleWorkspaceDragOver}
+            onDrop={handleWorkspaceDrop}
+            onPointerMove={handleWorkspacePointerMove}
+            onPointerUp={handleWorkspacePointerEnd}
+            onPointerCancel={handleWorkspacePointerEnd}
+          >
+            <div className="workspace-grid">
+              {workspaceRows.map((row, rowIndex) => (
+                <React.Fragment key={`workspace-row-${rowIndex}`}>
+                  <div
+                    className="workspace-tile-row"
+                    style={{ flex: workspaceRowRatios[rowIndex] || 1 }}
+                  >
+                    {row.map((tile, columnIndex) => (
+                      <React.Fragment key={tile.id}>
+                        {tile.kind === 'view' ? (
+                          <section
+                            className="workspace-card workspace-card-view"
+                            aria-label="View component"
+                            data-workspace-card-id={tile.id}
+                            style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
+                          >
+                            <header
+                              className="workspace-card-header"
+                              draggable
+                              onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
+                              onDragEnd={handleWorkspaceDragEnd}
+                            >
+                              <div className="workspace-card-title">
+                                <span className="workspace-card-dot workspace-card-dot-view" aria-hidden="true" />
+                                <span>View</span>
+                              </div>
+                            </header>
+                            <div className="workspace-card-content workspace-card-content-view">
+                              {renderViewContent()}
+                            </div>
+                          </section>
+                        ) : tile.kind === 'pads' ? (
+                          <section
+                            className="workspace-card workspace-card-pads"
+                            aria-label="Pad controls component"
+                            data-workspace-card-id={tile.id}
+                            style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
+                          >
+                            <header
+                              className="workspace-card-header"
+                              draggable
+                              onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
+                              onDragEnd={handleWorkspaceDragEnd}
+                            >
+                              <div className="workspace-card-title">
+                                <span className="workspace-card-dot workspace-card-dot-pad" aria-hidden="true" />
+                                <span>Pad controls</span>
+                              </div>
+                            </header>
+                            <div className="workspace-card-content">
+                              {renderPadControls(true)}
+                            </div>
+                          </section>
+                        ) : (
+                          <section
+                            className={`workspace-card workspace-card-${tile.panel.type} ${lastAddedWorkspacePanelId === tile.panel.id ? 'is-settling' : ''}`}
+                            aria-label={tile.panel.title}
+                            data-workspace-card-id={tile.panel.id}
+                            style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
+                            onAnimationEnd={() => {
+                              setLastAddedWorkspacePanelId(prev => prev === tile.panel.id ? null : prev);
+                            }}
+                          >
+                            <header
+                              className="workspace-card-header"
+                              draggable
+                              onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
+                              onDragEnd={handleWorkspaceDragEnd}
+                            >
+                              <div className="workspace-card-title">
+                                <span className={`workspace-card-dot workspace-card-dot-${tile.panel.type}`} aria-hidden="true" />
+                                <span>{tile.panel.title}</span>
+                              </div>
+                              <div className="workspace-card-actions">
+                                <button
+                                  type="button"
+                                  onClick={() => handleRemoveWorkspacePanel(tile.panel.id)}
+                                  title="Remove panel"
+                                  aria-label={`Remove ${tile.panel.title}`}
+                                >
+                                  {icons.trash}
+                                </button>
+                              </div>
+                            </header>
+                            <div className="workspace-card-content">
+                              {renderWorkspacePanelContent(tile.panel)}
+                            </div>
+                          </section>
+                        )}
+                        {columnIndex < row.length - 1 && (
+                          <div
+                            className="workspace-column-resize-handle"
+                            onPointerDown={(event) => handleWorkspaceColumnResizeStart(event, rowIndex, columnIndex)}
+                            role="separator"
+                            aria-orientation="vertical"
+                            aria-label="Resize workspace columns"
+                          >
+                            <div className="workspace-resize-handle-bar" />
+                          </div>
+                        )}
+                      </React.Fragment>
+                    ))}
                   </div>
-                </div>
-              )
-            ) : (
-              <div>Connecting to ROS...</div>
-            )}
+                  {rowIndex < workspaceRows.length - 1 && (
+                    <div
+                      className="workspace-row-resize-handle"
+                      onPointerDown={(event) => handleWorkspaceRowResizeStart(event, rowIndex)}
+                      role="separator"
+                      aria-orientation="horizontal"
+                      aria-label="Resize workspace rows"
+                    >
+                      <div className="workspace-resize-handle-bar" />
+                    </div>
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Render AddPanelMenu using Portal outside main flow */}

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -101,6 +101,27 @@ const IconMCVSplit = () => (
     <rect x="4" y="14" width="16" height="6" rx="1.5"/>
   </svg>
 );
+const IconMCVSaveLayout = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M5 4h11l3 3v13H5z"/>
+    <path d="M8 4v6h8V4"/>
+    <path d="M8 16h8"/>
+  </svg>
+);
+const IconMCVDownload = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 3v12"/>
+    <path d="m7 10 5 5 5-5"/>
+    <path d="M5 21h14"/>
+  </svg>
+);
+const IconMCVUpload = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 21V9"/>
+    <path d="m7 14 5-5 5 5"/>
+    <path d="M5 3h14"/>
+  </svg>
+);
 // --- End Top Bar Icons ---
 
 // Use Icon components
@@ -117,6 +138,9 @@ const icons = {
   grip: <IconMCVGrip />,
   tile: <IconMCVTile />,
   split: <IconMCVSplit />,
+  saveLayout: <IconMCVSaveLayout />,
+  download: <IconMCVDownload />,
+  upload: <IconMCVUpload />,
 };
 
 // Define Panel Types
@@ -156,6 +180,7 @@ type WorkspaceTile =
 const WORKSPACE_PANELS_KEY = 'robo-boy-desktop-workspace-panels-v1';
 const WORKSPACE_LAYOUT_KEY = 'robo-boy-desktop-workspace-layout-v1';
 const WORKSPACE_TILE_ORDER_KEY = 'robo-boy-desktop-workspace-tile-order-v1';
+const WORKSPACE_CUSTOM_TEMPLATES_KEY = 'robo-boy-desktop-workspace-custom-templates-v1';
 const DESKTOP_WORKSPACE_QUERY = '(min-width: 1024px)';
 const WORKSPACE_DRAG_FORMAT = 'application/x-robo-boy-workspace-panel';
 const WORKSPACE_TILE_DRAG_FORMAT = 'application/x-robo-boy-workspace-tile';
@@ -266,6 +291,7 @@ type WorkspaceSnapTemplate = {
   rowSizes: number[];
   rowRatios?: number[];
   columnRatiosByRow?: Record<number, number[]>;
+  isCustom?: boolean;
 };
 
 const normalizeRatios = (ratios: unknown, length: number): number[] => {
@@ -301,6 +327,56 @@ const loadWorkspaceLayout = (): WorkspaceLayoutState => {
   } catch (error) {
     console.error('Failed to load desktop workspace layout:', error);
     return { rowRatios: [], columnRatiosByRow: {} };
+  }
+};
+
+const normalizeWorkspaceSnapTemplate = (template: unknown): WorkspaceSnapTemplate | null => {
+  if (!template || typeof template !== 'object') return null;
+  const candidate = template as Partial<WorkspaceSnapTemplate>;
+  if (
+    typeof candidate.id !== 'string' ||
+    !candidate.id.startsWith('custom-') ||
+    typeof candidate.title !== 'string' ||
+    !Array.isArray(candidate.rowSizes) ||
+    candidate.rowSizes.length === 0 ||
+    !candidate.rowSizes.every(value => Number.isInteger(value) && value > 0)
+  ) {
+    return null;
+  }
+
+  const columnRatiosByRow = candidate.columnRatiosByRow && typeof candidate.columnRatiosByRow === 'object'
+    ? Object.entries(candidate.columnRatiosByRow).reduce<Record<number, number[]>>((ratios, [key, value]) => {
+      if (Array.isArray(value)) {
+        const numericRatios = value.filter(item => typeof item === 'number' && Number.isFinite(item) && item > 0);
+        if (numericRatios.length > 0) ratios[Number(key)] = numericRatios;
+      }
+      return ratios;
+    }, {})
+    : undefined;
+
+  return {
+    id: candidate.id,
+    title: candidate.title.trim() || 'Custom layout',
+    rowSizes: candidate.rowSizes,
+    rowRatios: Array.isArray(candidate.rowRatios)
+      ? candidate.rowRatios.filter(value => typeof value === 'number' && Number.isFinite(value) && value > 0)
+      : undefined,
+    columnRatiosByRow,
+    isCustom: true,
+  };
+};
+
+const loadWorkspaceCustomTemplates = (): WorkspaceSnapTemplate[] => {
+  try {
+    const stored = localStorage.getItem(WORKSPACE_CUSTOM_TEMPLATES_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed)
+      ? parsed.map(template => normalizeWorkspaceSnapTemplate(template)).filter((template): template is WorkspaceSnapTemplate => template !== null)
+      : [];
+  } catch (error) {
+    console.error('Failed to load workspace custom templates:', error);
+    return [];
   }
 };
 
@@ -398,8 +474,8 @@ const WORKSPACE_SNAP_TEMPLATES: WorkspaceSnapTemplate[] = [
   },
 ];
 
-const getWorkspaceSnapTemplates = (tileCount: number) => {
-  return WORKSPACE_SNAP_TEMPLATES.filter(template => (
+const getWorkspaceSnapTemplates = (tileCount: number, templates: WorkspaceSnapTemplate[]) => {
+  return templates.filter(template => (
     template.rowSizes.reduce((total, size) => total + size, 0) <= tileCount
   ));
 };
@@ -440,7 +516,10 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const [workspacePanels, setWorkspacePanels] = useState<WorkspacePanel[]>(loadWorkspacePanels);
   const [workspaceLayout, setWorkspaceLayout] = useState<WorkspaceLayoutState>(loadWorkspaceLayout);
   const [workspaceTileOrder, setWorkspaceTileOrder] = useState<string[]>(loadWorkspaceTileOrder);
+  const [customWorkspaceSnapTemplates, setCustomWorkspaceSnapTemplates] = useState<WorkspaceSnapTemplate[]>(loadWorkspaceCustomTemplates);
   const [isWorkspaceAddMenuOpen, setIsWorkspaceAddMenuOpen] = useState(false);
+  const [isWorkspaceTemplateMenuOpen, setIsWorkspaceTemplateMenuOpen] = useState(false);
+  const [workspaceTemplateName, setWorkspaceTemplateName] = useState('');
   const [isWorkspaceDragActive, setIsWorkspaceDragActive] = useState(false);
   const [workspaceDragKind, setWorkspaceDragKind] = useState<'new' | 'move' | null>(null);
   const [workspaceSnapTarget, setWorkspaceSnapTarget] = useState<WorkspaceSnapTarget | null>(null);
@@ -484,6 +563,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const viewPanelRef = useRef<HTMLDivElement>(null);
   const workspaceRef = useRef<HTMLDivElement>(null);
   const workspaceInteractionRef = useRef<WorkspaceInteraction | null>(null);
+  const templateImportInputRef = useRef<HTMLInputElement>(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
 
   const isDesktopWorkspace = isLargeScreen && isWorkspaceOpen;
@@ -520,9 +600,13 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       .reduce((total, row) => total + row.length, columnIndex);
   };
   const workspaceSnapTileCount = workspaceTiles.length + (workspaceDragKind === 'new' ? 1 : 0);
+  const allWorkspaceSnapTemplates = useMemo(
+    () => [...WORKSPACE_SNAP_TEMPLATES, ...customWorkspaceSnapTemplates],
+    [customWorkspaceSnapTemplates]
+  );
   const workspaceSnapTemplates = useMemo(
-    () => getWorkspaceSnapTemplates(workspaceSnapTileCount),
-    [workspaceSnapTileCount]
+    () => getWorkspaceSnapTemplates(workspaceSnapTileCount, allWorkspaceSnapTemplates),
+    [allWorkspaceSnapTemplates, workspaceSnapTileCount]
   );
 
   // Resizable panels hook
@@ -540,6 +624,10 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   useEffect(() => {
     localStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(workspaceLayout));
   }, [workspaceLayout]);
+
+  useEffect(() => {
+    localStorage.setItem(WORKSPACE_CUSTOM_TEMPLATES_KEY, JSON.stringify(customWorkspaceSnapTemplates));
+  }, [customWorkspaceSnapTemplates]);
 
   useEffect(() => {
     const normalizedOrder = normalizeWorkspaceTileOrder(
@@ -796,11 +884,13 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       resetWorkspaceLayout();
     }
     setIsWorkspaceAddMenuOpen(false);
+    setIsWorkspaceTemplateMenuOpen(false);
   };
 
   const handleReturnToSplitView = () => {
     setIsWorkspaceOpen(false);
     setIsWorkspaceAddMenuOpen(false);
+    setIsWorkspaceTemplateMenuOpen(false);
     setIsWorkspaceDragActive(false);
     setWorkspaceDragKind(null);
     setWorkspaceSnapTarget(null);
@@ -857,7 +947,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   };
 
   const getWorkspaceSnapTemplate = (templateId: string) => {
-    return WORKSPACE_SNAP_TEMPLATES.find(template => template.id === templateId) || null;
+    return allWorkspaceSnapTemplates.find(template => template.id === templateId) || null;
   };
 
   const handleWorkspaceSnapDragOver = (
@@ -1099,12 +1189,91 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     handleOpenCustomEditor();
   };
 
+  const handleSaveWorkspaceTemplate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (workspaceTiles.length === 0 || workspaceRows.length === 0) return;
+
+    const title = workspaceTemplateName.trim() || `Custom ${customWorkspaceSnapTemplates.length + 1}`;
+    const rowSizes = workspaceRows.map(row => row.length);
+    const columnRatiosByRow = rowSizes.reduce<Record<number, number[]>>((ratiosByRow, rowSize, rowIndex) => {
+      ratiosByRow[rowIndex] = workspaceColumnRatiosByRow[rowIndex]?.length === rowSize
+        ? workspaceColumnRatiosByRow[rowIndex]
+        : Array.from({ length: rowSize }, () => 1);
+      return ratiosByRow;
+    }, {});
+
+    const newTemplate: WorkspaceSnapTemplate = {
+      id: `custom-${Date.now()}`,
+      title,
+      rowSizes,
+      rowRatios: workspaceRowRatios.length === rowSizes.length
+        ? workspaceRowRatios
+        : Array.from({ length: rowSizes.length }, () => 1),
+      columnRatiosByRow,
+      isCustom: true,
+    };
+
+    setCustomWorkspaceSnapTemplates(prev => [...prev, newTemplate]);
+    setWorkspaceTemplateName('');
+  };
+
+  const handleDeleteWorkspaceTemplate = (templateId: string) => {
+    setCustomWorkspaceSnapTemplates(prev => prev.filter(template => template.id !== templateId));
+  };
+
+  const handleExportWorkspaceTemplates = () => {
+    if (customWorkspaceSnapTemplates.length === 0) return;
+
+    const blob = new Blob([
+      JSON.stringify({
+        version: 1,
+        templates: customWorkspaceSnapTemplates,
+      }, null, 2),
+    ], { type: 'application/json' });
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = objectUrl;
+    link.download = 'robo-boy-workspace-templates.json';
+    link.click();
+    URL.revokeObjectURL(objectUrl);
+  };
+
+  const handleImportWorkspaceTemplates = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const parsed = JSON.parse(String(reader.result || ''));
+        const candidates = Array.isArray(parsed) ? parsed : parsed?.templates;
+        if (!Array.isArray(candidates)) return;
+
+        const importedTemplates = candidates
+          .map(template => normalizeWorkspaceSnapTemplate(template))
+          .filter((template): template is WorkspaceSnapTemplate => template !== null)
+          .map(template => ({
+            ...template,
+            id: `custom-${Date.now()}-${template.id}`,
+          }));
+
+        if (importedTemplates.length === 0) return;
+        setCustomWorkspaceSnapTemplates(prev => [...prev, ...importedTemplates]);
+      } catch (error) {
+        console.error('Failed to import workspace templates:', error);
+      }
+    };
+    reader.readAsText(file);
+  };
+
   const handleAutoTileWorkspacePanels = () => {
     setIsWorkspaceOpen(true);
     setIsWorkspaceDragActive(false);
     setWorkspaceDropIndex(null);
     resetWorkspaceLayout();
     setIsWorkspaceAddMenuOpen(false);
+    setIsWorkspaceTemplateMenuOpen(false);
   };
 
   // Memoize the selected panel component to prevent unnecessary re-renders
@@ -1421,6 +1590,79 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     );
   };
 
+  const renderWorkspaceTemplateMenu = () => {
+    if (!isWorkspaceTemplateMenuOpen) return null;
+
+    return (
+      <div className="workspace-template-menu">
+        <form className="workspace-template-form" onSubmit={handleSaveWorkspaceTemplate}>
+          <label htmlFor="workspace-template-name">Name</label>
+          <div className="workspace-template-form-row">
+            <input
+              id="workspace-template-name"
+              value={workspaceTemplateName}
+              onChange={(event) => setWorkspaceTemplateName(event.target.value)}
+              placeholder={`Custom ${customWorkspaceSnapTemplates.length + 1}`}
+              maxLength={28}
+            />
+            <button
+              type="submit"
+              disabled={workspaceTiles.length === 0}
+              title="Save current template"
+              aria-label="Save current template"
+            >
+              {icons.saveLayout}
+            </button>
+          </div>
+        </form>
+        <div className="workspace-template-transfer-row">
+          <button
+            type="button"
+            onClick={() => templateImportInputRef.current?.click()}
+            title="Import templates"
+            aria-label="Import templates"
+          >
+            {icons.upload}
+            <span>Import</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleExportWorkspaceTemplates}
+            disabled={customWorkspaceSnapTemplates.length === 0}
+            title="Export templates"
+            aria-label="Export templates"
+          >
+            {icons.download}
+            <span>Export</span>
+          </button>
+          <input
+            ref={templateImportInputRef}
+            type="file"
+            accept="application/json,.json"
+            onChange={handleImportWorkspaceTemplates}
+          />
+        </div>
+        {customWorkspaceSnapTemplates.length > 0 && (
+          <div className="workspace-template-list">
+            {customWorkspaceSnapTemplates.map(template => (
+              <div className="workspace-template-item" key={template.id}>
+                <span>{template.title}</span>
+                <button
+                  type="button"
+                  onClick={() => handleDeleteWorkspaceTemplate(template.id)}
+                  title={`Delete ${template.title}`}
+                  aria-label={`Delete ${template.title}`}
+                >
+                  {icons.trash}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const renderWorkspaceSnapAssistant = () => {
     if (!isWorkspaceDragActive || workspaceSnapTemplates.length === 0) return null;
 
@@ -1570,30 +1812,52 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                 {icons.tile}
               </button>
               {isDesktopWorkspace && (
-                <button
-                  type="button"
-                  className="workspace-split-button"
-                  onClick={handleReturnToSplitView}
-                  title="Return to split view"
-                  aria-label="Return to split view"
-                >
-                  {icons.split}
-                </button>
+                <>
+                  <div className="workspace-template-control">
+                    <button
+                      type="button"
+                      className="workspace-template-button"
+                      onClick={() => {
+                        setIsWorkspaceTemplateMenuOpen(prev => !prev);
+                        setIsWorkspaceAddMenuOpen(false);
+                      }}
+                      title="Manage snap templates"
+                      aria-label="Manage snap templates"
+                    >
+                      {icons.saveLayout}
+                    </button>
+                    {renderWorkspaceTemplateMenu()}
+                  </div>
+                  <button
+                    type="button"
+                    className="workspace-split-button"
+                    onClick={handleReturnToSplitView}
+                    title="Return to split view"
+                    aria-label="Return to split view"
+                  >
+                    {icons.split}
+                  </button>
+                </>
               )}
             </>
           )}
-          <div className="workspace-add-control">
-            <button
-              type="button"
-              className="workspace-add-button"
-              onClick={() => setIsWorkspaceAddMenuOpen(prev => !prev)}
-              title="Add workspace panel"
-              aria-label="Add workspace panel"
-            >
-              {icons.add}
-            </button>
-            {renderWorkspaceAddMenu()}
-          </div>
+          {isDesktopWorkspace && (
+            <div className="workspace-add-control">
+              <button
+                type="button"
+                className="workspace-add-button"
+                onClick={() => {
+                  setIsWorkspaceAddMenuOpen(prev => !prev);
+                  setIsWorkspaceTemplateMenuOpen(false);
+                }}
+                title="Add workspace panel"
+                aria-label="Add workspace panel"
+              >
+                {icons.add}
+              </button>
+              {renderWorkspaceAddMenu()}
+            </div>
+          )}
         </div>
         <div className="status-controls">
           <div

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -1815,24 +1815,22 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     return (
       <div className="workspace-pad-component">
         <div className="workspace-pad-selector">
-          <div className="workspace-pad-select-field">
-            <label htmlFor={`workspace-pad-select-${panel.id}`}>Pad layout</label>
-            {gamepadLibrary.length > 0 ? (
-              <select
-                id={`workspace-pad-select-${panel.id}`}
-                value={selectedLayoutId}
-                onChange={(event) => handleWorkspacePadLayoutChange(panel.id, event.target.value)}
-              >
-                {gamepadLibrary.map(item => (
-                  <option key={item.id} value={item.id}>
-                    {item.name}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <span className="workspace-pad-selector-empty">No pads</span>
-            )}
-          </div>
+          <label htmlFor={`workspace-pad-select-${panel.id}`}>Pad layout</label>
+          {gamepadLibrary.length > 0 ? (
+            <select
+              id={`workspace-pad-select-${panel.id}`}
+              value={selectedLayoutId}
+              onChange={(event) => handleWorkspacePadLayoutChange(panel.id, event.target.value)}
+            >
+              {gamepadLibrary.map(item => (
+                <option key={item.id} value={item.id}>
+                  {item.name}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span className="workspace-pad-selector-empty">No pads</span>
+          )}
           <button
             type="button"
             className="workspace-pad-create-button"

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -181,6 +181,8 @@ const WORKSPACE_PANELS_KEY = 'robo-boy-desktop-workspace-panels-v1';
 const WORKSPACE_LAYOUT_KEY = 'robo-boy-desktop-workspace-layout-v1';
 const WORKSPACE_TILE_ORDER_KEY = 'robo-boy-desktop-workspace-tile-order-v1';
 const WORKSPACE_CUSTOM_TEMPLATES_KEY = 'robo-boy-desktop-workspace-custom-templates-v1';
+const WORKSPACE_SAVED_LAYOUTS_KEY = 'robo-boy-desktop-workspace-saved-layouts-v1';
+const WORKSPACE_ACTIVE_LAYOUT_KEY = 'robo-boy-desktop-workspace-active-layout-v1';
 const DESKTOP_WORKSPACE_QUERY = '(min-width: 1024px)';
 const WORKSPACE_DRAG_FORMAT = 'application/x-robo-boy-workspace-panel';
 const WORKSPACE_TILE_DRAG_FORMAT = 'application/x-robo-boy-workspace-tile';
@@ -194,6 +196,11 @@ type WorkspaceSnapTarget = {
   templateId: string;
   zoneIndex: number;
 };
+
+type WorkspaceDropPlacement =
+  | { mode: 'column'; targetTileId: string; edge: 'before' | 'after' }
+  | { mode: 'row'; targetTileId: string; edge: 'before' | 'after' }
+  | { mode: 'end' };
 
 type WorkspaceInteraction =
   | {
@@ -285,6 +292,16 @@ type WorkspaceLayoutState = {
   rowSizes?: number[];
 };
 
+type SavedWorkspaceLayout = {
+  id: string;
+  title: string;
+  panels: WorkspacePanel[];
+  tileOrder: string[];
+  layout: WorkspaceLayoutState;
+  createdAt: string;
+  updatedAt: string;
+};
+
 type WorkspaceSnapTemplate = {
   id: string;
   title: string;
@@ -327,6 +344,81 @@ const loadWorkspaceLayout = (): WorkspaceLayoutState => {
   } catch (error) {
     console.error('Failed to load desktop workspace layout:', error);
     return { rowRatios: [], columnRatiosByRow: {} };
+  }
+};
+
+const normalizeWorkspaceLayoutState = (layout: unknown): WorkspaceLayoutState => {
+  if (!layout || typeof layout !== 'object') {
+    return { rowRatios: [], columnRatiosByRow: {} };
+  }
+
+  const candidate = layout as Partial<WorkspaceLayoutState>;
+  return {
+    rowRatios: Array.isArray(candidate.rowRatios)
+      ? candidate.rowRatios.filter(value => typeof value === 'number' && Number.isFinite(value) && value > 0)
+      : [],
+    columnRatiosByRow: candidate.columnRatiosByRow && typeof candidate.columnRatiosByRow === 'object'
+      ? Object.entries(candidate.columnRatiosByRow).reduce<Record<number, number[]>>((ratiosByRow, [key, value]) => {
+        if (Array.isArray(value)) {
+          const numericRatios = value.filter(item => typeof item === 'number' && Number.isFinite(item) && item > 0);
+          if (numericRatios.length > 0) ratiosByRow[Number(key)] = numericRatios;
+        }
+        return ratiosByRow;
+      }, {})
+      : {},
+    rowSizes: Array.isArray(candidate.rowSizes)
+      ? candidate.rowSizes.filter(value => Number.isInteger(value) && value > 0)
+      : undefined,
+  };
+};
+
+const normalizeSavedWorkspaceLayout = (layout: unknown): SavedWorkspaceLayout | null => {
+  if (!layout || typeof layout !== 'object') return null;
+  const candidate = layout as Partial<SavedWorkspaceLayout>;
+  if (typeof candidate.id !== 'string' || typeof candidate.title !== 'string') return null;
+
+  const panels = Array.isArray(candidate.panels)
+    ? candidate.panels.map(panel => normalizeWorkspacePanel(panel)).filter(isWorkspacePanel)
+    : [];
+  const tileOrder = normalizeWorkspaceTileOrder(
+    Array.isArray(candidate.tileOrder)
+      ? candidate.tileOrder.filter(item => typeof item === 'string')
+      : BASE_WORKSPACE_TILE_IDS,
+    panels.map(panel => panel.id)
+  );
+
+  return {
+    id: candidate.id,
+    title: candidate.title.trim() || 'Workspace layout',
+    panels,
+    tileOrder,
+    layout: normalizeWorkspaceLayoutState(candidate.layout),
+    createdAt: typeof candidate.createdAt === 'string' ? candidate.createdAt : new Date().toISOString(),
+    updatedAt: typeof candidate.updatedAt === 'string' ? candidate.updatedAt : new Date().toISOString(),
+  };
+};
+
+const loadSavedWorkspaceLayouts = (): SavedWorkspaceLayout[] => {
+  try {
+    const stored = localStorage.getItem(WORKSPACE_SAVED_LAYOUTS_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed)
+      ? parsed.map(layout => normalizeSavedWorkspaceLayout(layout)).filter((layout): layout is SavedWorkspaceLayout => layout !== null)
+      : [];
+  } catch (error) {
+    console.error('Failed to load saved desktop workspace layouts:', error);
+    return [];
+  }
+};
+
+const loadActiveWorkspaceLayoutId = (): string | null => {
+  try {
+    const stored = localStorage.getItem(WORKSPACE_ACTIVE_LAYOUT_KEY);
+    return stored || null;
+  } catch (error) {
+    console.error('Failed to load active desktop workspace layout:', error);
+    return null;
   }
 };
 
@@ -480,6 +572,30 @@ const getWorkspaceSnapTemplates = (tileCount: number, templates: WorkspaceSnapTe
   ));
 };
 
+const getWorkspaceLayoutSignature = (
+  panels: WorkspacePanel[],
+  tileOrder: string[],
+  layout: WorkspaceLayoutState
+) => {
+  const normalizedTileOrder = normalizeWorkspaceTileOrder(tileOrder, panels.map(panel => panel.id));
+  const normalizedLayout = normalizeWorkspaceLayoutState(layout);
+  const rowSizes = buildWorkspaceRows(normalizedTileOrder, normalizedLayout.rowSizes).map(row => row.length);
+  const columnRatiosByRow = rowSizes.reduce<Record<number, number[]>>((ratiosByRow, rowSize, rowIndex) => {
+    ratiosByRow[rowIndex] = normalizeRatios(normalizedLayout.columnRatiosByRow[rowIndex], rowSize);
+    return ratiosByRow;
+  }, {});
+
+  return JSON.stringify({
+    panels,
+    tileOrder: normalizedTileOrder,
+    layout: {
+      rowSizes,
+      rowRatios: normalizeRatios(normalizedLayout.rowRatios, rowSizes.length),
+      columnRatiosByRow,
+    },
+  });
+};
+
 const createWorkspaceLayoutFromTemplate = (
   template: WorkspaceSnapTemplate,
   tileCount: number
@@ -510,6 +626,55 @@ const createWorkspaceLayoutFromTemplate = (
   };
 };
 
+const createWorkspaceLayoutFromRows = (rows: string[][]): WorkspaceLayoutState => ({
+  rowSizes: rows.map(row => row.length),
+  rowRatios: Array.from({ length: rows.length }, () => 1),
+  columnRatiosByRow: rows.reduce<Record<number, number[]>>((ratiosByRow, row, rowIndex) => {
+    ratiosByRow[rowIndex] = Array.from({ length: row.length }, () => 1);
+    return ratiosByRow;
+  }, {}),
+});
+
+const applyWorkspaceDropPlacement = (
+  currentOrder: string[],
+  rowSizes: number[] | undefined,
+  tileId: string,
+  placement: WorkspaceDropPlacement,
+  movedTileId?: string
+) => {
+  const sourceRows = buildWorkspaceRows(currentOrder, rowSizes).map(row => [...row]);
+  const rows = sourceRows
+    .map(row => row.filter(id => id !== movedTileId && id !== tileId))
+    .filter(row => row.length > 0);
+
+  if (placement.mode === 'end' || rows.length === 0) {
+    rows.push([tileId]);
+  } else {
+    const targetRowIndex = rows.findIndex(row => row.includes(placement.targetTileId));
+    if (targetRowIndex === -1) {
+      rows.push([tileId]);
+    } else if (placement.mode === 'row') {
+      rows.splice(
+        placement.edge === 'before' ? targetRowIndex : targetRowIndex + 1,
+        0,
+        [tileId]
+      );
+    } else {
+      const targetColumnIndex = rows[targetRowIndex].indexOf(placement.targetTileId);
+      rows[targetRowIndex].splice(
+        placement.edge === 'before' ? targetColumnIndex : targetColumnIndex + 1,
+        0,
+        tileId
+      );
+    }
+  }
+
+  return {
+    order: rows.flat(),
+    layout: createWorkspaceLayoutFromRows(rows),
+  };
+};
+
 const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onDisconnect }) => {
   const [viewMode, setViewMode] = useState<ViewMode>('camera');
   const [isWorkspaceOpen, setIsWorkspaceOpen] = useState(false);
@@ -517,14 +682,16 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const [workspaceLayout, setWorkspaceLayout] = useState<WorkspaceLayoutState>(loadWorkspaceLayout);
   const [workspaceTileOrder, setWorkspaceTileOrder] = useState<string[]>(loadWorkspaceTileOrder);
   const [customWorkspaceSnapTemplates, setCustomWorkspaceSnapTemplates] = useState<WorkspaceSnapTemplate[]>(loadWorkspaceCustomTemplates);
+  const [savedWorkspaceLayouts, setSavedWorkspaceLayouts] = useState<SavedWorkspaceLayout[]>(loadSavedWorkspaceLayouts);
+  const [activeWorkspaceLayoutId, setActiveWorkspaceLayoutId] = useState<string | null>(loadActiveWorkspaceLayoutId);
   const [isWorkspaceAddMenuOpen, setIsWorkspaceAddMenuOpen] = useState(false);
   const [isWorkspaceTemplateMenuOpen, setIsWorkspaceTemplateMenuOpen] = useState(false);
-  const [workspaceTemplateName, setWorkspaceTemplateName] = useState('');
+  const [workspaceLayoutName, setWorkspaceLayoutName] = useState('');
   const [isWorkspaceDragActive, setIsWorkspaceDragActive] = useState(false);
   const [workspaceDragKind, setWorkspaceDragKind] = useState<'new' | 'move' | null>(null);
   const [workspaceSnapTarget, setWorkspaceSnapTarget] = useState<WorkspaceSnapTarget | null>(null);
   const [isWorkspaceResizing, setIsWorkspaceResizing] = useState(false);
-  const [workspaceDropIndex, setWorkspaceDropIndex] = useState<number | null>(null);
+  const [workspaceDropPlacement, setWorkspaceDropPlacement] = useState<WorkspaceDropPlacement | null>(null);
   const [lastAddedWorkspacePanelId, setLastAddedWorkspacePanelId] = useState<string | null>(null);
   const [isLargeScreen, setIsLargeScreen] = useState(() => {
     if (typeof window === 'undefined' || !window.matchMedia) return true;
@@ -564,6 +731,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const workspaceRef = useRef<HTMLDivElement>(null);
   const workspaceInteractionRef = useRef<WorkspaceInteraction | null>(null);
   const templateImportInputRef = useRef<HTMLInputElement>(null);
+  const workspaceTemplateControlRef = useRef<HTMLDivElement>(null);
+  const workspaceAddControlRef = useRef<HTMLDivElement>(null);
   const [isTransitioning, setIsTransitioning] = useState(false);
 
   const isDesktopWorkspace = isLargeScreen && isWorkspaceOpen;
@@ -594,6 +763,40 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       row.length
     ))
   ), [workspaceLayout.columnRatiosByRow, workspaceRows]);
+  const capturedWorkspaceLayout = useMemo<WorkspaceLayoutState>(() => {
+    const rowSizes = workspaceRows.map(row => row.length);
+    const columnRatiosByRow = rowSizes.reduce<Record<number, number[]>>((ratiosByRow, rowSize, rowIndex) => {
+      ratiosByRow[rowIndex] = workspaceColumnRatiosByRow[rowIndex]?.length === rowSize
+        ? workspaceColumnRatiosByRow[rowIndex]
+        : Array.from({ length: rowSize }, () => 1);
+      return ratiosByRow;
+    }, {});
+
+    return {
+      rowSizes,
+      rowRatios: workspaceRowRatios.length === rowSizes.length
+        ? workspaceRowRatios
+        : Array.from({ length: rowSizes.length }, () => 1),
+      columnRatiosByRow,
+    };
+  }, [workspaceColumnRatiosByRow, workspaceRowRatios, workspaceRows]);
+  const activeWorkspaceLayout = useMemo(
+    () => savedWorkspaceLayouts.find(layout => layout.id === activeWorkspaceLayoutId) || null,
+    [activeWorkspaceLayoutId, savedWorkspaceLayouts]
+  );
+  const currentWorkspaceLayoutSignature = useMemo(
+    () => getWorkspaceLayoutSignature(workspacePanels, normalizedWorkspaceTileOrder, capturedWorkspaceLayout),
+    [capturedWorkspaceLayout, normalizedWorkspaceTileOrder, workspacePanels]
+  );
+  const activeWorkspaceLayoutSignature = useMemo(
+    () => activeWorkspaceLayout
+      ? getWorkspaceLayoutSignature(activeWorkspaceLayout.panels, activeWorkspaceLayout.tileOrder, activeWorkspaceLayout.layout)
+      : null,
+    [activeWorkspaceLayout]
+  );
+  const isActiveWorkspaceLayoutDirty = Boolean(
+    activeWorkspaceLayout && activeWorkspaceLayoutSignature !== currentWorkspaceLayoutSignature
+  );
   const getWorkspaceTileIndex = (rowIndex: number, columnIndex: number) => {
     return workspaceRows
       .slice(0, rowIndex)
@@ -630,6 +833,24 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   }, [customWorkspaceSnapTemplates]);
 
   useEffect(() => {
+    localStorage.setItem(WORKSPACE_SAVED_LAYOUTS_KEY, JSON.stringify(savedWorkspaceLayouts));
+  }, [savedWorkspaceLayouts]);
+
+  useEffect(() => {
+    if (activeWorkspaceLayoutId) {
+      localStorage.setItem(WORKSPACE_ACTIVE_LAYOUT_KEY, activeWorkspaceLayoutId);
+    } else {
+      localStorage.removeItem(WORKSPACE_ACTIVE_LAYOUT_KEY);
+    }
+  }, [activeWorkspaceLayoutId]);
+
+  useEffect(() => {
+    if (activeWorkspaceLayoutId && !savedWorkspaceLayouts.some(layout => layout.id === activeWorkspaceLayoutId)) {
+      setActiveWorkspaceLayoutId(null);
+    }
+  }, [activeWorkspaceLayoutId, savedWorkspaceLayouts]);
+
+  useEffect(() => {
     const normalizedOrder = normalizeWorkspaceTileOrder(
       workspaceTileOrder,
       workspacePanels.map(panel => panel.id)
@@ -656,6 +877,46 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       mediaQuery.removeEventListener('change', handleMediaChange);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isWorkspaceTemplateMenuOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        workspaceTemplateControlRef.current &&
+        !workspaceTemplateControlRef.current.contains(target)
+      ) {
+        setIsWorkspaceTemplateMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+    };
+  }, [isWorkspaceTemplateMenuOpen]);
+
+  useEffect(() => {
+    if (!isWorkspaceAddMenuOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        workspaceAddControlRef.current &&
+        !workspaceAddControlRef.current.contains(target)
+      ) {
+        setIsWorkspaceAddMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+    };
+  }, [isWorkspaceAddMenuOpen]);
 
   // Fetch topics when connected
   useEffect(() => {
@@ -895,7 +1156,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     setWorkspaceDragKind(null);
     setWorkspaceSnapTarget(null);
     setIsWorkspaceResizing(false);
-    setWorkspaceDropIndex(null);
+    setWorkspaceDropPlacement(null);
   };
 
   const handleWorkspaceDragStart = (
@@ -924,7 +1185,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     setIsWorkspaceDragActive(false);
     setWorkspaceDragKind(null);
     setWorkspaceSnapTarget(null);
-    setWorkspaceDropIndex(null);
+    setWorkspaceDropPlacement(null);
   };
 
   const handleWorkspaceDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -935,14 +1196,14 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       event.preventDefault();
       event.dataTransfer.dropEffect = event.dataTransfer.types.includes(WORKSPACE_TILE_DRAG_FORMAT) ? 'move' : 'copy';
       setWorkspaceSnapTarget(null);
-      setWorkspaceDropIndex(getWorkspaceDropIndex(event.clientX, event.clientY));
+      setWorkspaceDropPlacement(getWorkspaceDropPlacement(event.clientX, event.clientY));
     }
   };
 
   const handleWorkspaceDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
     const nextTarget = event.relatedTarget;
     if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
-    setWorkspaceDropIndex(null);
+    setWorkspaceDropPlacement(null);
     setWorkspaceSnapTarget(null);
   };
 
@@ -958,25 +1219,42 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     event.stopPropagation();
     event.dataTransfer.dropEffect = workspaceDragKind === 'move' ? 'move' : 'copy';
     setWorkspaceSnapTarget(target);
-    setWorkspaceDropIndex(null);
+    setWorkspaceDropPlacement(null);
   };
 
-  const getWorkspaceDropIndex = (clientX: number, clientY: number) => {
-    if (!workspaceRef.current) return workspaceTiles.length;
+  const getWorkspaceDropPlacement = (clientX: number, clientY: number): WorkspaceDropPlacement => {
+    if (!workspaceRef.current) return { mode: 'end' };
 
     const cards = Array.from(workspaceRef.current.querySelectorAll<HTMLElement>('.workspace-card'));
-    for (let index = 0; index < cards.length; index += 1) {
-      const rect = cards[index].getBoundingClientRect();
-      const isAboveCardCenter = clientY < rect.top + rect.height / 2;
-      const isWithinCardRow = clientY >= rect.top && clientY <= rect.bottom;
-      const isBeforeCardCenter = clientX < rect.left + rect.width / 2;
+    for (const card of cards) {
+      const rect = card.getBoundingClientRect();
+      const targetTileId = card.dataset.workspaceCardId;
+      if (!targetTileId) continue;
 
-      if (isAboveCardCenter || (isWithinCardRow && isBeforeCardCenter)) {
-        return index;
+      const isWithinCard = (
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top &&
+        clientY <= rect.bottom
+      );
+      if (!isWithinCard) continue;
+
+      const verticalRatio = (clientY - rect.top) / rect.height;
+      if (verticalRatio < 0.28) {
+        return { mode: 'row', targetTileId, edge: 'before' };
       }
+      if (verticalRatio > 0.72) {
+        return { mode: 'row', targetTileId, edge: 'after' };
+      }
+
+      return {
+        mode: 'column',
+        targetTileId,
+        edge: clientX < rect.left + rect.width / 2 ? 'before' : 'after',
+      };
     }
 
-    return workspaceTiles.length;
+    return { mode: 'end' };
   };
 
   const handleWorkspaceDrop = (event: React.DragEvent<HTMLDivElement>) => {
@@ -987,26 +1265,42 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       setWorkspaceDragKind(null);
       const snapTarget = workspaceSnapTarget;
       setWorkspaceSnapTarget(null);
-      setWorkspaceDropIndex(null);
+      const dropPlacement = workspaceDropPlacement || getWorkspaceDropPlacement(event.clientX, event.clientY);
+      setWorkspaceDropPlacement(null);
       const snapTemplate = snapTarget ? getWorkspaceSnapTemplate(snapTarget.templateId) : null;
-      const dropIndex = snapTarget ? snapTarget.zoneIndex : getWorkspaceDropIndex(event.clientX, event.clientY);
+      const snapZoneIndex = snapTarget?.zoneIndex;
       setWorkspaceTileOrder(prevOrder => {
         const currentOrder = normalizeWorkspaceTileOrder(prevOrder, workspacePanels.map(panel => panel.id));
         const fromIndex = currentOrder.indexOf(movedTileId);
         if (fromIndex === -1) return currentOrder;
 
-        const nextOrder = [...currentOrder];
-        const [movedId] = nextOrder.splice(fromIndex, 1);
-        const adjustedDropIndex = dropIndex > fromIndex ? dropIndex - 1 : dropIndex;
-        nextOrder.splice(clamp(adjustedDropIndex, 0, nextOrder.length), 0, movedId);
         if (snapTemplate) {
+          const nextOrder = [...currentOrder];
+          const [movedId] = nextOrder.splice(fromIndex, 1);
+          const targetIndex = snapZoneIndex ?? nextOrder.length;
+          const adjustedDropIndex = targetIndex > fromIndex ? targetIndex - 1 : targetIndex;
+          nextOrder.splice(clamp(adjustedDropIndex, 0, nextOrder.length), 0, movedId);
           setWorkspaceLayout(createWorkspaceLayoutFromTemplate(snapTemplate, nextOrder.length));
+          return nextOrder;
         }
-        return nextOrder;
+
+        if (
+          dropPlacement.mode !== 'end' &&
+          dropPlacement.targetTileId === movedTileId
+        ) {
+          return currentOrder;
+        }
+
+        const result = applyWorkspaceDropPlacement(
+          currentOrder,
+          capturedWorkspaceLayout.rowSizes,
+          movedTileId,
+          dropPlacement,
+          movedTileId
+        );
+        setWorkspaceLayout(result.layout);
+        return result.order;
       });
-      if (!snapTemplate) {
-        resetWorkspaceLayout();
-      }
       return;
     }
 
@@ -1018,14 +1312,47 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     setWorkspaceDragKind(null);
     const snapTarget = workspaceSnapTarget;
     setWorkspaceSnapTarget(null);
-    setWorkspaceDropIndex(null);
+    const dropPlacement = workspaceDropPlacement || getWorkspaceDropPlacement(event.clientX, event.clientY);
+    setWorkspaceDropPlacement(null);
     try {
       const draft = JSON.parse(payload) as WorkspaceDraft;
       if (!['camera', '3d', 'pad', 'behaviorTree'].includes(draft.type)) return;
 
       const snapTemplate = snapTarget ? getWorkspaceSnapTemplate(snapTarget.templateId) : null;
-      const tileIndex = snapTarget ? snapTarget.zoneIndex : getWorkspaceDropIndex(event.clientX, event.clientY);
-      handleAddWorkspacePanel(draft.type, tileIndex, snapTemplate || undefined);
+      const tileIndex = snapTarget ? snapTarget.zoneIndex : undefined;
+      const selectedPadPanel = selectedPanelId
+        ? activePanels.find(panel => panel.id === selectedPanelId)
+        : null;
+      const newPanel = createWorkspacePanel(
+        { type: draft.type },
+        {
+          cameraTopic: selectedCameraTopic || availableCameraTopics[0],
+          layoutId: selectedPadPanel?.layoutId || gamepadLibrary[0]?.id,
+        }
+      );
+
+      setWorkspacePanels(prev => [...prev, newPanel]);
+      setWorkspaceTileOrder(prevOrder => {
+        const currentOrder = normalizeWorkspaceTileOrder(prevOrder, workspacePanels.map(panel => panel.id));
+        if (snapTemplate && typeof tileIndex === 'number') {
+          const nextOrder = [...currentOrder];
+          nextOrder.splice(clamp(tileIndex, 0, nextOrder.length), 0, newPanel.id);
+          setWorkspaceLayout(createWorkspaceLayoutFromTemplate(snapTemplate, nextOrder.length));
+          return nextOrder;
+        }
+
+        const result = applyWorkspaceDropPlacement(
+          currentOrder,
+          capturedWorkspaceLayout.rowSizes,
+          newPanel.id,
+          dropPlacement
+        );
+        setWorkspaceLayout(result.layout);
+        return result.order;
+      });
+      setLastAddedWorkspacePanelId(newPanel.id);
+      setIsWorkspaceAddMenuOpen(false);
+      setIsWorkspaceTemplateMenuOpen(false);
     } catch (error) {
       console.error('Failed to add dropped workspace panel:', error);
     }
@@ -1189,56 +1516,96 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     handleOpenCustomEditor();
   };
 
-  const handleSaveWorkspaceTemplate = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (workspaceTiles.length === 0 || workspaceRows.length === 0) return;
+  const createSavedWorkspaceSnapshot = (
+    title: string,
+    existingLayout?: SavedWorkspaceLayout
+  ): SavedWorkspaceLayout => {
+    const now = new Date().toISOString();
+    const panels = workspacePanels.map(panel => ({ ...panel }));
+    const tileOrder = normalizeWorkspaceTileOrder(
+      normalizedWorkspaceTileOrder,
+      panels.map(panel => panel.id)
+    );
 
-    const title = workspaceTemplateName.trim() || `Custom ${customWorkspaceSnapTemplates.length + 1}`;
-    const rowSizes = workspaceRows.map(row => row.length);
-    const columnRatiosByRow = rowSizes.reduce<Record<number, number[]>>((ratiosByRow, rowSize, rowIndex) => {
-      ratiosByRow[rowIndex] = workspaceColumnRatiosByRow[rowIndex]?.length === rowSize
-        ? workspaceColumnRatiosByRow[rowIndex]
-        : Array.from({ length: rowSize }, () => 1);
-      return ratiosByRow;
-    }, {});
-
-    const newTemplate: WorkspaceSnapTemplate = {
-      id: `custom-${Date.now()}`,
+    return {
+      id: existingLayout?.id || `workspace-layout-${Date.now()}`,
       title,
-      rowSizes,
-      rowRatios: workspaceRowRatios.length === rowSizes.length
-        ? workspaceRowRatios
-        : Array.from({ length: rowSizes.length }, () => 1),
-      columnRatiosByRow,
-      isCustom: true,
+      panels,
+      tileOrder,
+      layout: capturedWorkspaceLayout,
+      createdAt: existingLayout?.createdAt || now,
+      updatedAt: now,
     };
-
-    setCustomWorkspaceSnapTemplates(prev => [...prev, newTemplate]);
-    setWorkspaceTemplateName('');
   };
 
-  const handleDeleteWorkspaceTemplate = (templateId: string) => {
-    setCustomWorkspaceSnapTemplates(prev => prev.filter(template => template.id !== templateId));
+  const getNextWorkspaceLayoutTitle = () => `Workspace ${savedWorkspaceLayouts.length + 1}`;
+
+  const handleSaveWorkspaceLayout = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (workspaceTiles.length === 0) return;
+
+    const existingLayout = activeWorkspaceLayout || undefined;
+    const title = workspaceLayoutName.trim() || existingLayout?.title || getNextWorkspaceLayoutTitle();
+    const savedLayout = createSavedWorkspaceSnapshot(title, existingLayout);
+
+    setSavedWorkspaceLayouts(prev => {
+      if (!existingLayout) return [...prev, savedLayout];
+      return prev.map(layout => layout.id === existingLayout.id ? savedLayout : layout);
+    });
+    setActiveWorkspaceLayoutId(savedLayout.id);
+    setWorkspaceLayoutName('');
   };
 
-  const handleExportWorkspaceTemplates = () => {
-    if (customWorkspaceSnapTemplates.length === 0) return;
+  const handleSaveWorkspaceLayoutAsNew = () => {
+    if (workspaceTiles.length === 0) return;
+
+    const title = workspaceLayoutName.trim() || getNextWorkspaceLayoutTitle();
+    const savedLayout = createSavedWorkspaceSnapshot(title);
+    setSavedWorkspaceLayouts(prev => [...prev, savedLayout]);
+    setActiveWorkspaceLayoutId(savedLayout.id);
+    setWorkspaceLayoutName('');
+  };
+
+  const handleDeleteSavedWorkspaceLayout = (layoutId: string) => {
+    setSavedWorkspaceLayouts(prev => prev.filter(layout => layout.id !== layoutId));
+    if (activeWorkspaceLayoutId === layoutId) {
+      setActiveWorkspaceLayoutId(null);
+    }
+  };
+
+  const handleLoadSavedWorkspaceLayout = (layout: SavedWorkspaceLayout) => {
+    const normalizedTileOrder = normalizeWorkspaceTileOrder(
+      layout.tileOrder,
+      layout.panels.map(panel => panel.id)
+    );
+    setWorkspacePanels(layout.panels.map(panel => ({ ...panel })));
+    setWorkspaceTileOrder(normalizedTileOrder);
+    setWorkspaceLayout(layout.layout);
+    setActiveWorkspaceLayoutId(layout.id);
+    setWorkspaceLayoutName('');
+    setIsWorkspaceOpen(true);
+    setIsWorkspaceTemplateMenuOpen(false);
+    setIsWorkspaceAddMenuOpen(false);
+  };
+
+  const handleExportWorkspaceLayouts = () => {
+    if (savedWorkspaceLayouts.length === 0) return;
 
     const blob = new Blob([
       JSON.stringify({
         version: 1,
-        templates: customWorkspaceSnapTemplates,
+        layouts: savedWorkspaceLayouts,
       }, null, 2),
     ], { type: 'application/json' });
     const objectUrl = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = objectUrl;
-    link.download = 'robo-boy-workspace-templates.json';
+    link.download = 'robo-boy-workspace-layouts.json';
     link.click();
     URL.revokeObjectURL(objectUrl);
   };
 
-  const handleImportWorkspaceTemplates = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImportWorkspaceLayouts = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = '';
     if (!file) return;
@@ -1247,21 +1614,24 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     reader.onload = () => {
       try {
         const parsed = JSON.parse(String(reader.result || ''));
-        const candidates = Array.isArray(parsed) ? parsed : parsed?.templates;
+        const candidates = Array.isArray(parsed) ? parsed : parsed?.layouts;
         if (!Array.isArray(candidates)) return;
 
-        const importedTemplates = candidates
-          .map(template => normalizeWorkspaceSnapTemplate(template))
-          .filter((template): template is WorkspaceSnapTemplate => template !== null)
-          .map(template => ({
-            ...template,
-            id: `custom-${Date.now()}-${template.id}`,
+        const importedLayouts = candidates
+          .map(layout => normalizeSavedWorkspaceLayout(layout))
+          .filter((layout): layout is SavedWorkspaceLayout => layout !== null)
+          .map(layout => ({
+            ...layout,
+            id: `workspace-layout-${Date.now()}-${layout.id}`,
+            title: layout.title,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
           }));
 
-        if (importedTemplates.length === 0) return;
-        setCustomWorkspaceSnapTemplates(prev => [...prev, ...importedTemplates]);
+        if (importedLayouts.length === 0) return;
+        setSavedWorkspaceLayouts(prev => [...prev, ...importedLayouts]);
       } catch (error) {
-        console.error('Failed to import workspace templates:', error);
+        console.error('Failed to import workspace layouts:', error);
       }
     };
     reader.readAsText(file);
@@ -1270,8 +1640,10 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const handleAutoTileWorkspacePanels = () => {
     setIsWorkspaceOpen(true);
     setIsWorkspaceDragActive(false);
-    setWorkspaceDropIndex(null);
-    resetWorkspaceLayout();
+    setWorkspaceDropPlacement(null);
+    if (isDesktopWorkspace) {
+      resetWorkspaceLayout();
+    }
     setIsWorkspaceAddMenuOpen(false);
     setIsWorkspaceTemplateMenuOpen(false);
   };
@@ -1443,28 +1815,30 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     return (
       <div className="workspace-pad-component">
         <div className="workspace-pad-selector">
-          <label htmlFor={`workspace-pad-select-${panel.id}`}>Pad</label>
-          {gamepadLibrary.length > 0 ? (
-            <select
-              id={`workspace-pad-select-${panel.id}`}
-              value={selectedLayoutId}
-              onChange={(event) => handleWorkspacePadLayoutChange(panel.id, event.target.value)}
-            >
-              {gamepadLibrary.map(item => (
-                <option key={item.id} value={item.id}>
-                  {item.name}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <span className="workspace-pad-selector-empty">No pads</span>
-          )}
+          <div className="workspace-pad-select-field">
+            <label htmlFor={`workspace-pad-select-${panel.id}`}>Pad layout</label>
+            {gamepadLibrary.length > 0 ? (
+              <select
+                id={`workspace-pad-select-${panel.id}`}
+                value={selectedLayoutId}
+                onChange={(event) => handleWorkspacePadLayoutChange(panel.id, event.target.value)}
+              >
+                {gamepadLibrary.map(item => (
+                  <option key={item.id} value={item.id}>
+                    {item.name}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <span className="workspace-pad-selector-empty">No pads</span>
+            )}
+          </div>
           <button
             type="button"
             className="workspace-pad-create-button"
             onClick={() => handleOpenWorkspacePadEditor(panel.id)}
-            title="Create pad for this component"
-            aria-label="Create pad for this component"
+            title="Create new pad"
+            aria-label="Create new pad"
           >
             {icons.add}
           </button>
@@ -1595,42 +1969,53 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
     return (
       <div className="workspace-template-menu">
-        <form className="workspace-template-form" onSubmit={handleSaveWorkspaceTemplate}>
-          <label htmlFor="workspace-template-name">Name</label>
+        <form className="workspace-template-form" onSubmit={handleSaveWorkspaceLayout}>
+          <label htmlFor="workspace-layout-name">Layout name</label>
           <div className="workspace-template-form-row">
             <input
-              id="workspace-template-name"
-              value={workspaceTemplateName}
-              onChange={(event) => setWorkspaceTemplateName(event.target.value)}
-              placeholder={`Custom ${customWorkspaceSnapTemplates.length + 1}`}
+              id="workspace-layout-name"
+              value={workspaceLayoutName}
+              onChange={(event) => setWorkspaceLayoutName(event.target.value)}
+              placeholder={activeWorkspaceLayout?.title || getNextWorkspaceLayoutTitle()}
               maxLength={28}
             />
             <button
               type="submit"
               disabled={workspaceTiles.length === 0}
-              title="Save current template"
-              aria-label="Save current template"
+              title={activeWorkspaceLayout ? 'Update current layout' : 'Save current layout'}
+              aria-label={activeWorkspaceLayout ? 'Update current layout' : 'Save current layout'}
             >
               {icons.saveLayout}
             </button>
+            {activeWorkspaceLayout && (
+              <button
+                type="button"
+                onClick={handleSaveWorkspaceLayoutAsNew}
+                disabled={workspaceTiles.length === 0}
+                title="Save as new layout"
+                aria-label="Save as new layout"
+              >
+                {icons.add}
+              </button>
+            )}
           </div>
         </form>
         <div className="workspace-template-transfer-row">
           <button
             type="button"
             onClick={() => templateImportInputRef.current?.click()}
-            title="Import templates"
-            aria-label="Import templates"
+            title="Import layouts"
+            aria-label="Import layouts"
           >
             {icons.upload}
             <span>Import</span>
           </button>
           <button
             type="button"
-            onClick={handleExportWorkspaceTemplates}
-            disabled={customWorkspaceSnapTemplates.length === 0}
-            title="Export templates"
-            aria-label="Export templates"
+            onClick={handleExportWorkspaceLayouts}
+            disabled={savedWorkspaceLayouts.length === 0}
+            title="Export layouts"
+            aria-label="Export layouts"
           >
             {icons.download}
             <span>Export</span>
@@ -1639,25 +2024,44 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
             ref={templateImportInputRef}
             type="file"
             accept="application/json,.json"
-            onChange={handleImportWorkspaceTemplates}
+            onChange={handleImportWorkspaceLayouts}
           />
         </div>
-        {customWorkspaceSnapTemplates.length > 0 && (
+        {savedWorkspaceLayouts.length > 0 ? (
           <div className="workspace-template-list">
-            {customWorkspaceSnapTemplates.map(template => (
-              <div className="workspace-template-item" key={template.id}>
-                <span>{template.title}</span>
+            {savedWorkspaceLayouts.map(layout => (
+              <div
+                className={`workspace-template-item ${layout.id === activeWorkspaceLayoutId ? 'active' : ''}`}
+                key={layout.id}
+              >
                 <button
                   type="button"
-                  onClick={() => handleDeleteWorkspaceTemplate(template.id)}
-                  title={`Delete ${template.title}`}
-                  aria-label={`Delete ${template.title}`}
+                  className="workspace-template-load-row"
+                  onClick={() => handleLoadSavedWorkspaceLayout(layout)}
+                  title={`Load ${layout.title}`}
+                  aria-label={`Load ${layout.title}`}
+                >
+                  <span className="workspace-template-title" title={layout.title}>{layout.title}</span>
+                  {layout.id === activeWorkspaceLayoutId && (
+                    <span className="workspace-template-current">
+                      {isActiveWorkspaceLayoutDirty ? 'Edited' : 'Current'}
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className="workspace-template-delete-button"
+                  onClick={() => handleDeleteSavedWorkspaceLayout(layout.id)}
+                  title={`Delete ${layout.title}`}
+                  aria-label={`Delete ${layout.title}`}
                 >
                   {icons.trash}
                 </button>
               </div>
             ))}
           </div>
+        ) : (
+          <div className="workspace-template-empty">No saved layouts yet</div>
         )}
       </div>
     );
@@ -1813,7 +2217,17 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
               </button>
               {isDesktopWorkspace && (
                 <>
-                  <div className="workspace-template-control">
+                  <span
+                    className={`workspace-active-layout-name ${isActiveWorkspaceLayoutDirty ? 'dirty' : ''}`}
+                    title={activeWorkspaceLayout
+                      ? `${activeWorkspaceLayout.title}${isActiveWorkspaceLayoutDirty ? ' (edited)' : ''}`
+                      : 'Unsaved workspace layout'}
+                  >
+                    {activeWorkspaceLayout
+                      ? `${activeWorkspaceLayout.title}${isActiveWorkspaceLayoutDirty ? '*' : ''}`
+                      : 'Unsaved layout'}
+                  </span>
+                  <div className="workspace-template-control" ref={workspaceTemplateControlRef}>
                     <button
                       type="button"
                       className="workspace-template-button"
@@ -1821,8 +2235,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                         setIsWorkspaceTemplateMenuOpen(prev => !prev);
                         setIsWorkspaceAddMenuOpen(false);
                       }}
-                      title="Manage snap templates"
-                      aria-label="Manage snap templates"
+                      title="Manage workspace layouts"
+                      aria-label="Manage workspace layouts"
                     >
                       {icons.saveLayout}
                     </button>
@@ -1842,7 +2256,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
             </>
           )}
           {isDesktopWorkspace && (
-            <div className="workspace-add-control">
+            <div className="workspace-add-control" ref={workspaceAddControlRef}>
               <button
                 type="button"
                 className="workspace-add-button"
@@ -1899,15 +2313,26 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
             <div className="workspace-grid">
               {workspaceRows.map((row, rowIndex) => (
                 <React.Fragment key={`workspace-row-${rowIndex}`}>
+                  {workspaceDropPlacement?.mode === 'row' &&
+                    workspaceDropPlacement.edge === 'before' &&
+                    row.some(tile => tile.id === workspaceDropPlacement.targetTileId) && (
+                      <div className="workspace-drop-indicator workspace-drop-indicator-row" aria-hidden="true" />
+                    )}
                   <div
                     className="workspace-tile-row"
                     style={{ flex: workspaceRowRatios[rowIndex] || 1 }}
                   >
                     {row.map((tile, columnIndex) => {
                       const tileIndex = getWorkspaceTileIndex(rowIndex, columnIndex);
+                      const showColumnDropBefore = workspaceDropPlacement?.mode === 'column' &&
+                        workspaceDropPlacement.edge === 'before' &&
+                        workspaceDropPlacement.targetTileId === tile.id;
+                      const showColumnDropAfter = workspaceDropPlacement?.mode === 'column' &&
+                        workspaceDropPlacement.edge === 'after' &&
+                        workspaceDropPlacement.targetTileId === tile.id;
                       return (
                         <React.Fragment key={tile.id}>
-                          {workspaceDropIndex === tileIndex && (
+                          {showColumnDropBefore && (
                             <div className="workspace-drop-indicator" aria-hidden="true" />
                           )}
                           {tile.kind === 'view' ? (
@@ -1915,6 +2340,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                               className="workspace-card workspace-card-view"
                               aria-label="View component"
                               data-workspace-card-id={tile.id}
+                              data-workspace-row-index={rowIndex}
+                              data-workspace-column-index={columnIndex}
                               style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
                             >
                               <header
@@ -1947,6 +2374,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                               className="workspace-card workspace-card-pads"
                               aria-label="Pad controls component"
                               data-workspace-card-id={tile.id}
+                              data-workspace-row-index={rowIndex}
+                              data-workspace-column-index={columnIndex}
                               style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
                             >
                               <header
@@ -1979,6 +2408,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                               className={`workspace-card workspace-card-${tile.panel.type} ${lastAddedWorkspacePanelId === tile.panel.id ? 'is-settling' : ''}`}
                               aria-label={tile.panel.title}
                               data-workspace-card-id={tile.panel.id}
+                              data-workspace-row-index={rowIndex}
+                              data-workspace-column-index={columnIndex}
                               style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
                               onAnimationEnd={() => {
                                 setLastAddedWorkspacePanelId(prev => prev === tile.panel.id ? null : prev);
@@ -2010,6 +2441,9 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                               </div>
                             </section>
                           )}
+                          {showColumnDropAfter && (
+                            <div className="workspace-drop-indicator" aria-hidden="true" />
+                          )}
                           {columnIndex < row.length - 1 && (
                             <div
                               className="workspace-column-resize-handle"
@@ -2024,10 +2458,15 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                         </React.Fragment>
                       );
                     })}
-                    {rowIndex === workspaceRows.length - 1 && workspaceDropIndex === workspaceTiles.length && (
+                    {rowIndex === workspaceRows.length - 1 && workspaceDropPlacement?.mode === 'end' && (
                       <div className="workspace-drop-indicator workspace-drop-indicator-end" aria-hidden="true" />
                     )}
                   </div>
+                  {workspaceDropPlacement?.mode === 'row' &&
+                    workspaceDropPlacement.edge === 'after' &&
+                    row.some(tile => tile.id === workspaceDropPlacement.targetTileId) && (
+                      <div className="workspace-drop-indicator workspace-drop-indicator-row" aria-hidden="true" />
+                    )}
                   {rowIndex < workspaceRows.length - 1 && (
                     <div
                       className="workspace-row-resize-handle"

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -183,6 +183,7 @@ const WORKSPACE_TILE_ORDER_KEY = 'robo-boy-desktop-workspace-tile-order-v1';
 const WORKSPACE_CUSTOM_TEMPLATES_KEY = 'robo-boy-desktop-workspace-custom-templates-v1';
 const WORKSPACE_SAVED_LAYOUTS_KEY = 'robo-boy-desktop-workspace-saved-layouts-v1';
 const WORKSPACE_ACTIVE_LAYOUT_KEY = 'robo-boy-desktop-workspace-active-layout-v1';
+const WORKSPACE_OPEN_KEY = 'robo-boy-desktop-workspace-open-v1';
 const DESKTOP_WORKSPACE_QUERY = '(min-width: 1024px)';
 const WORKSPACE_DRAG_FORMAT = 'application/x-robo-boy-workspace-panel';
 const WORKSPACE_TILE_DRAG_FORMAT = 'application/x-robo-boy-workspace-tile';
@@ -419,6 +420,15 @@ const loadActiveWorkspaceLayoutId = (): string | null => {
   } catch (error) {
     console.error('Failed to load active desktop workspace layout:', error);
     return null;
+  }
+};
+
+const loadWorkspaceOpenPreference = (): boolean => {
+  try {
+    return localStorage.getItem(WORKSPACE_OPEN_KEY) === 'true';
+  } catch (error) {
+    console.error('Failed to load desktop workspace open preference:', error);
+    return false;
   }
 };
 
@@ -677,7 +687,7 @@ const applyWorkspaceDropPlacement = (
 
 const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onDisconnect }) => {
   const [viewMode, setViewMode] = useState<ViewMode>('camera');
-  const [isWorkspaceOpen, setIsWorkspaceOpen] = useState(false);
+  const [isWorkspaceOpen, setIsWorkspaceOpen] = useState(loadWorkspaceOpenPreference);
   const [workspacePanels, setWorkspacePanels] = useState<WorkspacePanel[]>(loadWorkspacePanels);
   const [workspaceLayout, setWorkspaceLayout] = useState<WorkspaceLayoutState>(loadWorkspaceLayout);
   const [workspaceTileOrder, setWorkspaceTileOrder] = useState<string[]>(loadWorkspaceTileOrder);
@@ -827,6 +837,10 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   useEffect(() => {
     localStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(workspaceLayout));
   }, [workspaceLayout]);
+
+  useEffect(() => {
+    localStorage.setItem(WORKSPACE_OPEN_KEY, String(isWorkspaceOpen));
+  }, [isWorkspaceOpen]);
 
   useEffect(() => {
     localStorage.setItem(WORKSPACE_CUSTOM_TEMPLATES_KEY, JSON.stringify(customWorkspaceSnapTemplates));

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -333,6 +333,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const [workspaceTileOrder, setWorkspaceTileOrder] = useState<string[]>(loadWorkspaceTileOrder);
   const [isWorkspaceAddMenuOpen, setIsWorkspaceAddMenuOpen] = useState(false);
   const [isWorkspaceDragActive, setIsWorkspaceDragActive] = useState(false);
+  const [isWorkspaceResizing, setIsWorkspaceResizing] = useState(false);
   const [workspaceDropIndex, setWorkspaceDropIndex] = useState<number | null>(null);
   const [lastAddedWorkspacePanelId, setLastAddedWorkspacePanelId] = useState<string | null>(null);
   const [isLargeScreen, setIsLargeScreen] = useState(() => {
@@ -673,6 +674,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     setIsWorkspaceOpen(false);
     setIsWorkspaceAddMenuOpen(false);
     setIsWorkspaceDragActive(false);
+    setIsWorkspaceResizing(false);
     setWorkspaceDropIndex(null);
   };
 
@@ -799,6 +801,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   ) => {
     event.preventDefault();
     event.currentTarget.setPointerCapture(event.pointerId);
+    setIsWorkspaceResizing(true);
     workspaceInteractionRef.current = {
       mode: 'row',
       index,
@@ -816,6 +819,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   ) => {
     event.preventDefault();
     event.currentTarget.setPointerCapture(event.pointerId);
+    setIsWorkspaceResizing(true);
     const rowElement = event.currentTarget.closest<HTMLElement>('.workspace-tile-row');
     workspaceInteractionRef.current = {
       mode: 'column',
@@ -868,6 +872,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
   const handleWorkspacePointerEnd = () => {
     workspaceInteractionRef.current = null;
+    setIsWorkspaceResizing(false);
   };
 
   useEffect(() => {
@@ -879,6 +884,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     };
     const handlePointerEnd = () => {
       workspaceInteractionRef.current = null;
+      setIsWorkspaceResizing(false);
     };
 
     document.addEventListener('pointermove', handlePointerMove);
@@ -1399,7 +1405,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
         {isDesktopWorkspace && (
           <div
-            className={`desktop-workspace ${isWorkspaceDragActive ? 'is-drop-active' : ''}`}
+            className={`desktop-workspace ${isWorkspaceDragActive ? 'is-drop-active' : ''} ${isWorkspaceResizing ? 'is-resizing' : ''}`}
             aria-label="Desktop workspace"
             ref={workspaceRef}
             onDragOver={handleWorkspaceDragOver}

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -165,6 +165,11 @@ type WorkspaceDraft = {
   type: WorkspacePanelType;
 };
 
+type WorkspaceSnapTarget = {
+  templateId: string;
+  zoneIndex: number;
+};
+
 type WorkspaceInteraction =
   | {
     mode: 'row';
@@ -252,6 +257,15 @@ const loadWorkspacePanels = (): WorkspacePanel[] => {
 type WorkspaceLayoutState = {
   rowRatios: number[];
   columnRatiosByRow: Record<number, number[]>;
+  rowSizes?: number[];
+};
+
+type WorkspaceSnapTemplate = {
+  id: string;
+  title: string;
+  rowSizes: number[];
+  rowRatios?: number[];
+  columnRatiosByRow?: Record<number, number[]>;
 };
 
 const normalizeRatios = (ratios: unknown, length: number): number[] => {
@@ -280,6 +294,9 @@ const loadWorkspaceLayout = (): WorkspaceLayoutState => {
       columnRatiosByRow: parsed.columnRatiosByRow && typeof parsed.columnRatiosByRow === 'object'
         ? parsed.columnRatiosByRow
         : {},
+      rowSizes: Array.isArray(parsed.rowSizes)
+        ? parsed.rowSizes.filter(value => Number.isInteger(value) && value > 0)
+        : undefined,
     };
   } catch (error) {
     console.error('Failed to load desktop workspace layout:', error);
@@ -316,13 +333,105 @@ const getWorkspaceColumnCount = (panelCount: number) => {
   return Math.ceil(Math.sqrt(panelCount));
 };
 
-const buildWorkspaceRows = <T,>(items: T[]) => {
+const buildWorkspaceRows = <T,>(items: T[], rowSizes?: number[]) => {
+  if (
+    rowSizes &&
+    rowSizes.length > 0 &&
+    rowSizes.every(size => Number.isInteger(size) && size > 0) &&
+    rowSizes.reduce((total, size) => total + size, 0) === items.length
+  ) {
+    const rows: T[][] = [];
+    let cursor = 0;
+    rowSizes.forEach(size => {
+      rows.push(items.slice(cursor, cursor + size));
+      cursor += size;
+    });
+    return rows;
+  }
+
   const columnCount = getWorkspaceColumnCount(items.length);
   const rows: T[][] = [];
   for (let index = 0; index < items.length; index += columnCount) {
     rows.push(items.slice(index, index + columnCount));
   }
   return rows;
+};
+
+const WORKSPACE_SNAP_TEMPLATES: WorkspaceSnapTemplate[] = [
+  {
+    id: 'split',
+    title: 'Split',
+    rowSizes: [2],
+    columnRatiosByRow: { 0: [1, 1] },
+  },
+  {
+    id: 'focus-left',
+    title: 'Focus left',
+    rowSizes: [2],
+    columnRatiosByRow: { 0: [1.7, 1] },
+  },
+  {
+    id: 'focus-right',
+    title: 'Focus right',
+    rowSizes: [2],
+    columnRatiosByRow: { 0: [1, 1.7] },
+  },
+  {
+    id: 'thirds',
+    title: 'Thirds',
+    rowSizes: [3],
+    columnRatiosByRow: { 0: [1, 1, 1] },
+  },
+  {
+    id: 'quad',
+    title: 'Quad',
+    rowSizes: [2, 2],
+    rowRatios: [1, 1],
+    columnRatiosByRow: { 0: [1, 1], 1: [1, 1] },
+  },
+  {
+    id: 'stack-top',
+    title: 'Top focus',
+    rowSizes: [1, 2],
+    rowRatios: [1.35, 1],
+    columnRatiosByRow: { 0: [1], 1: [1, 1] },
+  },
+];
+
+const getWorkspaceSnapTemplates = (tileCount: number) => {
+  return WORKSPACE_SNAP_TEMPLATES.filter(template => (
+    template.rowSizes.reduce((total, size) => total + size, 0) <= tileCount
+  ));
+};
+
+const createWorkspaceLayoutFromTemplate = (
+  template: WorkspaceSnapTemplate,
+  tileCount: number
+): WorkspaceLayoutState => {
+  const rowSizes = [...template.rowSizes];
+  const templateCapacity = rowSizes.reduce((total, size) => total + size, 0);
+  if (tileCount > templateCapacity && rowSizes.length > 0) {
+    rowSizes[rowSizes.length - 1] += tileCount - templateCapacity;
+  }
+
+  const columnRatiosByRow = rowSizes.reduce<Record<number, number[]>>((ratiosByRow, rowSize, index) => {
+    const templateRatios = template.columnRatiosByRow?.[index];
+    ratiosByRow[index] = templateRatios
+      ? [
+        ...templateRatios.slice(0, rowSize),
+        ...Array.from({ length: Math.max(0, rowSize - templateRatios.length) }, () => 1),
+      ]
+      : Array.from({ length: rowSize }, () => 1);
+    return ratiosByRow;
+  }, {});
+
+  return {
+    rowSizes,
+    rowRatios: template.rowRatios?.length === rowSizes.length
+      ? template.rowRatios
+      : Array.from({ length: rowSizes.length }, () => 1),
+    columnRatiosByRow,
+  };
 };
 
 const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onDisconnect }) => {
@@ -333,6 +442,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const [workspaceTileOrder, setWorkspaceTileOrder] = useState<string[]>(loadWorkspaceTileOrder);
   const [isWorkspaceAddMenuOpen, setIsWorkspaceAddMenuOpen] = useState(false);
   const [isWorkspaceDragActive, setIsWorkspaceDragActive] = useState(false);
+  const [workspaceDragKind, setWorkspaceDragKind] = useState<'new' | 'move' | null>(null);
+  const [workspaceSnapTarget, setWorkspaceSnapTarget] = useState<WorkspaceSnapTarget | null>(null);
   const [isWorkspaceResizing, setIsWorkspaceResizing] = useState(false);
   const [workspaceDropIndex, setWorkspaceDropIndex] = useState<number | null>(null);
   const [lastAddedWorkspacePanelId, setLastAddedWorkspacePanelId] = useState<string | null>(null);
@@ -389,7 +500,10 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       return panel ? [{ kind: 'panel' as const, id, panel }] : [];
     });
   }, [normalizedWorkspaceTileOrder, workspacePanels]);
-  const workspaceRows = useMemo(() => buildWorkspaceRows(workspaceTiles), [workspaceTiles]);
+  const workspaceRows = useMemo(
+    () => buildWorkspaceRows(workspaceTiles, workspaceLayout.rowSizes),
+    [workspaceLayout.rowSizes, workspaceTiles]
+  );
   const workspaceRowRatios = useMemo(
     () => normalizeRatios(workspaceLayout.rowRatios, workspaceRows.length),
     [workspaceLayout.rowRatios, workspaceRows.length]
@@ -405,6 +519,11 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       .slice(0, rowIndex)
       .reduce((total, row) => total + row.length, columnIndex);
   };
+  const workspaceSnapTileCount = workspaceTiles.length + (workspaceDragKind === 'new' ? 1 : 0);
+  const workspaceSnapTemplates = useMemo(
+    () => getWorkspaceSnapTemplates(workspaceSnapTileCount),
+    [workspaceSnapTileCount]
+  );
 
   // Resizable panels hook
   const { topHeight, bottomHeight, handleMouseDown, handleTouchStart, containerRef, isDragging } = useResizablePanels({
@@ -639,7 +758,11 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     setWorkspaceLayout({ rowRatios: [], columnRatiosByRow: {} });
   };
 
-  const handleAddWorkspacePanel = (type: WorkspacePanelType, insertIndex?: number) => {
+  const handleAddWorkspacePanel = (
+    type: WorkspacePanelType,
+    insertIndex?: number,
+    snapTemplate?: WorkspaceSnapTemplate
+  ) => {
     setIsWorkspaceOpen(true);
     setWorkspacePanels(prev => {
       const selectedPadPanel = selectedPanelId
@@ -661,12 +784,17 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
           0,
           newPanel.id
         );
+        if (snapTemplate) {
+          setWorkspaceLayout(createWorkspaceLayoutFromTemplate(snapTemplate, nextOrder.length));
+        }
         return nextOrder;
       });
       setLastAddedWorkspacePanelId(newPanel.id);
       return nextPanels;
     });
-    resetWorkspaceLayout();
+    if (!snapTemplate) {
+      resetWorkspaceLayout();
+    }
     setIsWorkspaceAddMenuOpen(false);
   };
 
@@ -674,6 +802,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     setIsWorkspaceOpen(false);
     setIsWorkspaceAddMenuOpen(false);
     setIsWorkspaceDragActive(false);
+    setWorkspaceDragKind(null);
+    setWorkspaceSnapTarget(null);
     setIsWorkspaceResizing(false);
     setWorkspaceDropIndex(null);
   };
@@ -687,6 +817,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     event.dataTransfer.effectAllowed = 'copy';
     setIsWorkspaceOpen(true);
     setIsWorkspaceDragActive(true);
+    setWorkspaceDragKind('new');
   };
 
   const handleWorkspaceTileDragStart = (
@@ -696,10 +827,13 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     event.dataTransfer.setData(WORKSPACE_TILE_DRAG_FORMAT, tileId);
     event.dataTransfer.effectAllowed = 'move';
     setIsWorkspaceDragActive(true);
+    setWorkspaceDragKind('move');
   };
 
   const handleWorkspaceDragEnd = () => {
     setIsWorkspaceDragActive(false);
+    setWorkspaceDragKind(null);
+    setWorkspaceSnapTarget(null);
     setWorkspaceDropIndex(null);
   };
 
@@ -710,6 +844,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     ) {
       event.preventDefault();
       event.dataTransfer.dropEffect = event.dataTransfer.types.includes(WORKSPACE_TILE_DRAG_FORMAT) ? 'move' : 'copy';
+      setWorkspaceSnapTarget(null);
       setWorkspaceDropIndex(getWorkspaceDropIndex(event.clientX, event.clientY));
     }
   };
@@ -717,6 +852,22 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const handleWorkspaceDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
     const nextTarget = event.relatedTarget;
     if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    setWorkspaceDropIndex(null);
+    setWorkspaceSnapTarget(null);
+  };
+
+  const getWorkspaceSnapTemplate = (templateId: string) => {
+    return WORKSPACE_SNAP_TEMPLATES.find(template => template.id === templateId) || null;
+  };
+
+  const handleWorkspaceSnapDragOver = (
+    event: React.DragEvent<HTMLButtonElement>,
+    target: WorkspaceSnapTarget
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = workspaceDragKind === 'move' ? 'move' : 'copy';
+    setWorkspaceSnapTarget(target);
     setWorkspaceDropIndex(null);
   };
 
@@ -743,8 +894,12 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     if (movedTileId) {
       event.preventDefault();
       setIsWorkspaceDragActive(false);
+      setWorkspaceDragKind(null);
+      const snapTarget = workspaceSnapTarget;
+      setWorkspaceSnapTarget(null);
       setWorkspaceDropIndex(null);
-      const dropIndex = getWorkspaceDropIndex(event.clientX, event.clientY);
+      const snapTemplate = snapTarget ? getWorkspaceSnapTemplate(snapTarget.templateId) : null;
+      const dropIndex = snapTarget ? snapTarget.zoneIndex : getWorkspaceDropIndex(event.clientX, event.clientY);
       setWorkspaceTileOrder(prevOrder => {
         const currentOrder = normalizeWorkspaceTileOrder(prevOrder, workspacePanels.map(panel => panel.id));
         const fromIndex = currentOrder.indexOf(movedTileId);
@@ -754,9 +909,14 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
         const [movedId] = nextOrder.splice(fromIndex, 1);
         const adjustedDropIndex = dropIndex > fromIndex ? dropIndex - 1 : dropIndex;
         nextOrder.splice(clamp(adjustedDropIndex, 0, nextOrder.length), 0, movedId);
+        if (snapTemplate) {
+          setWorkspaceLayout(createWorkspaceLayoutFromTemplate(snapTemplate, nextOrder.length));
+        }
         return nextOrder;
       });
-      resetWorkspaceLayout();
+      if (!snapTemplate) {
+        resetWorkspaceLayout();
+      }
       return;
     }
 
@@ -765,13 +925,17 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
     event.preventDefault();
     setIsWorkspaceDragActive(false);
+    setWorkspaceDragKind(null);
+    const snapTarget = workspaceSnapTarget;
+    setWorkspaceSnapTarget(null);
     setWorkspaceDropIndex(null);
     try {
       const draft = JSON.parse(payload) as WorkspaceDraft;
       if (!['camera', '3d', 'pad', 'behaviorTree'].includes(draft.type)) return;
 
-      const tileIndex = getWorkspaceDropIndex(event.clientX, event.clientY);
-      handleAddWorkspacePanel(draft.type, tileIndex);
+      const snapTemplate = snapTarget ? getWorkspaceSnapTemplate(snapTarget.templateId) : null;
+      const tileIndex = snapTarget ? snapTarget.zoneIndex : getWorkspaceDropIndex(event.clientX, event.clientY);
+      handleAddWorkspacePanel(draft.type, tileIndex, snapTemplate || undefined);
     } catch (error) {
       console.error('Failed to add dropped workspace panel:', error);
     }
@@ -1257,6 +1421,58 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     );
   };
 
+  const renderWorkspaceSnapAssistant = () => {
+    if (!isWorkspaceDragActive || workspaceSnapTemplates.length === 0) return null;
+
+    return (
+      <div className="workspace-snap-assistant" aria-label="Snap layouts">
+        {workspaceSnapTemplates.map(template => {
+          let zoneIndex = 0;
+
+          return (
+            <div className="workspace-snap-template" key={template.id}>
+              <span className="workspace-snap-template-title">{template.title}</span>
+              <div className="workspace-snap-template-grid">
+                {template.rowSizes.map((rowSize, rowIndex) => (
+                  <div
+                    className="workspace-snap-template-row"
+                    key={`${template.id}-row-${rowIndex}`}
+                    style={{ flex: template.rowRatios?.[rowIndex] || 1 }}
+                  >
+                    {Array.from({ length: rowSize }).map(() => {
+                      const currentZoneIndex = zoneIndex;
+                      zoneIndex += 1;
+                      const isActiveSnapZone = workspaceSnapTarget?.templateId === template.id &&
+                        workspaceSnapTarget.zoneIndex === currentZoneIndex;
+
+                      return (
+                        <button
+                          type="button"
+                          className={`workspace-snap-zone ${isActiveSnapZone ? 'active' : ''}`}
+                          key={`${template.id}-zone-${currentZoneIndex}`}
+                          onDragEnter={(event) => handleWorkspaceSnapDragOver(event, {
+                            templateId: template.id,
+                            zoneIndex: currentZoneIndex,
+                          })}
+                          onDragOver={(event) => handleWorkspaceSnapDragOver(event, {
+                            templateId: template.id,
+                            zoneIndex: currentZoneIndex,
+                          })}
+                          title={`Snap to ${template.title}`}
+                          aria-label={`Snap to ${template.title} zone ${currentZoneIndex + 1}`}
+                        />
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
   const renderStandardSplitLayout = (className = 'standard-stack-layout') => (
     <div className={className} ref={containerRef}>
       <div className="view-panel-container" style={{ height: `calc(${topHeight}% - 8px)` }}>
@@ -1415,6 +1631,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
             onPointerUp={handleWorkspacePointerEnd}
             onPointerCancel={handleWorkspacePointerEnd}
           >
+            {renderWorkspaceSnapAssistant()}
             <div className="workspace-grid">
               {workspaceRows.map((row, rowIndex) => (
                 <React.Fragment key={`workspace-row-${rowIndex}`}>

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -306,8 +306,8 @@ const normalizeWorkspaceTileOrder = (order: string[], panelIds: string[]) => {
   const orderedIds = order.filter((id, index) => (
     validIds.includes(id) && order.indexOf(id) === index
   ));
-  const missingIds = validIds.filter(id => !orderedIds.includes(id));
-  return [...orderedIds, ...missingIds];
+  const missingPanelIds = panelIds.filter(id => !orderedIds.includes(id));
+  return [...orderedIds, ...missingPanelIds];
 };
 
 const getWorkspaceColumnCount = (panelCount: number) => {
@@ -333,6 +333,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const [workspaceTileOrder, setWorkspaceTileOrder] = useState<string[]>(loadWorkspaceTileOrder);
   const [isWorkspaceAddMenuOpen, setIsWorkspaceAddMenuOpen] = useState(false);
   const [isWorkspaceDragActive, setIsWorkspaceDragActive] = useState(false);
+  const [workspaceDropIndex, setWorkspaceDropIndex] = useState<number | null>(null);
   const [lastAddedWorkspacePanelId, setLastAddedWorkspacePanelId] = useState<string | null>(null);
   const [isLargeScreen, setIsLargeScreen] = useState(() => {
     if (typeof window === 'undefined' || !window.matchMedia) return true;
@@ -354,6 +355,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const [selectedPanelId, setSelectedPanelId] = useState<string | null>(null);
   const [isAddPanelMenuOpen, setIsAddPanelMenuOpen] = useState(false);
   const [editorSession, setEditorSession] = useState<GamepadEditorSession | null>(null);
+  const [workspacePadEditorTargetId, setWorkspacePadEditorTargetId] = useState<string | null>(null);
   // State to trigger refresh of custom gamepads in AddPanelMenu
   const [customGamepadRefreshKey, setCustomGamepadRefreshKey] = useState(0);
   const gamepadLibrary = useMemo(
@@ -397,6 +399,11 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       row.length
     ))
   ), [workspaceLayout.columnRatiosByRow, workspaceRows]);
+  const getWorkspaceTileIndex = (rowIndex: number, columnIndex: number) => {
+    return workspaceRows
+      .slice(0, rowIndex)
+      .reduce((total, row) => total + row.length, columnIndex);
+  };
 
   // Resizable panels hook
   const { topHeight, bottomHeight, handleMouseDown, handleTouchStart, containerRef, isDragging } = useResizablePanels({
@@ -582,6 +589,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
   const handleCloseCustomEditor = () => {
     setEditorSession(null);
+    setWorkspacePadEditorTargetId(null);
   };
 
   const handleSaveCustomGamepad = (layout: CustomGamepadLayout) => {
@@ -602,7 +610,13 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       setSelectedPanelId(result.selectedPanelId);
       return result.panels;
     });
+    if (workspacePadEditorTargetId) {
+      setWorkspacePanels(prev => prev.map(panel =>
+        panel.id === workspacePadEditorTargetId ? { ...panel, layoutId: layout.id } : panel
+      ));
+    }
     setIsAddPanelMenuOpen(false);
+    setWorkspacePadEditorTargetId(null);
     // Trigger refresh of custom gamepad list in AddPanelMenu
     setCustomGamepadRefreshKey(prev => prev + 1);
   };
@@ -658,6 +672,8 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   const handleReturnToSplitView = () => {
     setIsWorkspaceOpen(false);
     setIsWorkspaceAddMenuOpen(false);
+    setIsWorkspaceDragActive(false);
+    setWorkspaceDropIndex(null);
   };
 
   const handleWorkspaceDragStart = (
@@ -682,6 +698,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
   const handleWorkspaceDragEnd = () => {
     setIsWorkspaceDragActive(false);
+    setWorkspaceDropIndex(null);
   };
 
   const handleWorkspaceDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -691,7 +708,14 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     ) {
       event.preventDefault();
       event.dataTransfer.dropEffect = event.dataTransfer.types.includes(WORKSPACE_TILE_DRAG_FORMAT) ? 'move' : 'copy';
+      setWorkspaceDropIndex(getWorkspaceDropIndex(event.clientX, event.clientY));
     }
+  };
+
+  const handleWorkspaceDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    setWorkspaceDropIndex(null);
   };
 
   const getWorkspaceDropIndex = (clientX: number, clientY: number) => {
@@ -717,6 +741,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     if (movedTileId) {
       event.preventDefault();
       setIsWorkspaceDragActive(false);
+      setWorkspaceDropIndex(null);
       const dropIndex = getWorkspaceDropIndex(event.clientX, event.clientY);
       setWorkspaceTileOrder(prevOrder => {
         const currentOrder = normalizeWorkspaceTileOrder(prevOrder, workspacePanels.map(panel => panel.id));
@@ -738,6 +763,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
     event.preventDefault();
     setIsWorkspaceDragActive(false);
+    setWorkspaceDropIndex(null);
     try {
       const draft = JSON.parse(payload) as WorkspaceDraft;
       if (!['camera', '3d', 'pad', 'behaviorTree'].includes(draft.type)) return;
@@ -876,6 +902,16 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     resetWorkspaceLayout();
   };
 
+  const handleRemoveWorkspaceTile = (tile: WorkspaceTile) => {
+    if (tile.kind === 'panel') {
+      handleRemoveWorkspacePanel(tile.panel.id);
+      return;
+    }
+
+    setWorkspaceTileOrder(prev => prev.filter(id => id !== tile.id));
+    resetWorkspaceLayout();
+  };
+
   const handleWorkspaceCameraTopicChange = (panelId: string, cameraTopic: string) => {
     setWorkspacePanels(prev => prev.map(panel =>
       panel.id === panelId ? { ...panel, cameraTopic } : panel
@@ -888,10 +924,15 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     ));
   };
 
+  const handleOpenWorkspacePadEditor = (panelId: string) => {
+    setWorkspacePadEditorTargetId(panelId);
+    handleOpenCustomEditor();
+  };
+
   const handleAutoTileWorkspacePanels = () => {
-    if (workspacePanels.length > 0) {
-      setIsWorkspaceOpen(true);
-    }
+    setIsWorkspaceOpen(true);
+    setIsWorkspaceDragActive(false);
+    setWorkspaceDropIndex(null);
     resetWorkspaceLayout();
     setIsWorkspaceAddMenuOpen(false);
   };
@@ -910,12 +951,17 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
   // View state management with animation
   const handleViewToggle = (mode: ViewMode) => {
     if (isTransitioning || viewMode === mode) return;
+
+    const currentView = viewPanelRef.current;
+    if (!currentView) {
+      setViewMode(mode);
+      setIsTransitioning(false);
+      return;
+    }
+
     setIsTransitioning(true);
 
     const newViewMode = mode;
-
-    const currentView = viewPanelRef.current;
-    if (!currentView) return;
 
     // Create timeline for the animation
     const timeline = anime.timeline({
@@ -1057,9 +1103,9 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
 
     return (
       <div className="workspace-pad-component">
-        {gamepadLibrary.length > 0 ? (
-          <div className="workspace-pad-selector">
-            <label htmlFor={`workspace-pad-select-${panel.id}`}>Pad</label>
+        <div className="workspace-pad-selector">
+          <label htmlFor={`workspace-pad-select-${panel.id}`}>Pad</label>
+          {gamepadLibrary.length > 0 ? (
             <select
               id={`workspace-pad-select-${panel.id}`}
               value={selectedLayoutId}
@@ -1071,8 +1117,19 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                 </option>
               ))}
             </select>
-          </div>
-        ) : null}
+          ) : (
+            <span className="workspace-pad-selector-empty">No pads</span>
+          )}
+          <button
+            type="button"
+            className="workspace-pad-create-button"
+            onClick={() => handleOpenWorkspacePadEditor(panel.id)}
+            title="Create pad for this component"
+            aria-label="Create pad for this component"
+          >
+            {icons.add}
+          </button>
+        </div>
         <div className="workspace-pad-body">
           {isConnected && ros && selectedLayoutId ? (
             <CustomGamepadWrapper ros={ros} layoutId={selectedLayoutId} />
@@ -1081,7 +1138,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
               <div className="pad-empty-state-content">
                 <span className="pad-empty-state-kicker">Custom controls</span>
                 <h2>No pads available</h2>
-                <p>Create a pad from the main pad controls.</p>
+                <p>Create a pad from this component.</p>
               </div>
             </div>
           )}
@@ -1216,87 +1273,91 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
     <div className="main-control-view">
       {/* Unified Top Bar */}
       <div className={`top-bar ${btExecution.isExecuting ? 'bt-running' : ''} ${isDesktopWorkspace ? 'workspace-active' : ''}`}>
-        <div className="view-toggle">
-          <button
-            onClick={() => handleViewToggle('camera')}
-            className={viewMode === 'camera' ? 'active' : ''}
-            title="Camera View"
-            aria-label="Switch to Camera View"
-          >
-            {icons.camera}
-          </button>
-          <button
-            onClick={() => handleViewToggle('3d')}
-            className={viewMode === '3d' ? 'active' : ''}
-            title="3D View"
-            aria-label="Switch to 3D View"
-          >
-            {icons.view3d}
-          </button>
-          {btExecution.isExecuting ? (
-            <div
-              className={`bt-execution-island ${viewMode === 'behaviorTree' ? 'active' : ''}`}
-              role="status"
-              aria-live="polite"
+        {!isDesktopWorkspace && (
+          <div className="view-toggle">
+            <button
+              onClick={() => handleViewToggle('camera')}
+              className={viewMode === 'camera' ? 'active' : ''}
+              title="Camera View"
+              aria-label="Switch to Camera View"
             >
+              {icons.camera}
+            </button>
+            <button
+              onClick={() => handleViewToggle('3d')}
+              className={viewMode === '3d' ? 'active' : ''}
+              title="3D View"
+              aria-label="Switch to 3D View"
+            >
+              {icons.view3d}
+            </button>
+            {btExecution.isExecuting ? (
+              <div
+                className={`bt-execution-island ${viewMode === 'behaviorTree' ? 'active' : ''}`}
+                role="status"
+                aria-live="polite"
+              >
+                <button
+                  className="bt-execution-return"
+                  onClick={handleReturnToBehaviorTree}
+                  title="Open behavior tree"
+                  aria-label="Open behavior tree"
+                >
+                  {icons.bt}
+                  <span className="bt-execution-pulse" aria-hidden="true" />
+                  <span className="bt-execution-copy">
+                    <span className="bt-execution-tree" title={btExecution.treeName || 'Behavior tree'}>
+                      {btExecution.treeName || 'Behavior tree'}
+                    </span>
+                    <span className="bt-execution-node" title={btExecution.activeNodeLabel || 'Running'}>
+                      {btExecution.activeNodeLabel || 'Running'}
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="bt-execution-stop"
+                  onClick={handleStopBehaviorTree}
+                  title="Stop behavior tree"
+                  aria-label="Stop behavior tree"
+                >
+                  {icons.stop}
+                </button>
+              </div>
+            ) : (
               <button
-                className="bt-execution-return"
-                onClick={handleReturnToBehaviorTree}
-                title="Open behavior tree"
-                aria-label="Open behavior tree"
+                onClick={() => handleViewToggle('behaviorTree')}
+                className={viewMode === 'behaviorTree' ? 'active' : ''}
+                title="Behavior Tree"
+                aria-label="Switch to Behavior Tree"
               >
                 {icons.bt}
-                <span className="bt-execution-pulse" aria-hidden="true" />
-                <span className="bt-execution-copy">
-                  <span className="bt-execution-tree" title={btExecution.treeName || 'Behavior tree'}>
-                    {btExecution.treeName || 'Behavior tree'}
-                  </span>
-                  <span className="bt-execution-node" title={btExecution.activeNodeLabel || 'Running'}>
-                    {btExecution.activeNodeLabel || 'Running'}
-                  </span>
-                </span>
               </button>
-              <button
-                className="bt-execution-stop"
-                onClick={handleStopBehaviorTree}
-                title="Stop behavior tree"
-                aria-label="Stop behavior tree"
-              >
-                {icons.stop}
-              </button>
-            </div>
-          ) : (
-            <button
-              onClick={() => handleViewToggle('behaviorTree')}
-              className={viewMode === 'behaviorTree' ? 'active' : ''}
-              title="Behavior Tree"
-              aria-label="Switch to Behavior Tree"
-            >
-              {icons.bt}
-            </button>
-          )}
-        </div>
+            )}
+          </div>
+        )}
         <div className="layout-controls">
-          {isDesktopWorkspace && (
+          {isLargeScreen && (
             <>
               <button
                 type="button"
-                className="workspace-split-button"
-                onClick={handleReturnToSplitView}
-                title="Return to split view"
-                aria-label="Return to split view"
-              >
-                {icons.split}
-              </button>
-              <button
-                type="button"
-                className="workspace-tile-button"
+                className={`workspace-tile-button ${isDesktopWorkspace ? 'active' : ''}`}
                 onClick={handleAutoTileWorkspacePanels}
-                title="Auto-arrange workspace panels"
-                aria-label="Auto-arrange workspace panels"
+                title={isDesktopWorkspace ? 'Auto-arrange workspace panels' : 'Open grid workspace'}
+                aria-label={isDesktopWorkspace ? 'Auto-arrange workspace panels' : 'Open grid workspace'}
               >
                 {icons.tile}
               </button>
+              {isDesktopWorkspace && (
+                <button
+                  type="button"
+                  className="workspace-split-button"
+                  onClick={handleReturnToSplitView}
+                  title="Return to split view"
+                  aria-label="Return to split view"
+                >
+                  {icons.split}
+                </button>
+              )}
             </>
           )}
           <div className="workspace-add-control">
@@ -1342,6 +1403,7 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
             aria-label="Desktop workspace"
             ref={workspaceRef}
             onDragOver={handleWorkspaceDragOver}
+            onDragLeave={handleWorkspaceDragLeave}
             onDrop={handleWorkspaceDrop}
             onPointerMove={handleWorkspacePointerMove}
             onPointerUp={handleWorkspacePointerEnd}
@@ -1354,101 +1416,130 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                     className="workspace-tile-row"
                     style={{ flex: workspaceRowRatios[rowIndex] || 1 }}
                   >
-                    {row.map((tile, columnIndex) => (
-                      <React.Fragment key={tile.id}>
-                        {tile.kind === 'view' ? (
-                          <section
-                            className="workspace-card workspace-card-view"
-                            aria-label="View component"
-                            data-workspace-card-id={tile.id}
-                            style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
-                          >
-                            <header
-                              className="workspace-card-header"
-                              draggable
-                              onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
-                              onDragEnd={handleWorkspaceDragEnd}
+                    {row.map((tile, columnIndex) => {
+                      const tileIndex = getWorkspaceTileIndex(rowIndex, columnIndex);
+                      return (
+                        <React.Fragment key={tile.id}>
+                          {workspaceDropIndex === tileIndex && (
+                            <div className="workspace-drop-indicator" aria-hidden="true" />
+                          )}
+                          {tile.kind === 'view' ? (
+                            <section
+                              className="workspace-card workspace-card-view"
+                              aria-label="View component"
+                              data-workspace-card-id={tile.id}
+                              style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
                             >
-                              <div className="workspace-card-title">
-                                <span className="workspace-card-dot workspace-card-dot-view" aria-hidden="true" />
-                                <span>View</span>
+                              <header
+                                className="workspace-card-header"
+                                draggable
+                                onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
+                                onDragEnd={handleWorkspaceDragEnd}
+                              >
+                                <div className="workspace-card-title">
+                                  <span className="workspace-card-dot workspace-card-dot-view" aria-hidden="true" />
+                                  <span>View</span>
+                                </div>
+                                <div className="workspace-card-actions">
+                                  <button
+                                    type="button"
+                                    onClick={() => handleRemoveWorkspaceTile(tile)}
+                                    title="Remove view tile"
+                                    aria-label="Remove view tile"
+                                  >
+                                    {icons.trash}
+                                  </button>
+                                </div>
+                              </header>
+                              <div className="workspace-card-content workspace-card-content-view">
+                                {renderViewContent()}
                               </div>
-                            </header>
-                            <div className="workspace-card-content workspace-card-content-view">
-                              {renderViewContent()}
-                            </div>
-                          </section>
-                        ) : tile.kind === 'pads' ? (
-                          <section
-                            className="workspace-card workspace-card-pads"
-                            aria-label="Pad controls component"
-                            data-workspace-card-id={tile.id}
-                            style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
-                          >
-                            <header
-                              className="workspace-card-header"
-                              draggable
-                              onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
-                              onDragEnd={handleWorkspaceDragEnd}
+                            </section>
+                          ) : tile.kind === 'pads' ? (
+                            <section
+                              className="workspace-card workspace-card-pads"
+                              aria-label="Pad controls component"
+                              data-workspace-card-id={tile.id}
+                              style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
                             >
-                              <div className="workspace-card-title">
-                                <span className="workspace-card-dot workspace-card-dot-pad" aria-hidden="true" />
-                                <span>Pad controls</span>
+                              <header
+                                className="workspace-card-header"
+                                draggable
+                                onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
+                                onDragEnd={handleWorkspaceDragEnd}
+                              >
+                                <div className="workspace-card-title">
+                                  <span className="workspace-card-dot workspace-card-dot-pad" aria-hidden="true" />
+                                  <span>Pad controls</span>
+                                </div>
+                                <div className="workspace-card-actions">
+                                  <button
+                                    type="button"
+                                    onClick={() => handleRemoveWorkspaceTile(tile)}
+                                    title="Remove pad controls tile"
+                                    aria-label="Remove pad controls tile"
+                                  >
+                                    {icons.trash}
+                                  </button>
+                                </div>
+                              </header>
+                              <div className="workspace-card-content">
+                                {renderPadControls(true)}
                               </div>
-                            </header>
-                            <div className="workspace-card-content">
-                              {renderPadControls(true)}
-                            </div>
-                          </section>
-                        ) : (
-                          <section
-                            className={`workspace-card workspace-card-${tile.panel.type} ${lastAddedWorkspacePanelId === tile.panel.id ? 'is-settling' : ''}`}
-                            aria-label={tile.panel.title}
-                            data-workspace-card-id={tile.panel.id}
-                            style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
-                            onAnimationEnd={() => {
-                              setLastAddedWorkspacePanelId(prev => prev === tile.panel.id ? null : prev);
-                            }}
-                          >
-                            <header
-                              className="workspace-card-header"
-                              draggable
-                              onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
-                              onDragEnd={handleWorkspaceDragEnd}
+                            </section>
+                          ) : (
+                            <section
+                              className={`workspace-card workspace-card-${tile.panel.type} ${lastAddedWorkspacePanelId === tile.panel.id ? 'is-settling' : ''}`}
+                              aria-label={tile.panel.title}
+                              data-workspace-card-id={tile.panel.id}
+                              style={{ flex: workspaceColumnRatiosByRow[rowIndex]?.[columnIndex] || 1 }}
+                              onAnimationEnd={() => {
+                                setLastAddedWorkspacePanelId(prev => prev === tile.panel.id ? null : prev);
+                              }}
                             >
-                              <div className="workspace-card-title">
-                                <span className={`workspace-card-dot workspace-card-dot-${tile.panel.type}`} aria-hidden="true" />
-                                <span>{tile.panel.title}</span>
+                              <header
+                                className="workspace-card-header"
+                                draggable
+                                onDragStart={(event) => handleWorkspaceTileDragStart(event, tile.id)}
+                                onDragEnd={handleWorkspaceDragEnd}
+                              >
+                                <div className="workspace-card-title">
+                                  <span className={`workspace-card-dot workspace-card-dot-${tile.panel.type}`} aria-hidden="true" />
+                                  <span>{tile.panel.title}</span>
+                                </div>
+                                <div className="workspace-card-actions">
+                                  <button
+                                    type="button"
+                                    onClick={() => handleRemoveWorkspaceTile(tile)}
+                                    title="Remove panel"
+                                    aria-label={`Remove ${tile.panel.title}`}
+                                  >
+                                    {icons.trash}
+                                  </button>
+                                </div>
+                              </header>
+                              <div className="workspace-card-content">
+                                {renderWorkspacePanelContent(tile.panel)}
                               </div>
-                              <div className="workspace-card-actions">
-                                <button
-                                  type="button"
-                                  onClick={() => handleRemoveWorkspacePanel(tile.panel.id)}
-                                  title="Remove panel"
-                                  aria-label={`Remove ${tile.panel.title}`}
-                                >
-                                  {icons.trash}
-                                </button>
-                              </div>
-                            </header>
-                            <div className="workspace-card-content">
-                              {renderWorkspacePanelContent(tile.panel)}
+                            </section>
+                          )}
+                          {columnIndex < row.length - 1 && (
+                            <div
+                              className="workspace-column-resize-handle"
+                              onPointerDown={(event) => handleWorkspaceColumnResizeStart(event, rowIndex, columnIndex)}
+                              role="separator"
+                              aria-orientation="vertical"
+                              aria-label="Resize workspace columns"
+                            >
+                              <div className="workspace-resize-handle-bar" />
                             </div>
-                          </section>
-                        )}
-                        {columnIndex < row.length - 1 && (
-                          <div
-                            className="workspace-column-resize-handle"
-                            onPointerDown={(event) => handleWorkspaceColumnResizeStart(event, rowIndex, columnIndex)}
-                            role="separator"
-                            aria-orientation="vertical"
-                            aria-label="Resize workspace columns"
-                          >
-                            <div className="workspace-resize-handle-bar" />
-                          </div>
-                        )}
-                      </React.Fragment>
-                    ))}
+                          )}
+                        </React.Fragment>
+                      );
+                    })}
+                    {rowIndex === workspaceRows.length - 1 && workspaceDropIndex === workspaceTiles.length && (
+                      <div className="workspace-drop-indicator workspace-drop-indicator-end" aria-hidden="true" />
+                    )}
                   </div>
                   {rowIndex < workspaceRows.length - 1 && (
                     <div
@@ -1463,6 +1554,12 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
                   )}
                 </React.Fragment>
               ))}
+              {workspaceTiles.length === 0 && (
+                <div className="workspace-empty-drop-zone">
+                  <div className="workspace-empty-drop-line" aria-hidden="true" />
+                  <span>Workspace empty</span>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Navbar from './Navbar';
+
+describe('Navbar', () => {
+  it('marks the current section as active and reports section changes', () => {
+    const setCurrentSection = vi.fn();
+
+    render(<Navbar currentSection="simple" setCurrentSection={setCurrentSection} />);
+
+    expect(screen.getByText('Simple Control')).toHaveClass('active');
+    expect(screen.getByText('Entry')).not.toHaveClass('active');
+
+    fireEvent.click(screen.getByText('3D View'));
+
+    expect(setCurrentSection).toHaveBeenCalledWith('3d');
+  });
+
+  it('positions the active bubble from the selected item bounds', () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      if (this.classList.contains('navbar')) {
+        return { left: 20, top: 0, width: 300, height: 40, right: 320, bottom: 40, x: 20, y: 0, toJSON: () => {} };
+      }
+
+      if (this.textContent === 'Entry') {
+        return { left: 20, top: 0, width: 60, height: 32, right: 80, bottom: 32, x: 20, y: 0, toJSON: () => {} };
+      }
+
+      return { left: 100, top: 0, width: 120, height: 32, right: 220, bottom: 32, x: 100, y: 0, toJSON: () => {} };
+    };
+
+    try {
+      const { container } = render(<Navbar currentSection="entry" setCurrentSection={vi.fn()} />);
+
+      expect(container.querySelector('.navbar-bubble')).toHaveStyle({
+        left: '0px',
+        width: '60px',
+        height: '32px',
+      });
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
+  });
+});

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import './Navbar.css'; // We'll create this CSS file next
 
 type Section = 'entry' | 'simple' | '3d';
@@ -13,11 +13,11 @@ const Navbar: React.FC<NavbarProps> = ({ currentSection, setCurrentSection }) =>
   const navRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLLIElement | null)[]>([]);
 
-  const sections: { id: Section; label: string }[] = [
+  const sections: { id: Section; label: string }[] = useMemo(() => [
     { id: 'entry', label: 'Entry' },
     { id: 'simple', label: 'Simple Control' },
     { id: '3d', label: '3D View' },
-  ];
+  ], []);
 
   useEffect(() => {
     const currentItemIndex = sections.findIndex(sec => sec.id === currentSection);

--- a/src/components/VisualizationPanel.tsx
+++ b/src/components/VisualizationPanel.tsx
@@ -38,12 +38,13 @@ import PoseStampedViz from './visualizers/PoseStampedViz'; // Import PoseStamped
 import { PoseStampedOptions } from '../hooks/usePoseStampedClient'; // Import PoseStampedOptions
 
 import {
-  saveVisualizationState,
-  getVisualizationState
+  getVisualizationStateForKey,
+  saveVisualizationStateForKey
 } from '../utils/visualizationState';
 
 interface VisualizationPanelProps {
   ros: Ros | null; // Allow null ros object
+  storageKey?: string;
 }
 
 // Define the structure for a visualization configuration
@@ -84,12 +85,17 @@ const VALID_VISUALIZATION_TYPES: VisualizationConfig['type'][] = [
   'posestamped',
 ];
 
-const VisualizationPanel: React.FC<VisualizationPanelProps> = memo(({ ros }: VisualizationPanelProps) => {
+const DEFAULT_STORAGE_KEY = 'roboboy_3d_visualization_state';
+
+const VisualizationPanel: React.FC<VisualizationPanelProps> = memo(({
+  ros,
+  storageKey = DEFAULT_STORAGE_KEY,
+}: VisualizationPanelProps) => {
   // console.log(`--- VisualizationPanel Render Start ---`);
 
   const viewerRef = useRef<HTMLDivElement>(null);
   const [initialState] = useState(() => {
-    const savedState = getVisualizationState();
+    const savedState = getVisualizationStateForKey(storageKey);
     return {
       ...savedState,
       visualizations: savedState.visualizations.filter((viz) =>
@@ -143,10 +149,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = memo(({ ros }: Vis
         showTfFrameLabels,
         tfAxesScale,
       };
-      saveVisualizationState(stateToSave);
+      saveVisualizationStateForKey(storageKey, stateToSave);
       console.log('Saved visualization state:', stateToSave);
     }
-  }, [visualizations, fixedFrame, displayedTfFrames, showTfFrameLabels, tfAxesScale, isRosConnected]);
+  }, [visualizations, fixedFrame, displayedTfFrames, showTfFrameLabels, tfAxesScale, isRosConnected, storageKey]);
 
   // --- Callback for handling TF messages (populates store & extracts frames) ---
   const handleTFMessage = useCallback((message: any, isStatic: boolean) => {

--- a/src/components/gamepads/custom/CustomGamepadWrapper.test.tsx
+++ b/src/components/gamepads/custom/CustomGamepadWrapper.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CustomGamepadWrapper from './CustomGamepadWrapper';
+
+const getGamepadLayout = vi.fn();
+const customLayout = vi.fn(({ layout, ros, isEditing }) => (
+  <div data-testid="custom-layout" data-layout-id={layout.id} data-ros={String(Boolean(ros))} data-editing={String(isEditing)} />
+));
+
+vi.mock('../../../features/customGamepad/gamepadStorage', () => ({
+  getGamepadLayout: (...args: unknown[]) => getGamepadLayout(...args),
+}));
+
+vi.mock('../../../features/customGamepad/components/CustomGamepadLayout', () => ({
+  default: (props: any) => customLayout(props),
+}));
+
+describe('CustomGamepadWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the stored custom layout in play mode', () => {
+    getGamepadLayout.mockReturnValue({ layout: { id: 'layout-1' } });
+
+    render(<CustomGamepadWrapper ros={{ connected: true } as any} layoutId="layout-1" />);
+
+    expect(getGamepadLayout).toHaveBeenCalledWith('layout-1');
+    expect(screen.getByTestId('custom-layout')).toHaveAttribute('data-layout-id', 'layout-1');
+    expect(screen.getByTestId('custom-layout')).toHaveAttribute('data-editing', 'false');
+  });
+
+  it('shows a clear error when the layout cannot be loaded', () => {
+    getGamepadLayout.mockReturnValue(null);
+
+    render(<CustomGamepadWrapper ros={{} as any} layoutId="missing-layout" />);
+
+    expect(screen.getByText('Layout Not Found')).toBeInTheDocument();
+    expect(screen.getByText('The gamepad layout "missing-layout" could not be loaded.')).toBeInTheDocument();
+  });
+});

--- a/src/components/gamepads/gameboy/GameBoyLayout.test.tsx
+++ b/src/components/gamepads/gameboy/GameBoyLayout.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import GameBoyLayout from './GameBoyLayout';
+
+const publish = vi.fn();
+const advertise = vi.fn();
+const unadvertise = vi.fn();
+
+vi.mock('roslib', () => ({
+  default: {
+    Message: vi.fn(function (this: any, data) {
+      return data;
+    }),
+    Topic: vi.fn(function () {
+      return { advertise, publish, unadvertise };
+    }),
+  },
+}));
+
+describe('GameBoyLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('advertises /joy and publishes button presses', () => {
+    render(<GameBoyLayout ros={{} as any} />);
+
+    expect(advertise).toHaveBeenCalled();
+
+    fireEvent.pointerDown(screen.getByText('A'));
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        axes: [],
+        buttons: [0, 0, 0, 0, 1, 0, 0, 0],
+      })
+    );
+    expect(screen.getByText('A')).toHaveClass('active');
+  });
+
+  it('publishes all buttons released before unadvertising on unmount', () => {
+    const { unmount } = render(<GameBoyLayout ros={{} as any} />);
+
+    fireEvent.pointerDown(screen.getByText('B'));
+    publish.mockClear();
+
+    unmount();
+
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ buttons: Array(8).fill(0) }));
+    expect(unadvertise).toHaveBeenCalled();
+  });
+});

--- a/src/components/gamepads/standard/StandardPadLayout.test.tsx
+++ b/src/components/gamepads/standard/StandardPadLayout.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import StandardPadLayout from './StandardPadLayout';
+
+const publish = vi.fn();
+const advertise = vi.fn();
+const unadvertise = vi.fn();
+const joystickProps: any[] = [];
+
+vi.mock('roslib', () => ({
+  default: {
+    Message: vi.fn(function (this: any, data) {
+      return data;
+    }),
+    Topic: vi.fn(function () {
+      return { advertise, publish, unadvertise };
+    }),
+  },
+}));
+
+vi.mock('react-joystick-component', () => ({
+  Joystick: (props: any) => {
+    joystickProps.push(props);
+    const index = joystickProps.length - 1;
+    return (
+      <button
+        type="button"
+        data-testid={`joystick-${index}`}
+        data-base-color={props.baseColor}
+        data-stick-color={props.stickColor}
+        onClick={() => props.move({ x: 25, y: -50 })}
+        onDoubleClick={() => props.stop()}
+      />
+    );
+  },
+}));
+
+describe('StandardPadLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    joystickProps.length = 0;
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    document.documentElement.style.setProperty('--secondary-color', '#123456');
+    document.documentElement.style.setProperty('--primary-color', '#abcdef');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.style.removeProperty('--secondary-color');
+    document.documentElement.style.removeProperty('--primary-color');
+  });
+
+  it('publishes normalized axes for left and right joysticks', () => {
+    render(<StandardPadLayout ros={{} as any} />);
+
+    expect(advertise).toHaveBeenCalled();
+    let [leftJoystick, rightJoystick] = screen.getAllByRole('button');
+    expect(leftJoystick).toHaveAttribute('data-base-color', '#123456');
+
+    fireEvent.click(leftJoystick);
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ axes: [0.5, -1, 0, 0], buttons: [] }));
+
+    [, rightJoystick] = screen.getAllByRole('button');
+    fireEvent.click(rightJoystick);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(publish).toHaveBeenLastCalledWith(expect.objectContaining({ axes: [0.5, -1, 0.5, -1], buttons: [] }));
+
+    [leftJoystick] = screen.getAllByRole('button');
+    fireEvent.doubleClick(leftJoystick);
+    expect(publish).toHaveBeenLastCalledWith(expect.objectContaining({ axes: [0, 0, 0.5, -1], buttons: [] }));
+  });
+
+  it('sends a stop command and unadvertises on unmount', () => {
+    const { unmount } = render(<StandardPadLayout ros={{} as any} />);
+
+    fireEvent.click(screen.getAllByRole('button')[1]);
+    publish.mockClear();
+
+    unmount();
+
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ axes: [0, 0, 0, 0] }));
+    expect(unadvertise).toHaveBeenCalled();
+  });
+
+  it('updates joystick colors when the document theme changes', async () => {
+    vi.useRealTimers();
+    render(<StandardPadLayout ros={{} as any} />);
+
+    act(() => {
+      document.documentElement.style.setProperty('--secondary-color', '#654321');
+      document.documentElement.style.setProperty('--primary-color', '#fedcba');
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    await waitFor(() => {
+      const [leftJoystick] = screen.getAllByRole('button');
+      expect(leftJoystick).toHaveAttribute('data-base-color', '#654321');
+      expect(leftJoystick).toHaveAttribute('data-stick-color', '#fedcba');
+    });
+  });
+});

--- a/src/components/gamepads/voice/VoiceLayout.test.tsx
+++ b/src/components/gamepads/voice/VoiceLayout.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import VoiceLayout from './VoiceLayout';
+
+const publish = vi.fn();
+const advertise = vi.fn();
+const unadvertise = vi.fn();
+const stopTrack = vi.fn();
+let recorderInstance: FakeMediaRecorder | null = null;
+
+class FakeMediaRecorder {
+  state = 'inactive';
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onstop: (() => void) | null = null;
+
+  start = vi.fn(() => {
+    this.state = 'recording';
+  });
+
+  stop = vi.fn(() => {
+    this.state = 'inactive';
+    this.ondataavailable?.({ data: new Blob(['audio']) } as BlobEvent);
+    this.onstop?.();
+  });
+
+  constructor() {
+    recorderInstance = this;
+  }
+}
+
+vi.mock('roslib', () => ({
+  default: {
+    Message: vi.fn(function (this: any, data) {
+      return data;
+    }),
+    Topic: vi.fn(function () {
+      return { advertise, publish, unadvertise };
+    }),
+  },
+}));
+
+describe('VoiceLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recorderInstance = null;
+    stopTrack.mockClear();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    Object.defineProperty(globalThis, 'MediaRecorder', {
+      value: FakeMediaRecorder,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getTracks: () => [{ stop: stopTrack }],
+        }),
+      },
+      configurable: true,
+    });
+  });
+
+  it('records audio and publishes placeholder voice data when stopped', async () => {
+    render(<VoiceLayout ros={{} as any} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record' }));
+
+    await screen.findByText('Recording... Click Stop to send.');
+    expect(recorderInstance?.start).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+
+    await waitFor(() => {
+      expect(publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: [0.1, 0.2, 0.3],
+        })
+      );
+    });
+    expect(stopTrack).toHaveBeenCalled();
+    expect(screen.getByText('Voice command sent (dummy)')).toBeInTheDocument();
+  });
+
+  it('shows an error if microphone permission fails', async () => {
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValueOnce(new Error('denied'));
+
+    render(<VoiceLayout ros={{} as any} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Record' }));
+
+    expect(await screen.findByText('Error: Could not access microphone.')).toBeInTheDocument();
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('stops an active recorder and unadvertises on unmount', async () => {
+    const { unmount } = render(<VoiceLayout ros={{} as any} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Record' }));
+    await screen.findByText('Recording... Click Stop to send.');
+
+    unmount();
+
+    expect(recorderInstance?.stop).toHaveBeenCalled();
+    expect(unadvertise).toHaveBeenCalled();
+  });
+});

--- a/src/features/theme/components/ThemeCreator.test.tsx
+++ b/src/features/theme/components/ThemeCreator.test.tsx
@@ -64,7 +64,7 @@ describe('ThemeCreator', () => {
           name: 'Existing',
           iconId: 'moon',
           fontFamily: DEFAULT_THEME_FONT_FAMILY,
-          colors: { primary: '#000001', secondary: '#000002' },
+          colors: { primary: '#000001', secondary: '#000002', background: '#ffffff' },
         }}
       />
     );

--- a/src/features/theme/components/ThemeCreator.test.tsx
+++ b/src/features/theme/components/ThemeCreator.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ThemeCreator from './ThemeCreator';
+import { DEFAULT_THEME_FONT_FAMILY } from '../themeUtils';
+
+vi.mock('uuid', () => ({ v4: () => 'generated-theme-id' }));
+
+describe('ThemeCreator', () => {
+  const onClose = vi.fn();
+  const onSave = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<ThemeCreator isOpen={false} onClose={onClose} onSave={onSave} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('creates a new theme with selected colors, icon, and font', () => {
+    render(<ThemeCreator isOpen onClose={onClose} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText('Theme Name'), { target: { value: ' Shop Floor ' } });
+    fireEvent.change(screen.getByLabelText('Primary'), { target: { value: '#112233' } });
+    fireEvent.click(screen.getByLabelText('Select star icon'));
+    fireEvent.change(screen.getByLabelText('Font'), { target: { value: DEFAULT_THEME_FONT_FAMILY } });
+    fireEvent.click(screen.getByText('Save Theme'));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'generated-theme-id',
+        name: 'Shop Floor',
+        iconId: 'star',
+        fontFamily: DEFAULT_THEME_FONT_FAMILY,
+        colors: expect.objectContaining({ primary: '#112233' }),
+      })
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('requires a non-empty theme name', () => {
+    render(<ThemeCreator isOpen onClose={onClose} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText('Theme Name'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('Save Theme'));
+
+    expect(window.alert).toHaveBeenCalledWith('Please enter a theme name.');
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('pre-populates and updates an existing theme', () => {
+    render(
+      <ThemeCreator
+        isOpen
+        onClose={onClose}
+        onSave={onSave}
+        existingTheme={{
+          id: 'existing-theme',
+          name: 'Existing',
+          iconId: 'moon',
+          fontFamily: DEFAULT_THEME_FONT_FAMILY,
+          colors: { primary: '#000001', secondary: '#000002' },
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText('Theme Name')).toHaveValue('Existing');
+    expect(screen.getByLabelText('Select moon icon')).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.change(screen.getByLabelText('Theme Name'), { target: { value: 'Updated' } });
+    fireEvent.click(screen.getByText('Save Theme'));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'existing-theme',
+        name: 'Updated',
+        iconId: 'moon',
+      })
+    );
+  });
+});

--- a/src/features/theme/components/ThemeSelector.test.tsx
+++ b/src/features/theme/components/ThemeSelector.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ThemeSelector from './ThemeSelector';
+
+const themes = [
+  { id: 'light', name: 'Light', isDefault: true },
+  { id: 'dark', name: 'Dark', isDefault: true },
+  { id: 'custom-theme', name: 'Workshop', isDefault: false },
+];
+
+describe('ThemeSelector', () => {
+  const selectTheme = vi.fn();
+  const openThemeCreator = vi.fn();
+  const deleteTheme = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('opens the menu and selects a theme', () => {
+    render(
+      <ThemeSelector
+        currentThemeId="light"
+        selectTheme={selectTheme}
+        themes={themes}
+        openThemeCreator={openThemeCreator}
+        deleteTheme={deleteTheme}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Select theme'));
+    expect(screen.getByRole('button', { name: /dark/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dark/i }));
+
+    expect(selectTheme).toHaveBeenCalledWith('dark');
+    expect(screen.getByLabelText('Select theme')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('edits, deletes, and creates custom themes from the menu', () => {
+    render(
+      <ThemeSelector
+        currentThemeId="custom-theme"
+        selectTheme={selectTheme}
+        themes={themes}
+        openThemeCreator={openThemeCreator}
+        deleteTheme={deleteTheme}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Select theme'));
+    fireEvent.click(screen.getByLabelText('Edit Workshop'));
+    expect(openThemeCreator).toHaveBeenCalledWith('custom-theme');
+
+    fireEvent.click(screen.getByLabelText('Select theme'));
+    fireEvent.click(screen.getByLabelText('Delete Workshop'));
+    expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to delete the theme "Workshop"?');
+    expect(deleteTheme).toHaveBeenCalledWith('custom-theme');
+
+    fireEvent.click(screen.getByLabelText('Select theme'));
+    fireEvent.click(screen.getByText('Create New Theme...'));
+    expect(openThemeCreator).toHaveBeenCalledWith();
+  });
+
+  it('keeps the menu open when deletion is cancelled', () => {
+    vi.mocked(window.confirm).mockReturnValue(false);
+
+    render(
+      <ThemeSelector
+        currentThemeId="custom-theme"
+        selectTheme={selectTheme}
+        themes={themes}
+        openThemeCreator={openThemeCreator}
+        deleteTheme={deleteTheme}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Select theme'));
+    fireEvent.click(screen.getByLabelText('Delete Workshop'));
+
+    expect(deleteTheme).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Select theme')).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/src/hooks/useThreePanelLayout.test.ts
+++ b/src/hooks/useThreePanelLayout.test.ts
@@ -1,0 +1,112 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useThreePanelLayout } from './useThreePanelLayout';
+
+const createMouseEvent = () => ({ preventDefault: vi.fn() }) as any;
+const createTouchEvent = (clientY = 0) => ({
+  preventDefault: vi.fn(),
+  touches: [{ clientY }],
+}) as any;
+
+describe('useThreePanelLayout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  });
+
+  it('loads valid stored heights and persists updates', () => {
+    localStorage.setItem('panels', JSON.stringify({ bt: 25, view: 50, control: 25 }));
+
+    const { result } = renderHook(() => useThreePanelLayout({ storageKey: 'panels' }));
+
+    expect(result.current.btHeight).toBe(25);
+    expect(result.current.viewHeight).toBe(50);
+    expect(result.current.controlHeight).toBe(25);
+    expect(localStorage.getItem('panels')).toBe(JSON.stringify({ bt: 25, view: 50, control: 25 }));
+  });
+
+  it('falls back when stored heights are invalid', () => {
+    localStorage.setItem('panels', JSON.stringify({ bt: 90, view: 5, control: 5 }));
+
+    const { result } = renderHook(() =>
+      useThreePanelLayout({ initialBtHeight: 30, initialViewHeight: 45, minPanelHeight: 15, storageKey: 'panels' })
+    );
+
+    expect(result.current.btHeight).toBe(30);
+    expect(result.current.viewHeight).toBe(45);
+    expect(result.current.controlHeight).toBe(25);
+  });
+
+  it('resizes the behavior tree panel with pointer movement', () => {
+    const { result } = renderHook(() => useThreePanelLayout({ minPanelHeight: 15 }));
+    const container = document.createElement('div');
+    container.getBoundingClientRect = vi.fn(() => ({
+      top: 100,
+      left: 0,
+      width: 400,
+      height: 500,
+      right: 400,
+      bottom: 600,
+      x: 0,
+      y: 100,
+      toJSON: () => {},
+    }));
+
+    act(() => {
+      result.current.containerRef.current = container;
+      result.current.handleBtViewMouseDown(createMouseEvent());
+    });
+
+    expect(result.current.activeHandle).toBe('bt-view');
+    expect(document.body.style.cursor).toBe('row-resize');
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientY: 300 }));
+    });
+
+    expect(result.current.btHeight).toBe(40);
+    expect(result.current.viewHeight).toBe(40);
+    expect(result.current.controlHeight).toBe(20);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'));
+    });
+
+    expect(result.current.isDragging).toBe(false);
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  it('supports touch resizing for the view/control divider', () => {
+    const { result } = renderHook(() => useThreePanelLayout({ initialBtHeight: 30, initialViewHeight: 40 }));
+    const container = document.createElement('div');
+    container.getBoundingClientRect = vi.fn(() => ({
+      top: 0,
+      left: 0,
+      width: 300,
+      height: 400,
+      right: 300,
+      bottom: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }));
+
+    act(() => {
+      result.current.containerRef.current = container;
+      result.current.handleViewControlTouchStart(createTouchEvent());
+    });
+
+    act(() => {
+      const touchMove = new Event('touchmove') as TouchEvent;
+      Object.defineProperty(touchMove, 'touches', {
+        value: [{ clientY: 260 }],
+      });
+      document.dispatchEvent(touchMove);
+    });
+
+    expect(result.current.btHeight).toBe(30);
+    expect(result.current.viewHeight).toBe(35);
+    expect(result.current.controlHeight).toBe(35);
+  });
+});

--- a/src/hooks/useThreePanelLayout.test.ts
+++ b/src/hooks/useThreePanelLayout.test.ts
@@ -54,7 +54,7 @@ describe('useThreePanelLayout', () => {
     }));
 
     act(() => {
-      result.current.containerRef.current = container;
+      (result.current.containerRef as any).current = container;
       result.current.handleBtViewMouseDown(createMouseEvent());
     });
 
@@ -93,7 +93,7 @@ describe('useThreePanelLayout', () => {
     }));
 
     act(() => {
-      result.current.containerRef.current = container;
+      (result.current.containerRef as any).current = container;
       result.current.handleViewControlTouchStart(createTouchEvent());
     });
 

--- a/src/utils/ros3dUrdfClient.test.ts
+++ b/src/utils/ros3dUrdfClient.test.ts
@@ -89,5 +89,5 @@ describe('UrdfClient cache', () => {
     expect(roslibMock.topicInstances).toHaveLength(1);
     expect(secondModel).toBe(firstModel);
     expect(rootObject.children).toContain(secondClient);
-  });
+  }, 10000);
 });

--- a/src/utils/visualizationState.test.ts
+++ b/src/utils/visualizationState.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { saveVisualizationState, getVisualizationState, clearVisualizationState } from './visualizationState';
+import {
+  clearVisualizationState,
+  clearVisualizationStateForKey,
+  getVisualizationState,
+  getVisualizationStateForKey,
+  saveVisualizationState,
+  saveVisualizationStateForKey,
+} from './visualizationState';
 
 describe('visualizationState', () => {
   beforeEach(() => {
@@ -7,6 +14,8 @@ describe('visualizationState', () => {
     localStorage.clear();
     // Clear internal state by calling clear
     clearVisualizationState();
+    clearVisualizationStateForKey('panel-a');
+    clearVisualizationStateForKey('panel-b');
   });
 
   const mockState = {
@@ -95,6 +104,19 @@ describe('visualizationState', () => {
 
     expect(getVisualizationState()).toEqual(urdfState);
     expect(JSON.parse(localStorage.getItem('roboboy_3d_visualization_state')!)).toEqual(urdfState);
+  });
+
+  it('should keep keyed visualization states independent', () => {
+    const panelAState = { ...mockState, fixedFrame: 'map' };
+    const panelBState = { ...mockState, fixedFrame: 'base_link' };
+
+    saveVisualizationStateForKey('panel-a', panelAState);
+    saveVisualizationStateForKey('panel-b', panelBState);
+
+    expect(getVisualizationStateForKey('panel-a')).toEqual(panelAState);
+    expect(getVisualizationStateForKey('panel-b')).toEqual(panelBState);
+    expect(JSON.parse(localStorage.getItem('panel-a')!)).toEqual(panelAState);
+    expect(JSON.parse(localStorage.getItem('panel-b')!)).toEqual(panelBState);
   });
 
   it('should clear state', () => {

--- a/src/utils/visualizationState.ts
+++ b/src/utils/visualizationState.ts
@@ -25,9 +25,10 @@ export const DEFAULT_VISUALIZATION_STATE: VisualizationPanelState = {
   tfAxesScale: 0.5,
 };
 
+const DEFAULT_STORAGE_KEY = 'roboboy_3d_visualization_state';
+
 // Keep an explicit flag because an empty visualization list is still valid saved state.
-let hasSavedStateInMemory = false;
-let savedState: VisualizationPanelState = { ...DEFAULT_VISUALIZATION_STATE };
+const inMemoryState = new Map<string, VisualizationPanelState>();
 
 const normalizeVisualizationState = (
   state: Partial<VisualizationPanelState> | null | undefined
@@ -46,12 +47,16 @@ const normalizeVisualizationState = (
  * @param state Current visualization panel state
  */
 export const saveVisualizationState = (state: VisualizationPanelState): void => {
-  savedState = normalizeVisualizationState(state);
-  hasSavedStateInMemory = true;
+  saveVisualizationStateForKey(DEFAULT_STORAGE_KEY, state);
+};
+
+export const saveVisualizationStateForKey = (storageKey: string, state: VisualizationPanelState): void => {
+  const normalizedState = normalizeVisualizationState(state);
+  inMemoryState.set(storageKey, normalizedState);
   
   // Also save to localStorage for persistence across sessions
   try {
-    localStorage.setItem('roboboy_3d_visualization_state', JSON.stringify(savedState));
+    localStorage.setItem(storageKey, JSON.stringify(normalizedState));
   } catch (error) {
     console.error('Failed to save visualization state to localStorage:', error);
   }
@@ -62,18 +67,22 @@ export const saveVisualizationState = (state: VisualizationPanelState): void => 
  * @returns The saved visualization panel state
  */
 export const getVisualizationState = (): VisualizationPanelState => {
+  return getVisualizationStateForKey(DEFAULT_STORAGE_KEY);
+};
+
+export const getVisualizationStateForKey = (storageKey: string): VisualizationPanelState => {
   // If we have in-memory state, return that
-  if (hasSavedStateInMemory) {
+  const savedState = inMemoryState.get(storageKey);
+  if (savedState) {
     return { ...savedState };
   }
   
   // Otherwise try to load from localStorage
   try {
-    const savedStateStr = localStorage.getItem('roboboy_3d_visualization_state');
+    const savedStateStr = localStorage.getItem(storageKey);
     if (savedStateStr) {
       const parsedState = normalizeVisualizationState(JSON.parse(savedStateStr));
-      savedState = parsedState; // Update in-memory state
-      hasSavedStateInMemory = true;
+      inMemoryState.set(storageKey, parsedState);
       return parsedState;
     }
   } catch (error) {
@@ -88,11 +97,14 @@ export const getVisualizationState = (): VisualizationPanelState => {
  * Clear the saved visualization state
  */
 export const clearVisualizationState = (): void => {
-  savedState = { ...DEFAULT_VISUALIZATION_STATE };
-  hasSavedStateInMemory = false;
+  clearVisualizationStateForKey(DEFAULT_STORAGE_KEY);
+};
+
+export const clearVisualizationStateForKey = (storageKey: string): void => {
+  inMemoryState.delete(storageKey);
   
   try {
-    localStorage.removeItem('roboboy_3d_visualization_state');
+    localStorage.removeItem(storageKey);
   } catch (error) {
     console.error('Failed to clear visualization state from localStorage:', error);
   }


### PR DESCRIPTION
## Description

Adds a desktop multiview workspace optimized for larger screens.

## What Changed

* Added grid/multiview mode with draggable and resizable workspace tiles.
* Added support for camera, 3D visualization, behavior tree, and pad control tiles.
* Added horizontal and vertical tile splitting via drag and drop.
* Added named workspace layouts with save, load, delete, import, and export support.
* Preserved workspace state when switching between split/mobile view and grid mode.
* Improved the multiview pad selector UI and popup behavior.
* Kept visualization state isolated per panel.
