### PR TITLE
Validate a promotion while its pull request is still open

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -12,7 +12,7 @@ on:
         required: false
   workflow_dispatch:
   pull_request:
-    types: [closed]
+    types: [opened, synchronize, reopened]
     branches: [main]
 
 permissions:
@@ -25,11 +25,10 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.name }}
-    # On a pull request this only validates the revision that reached main, matching how the
-    # Docker build test is gated. Every other trigger is explicit.
+    # On a pull request this validates the promotion of dev into main before it lands, matching
+    # how the Docker build test is gated. Every other trigger is explicit.
     if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev')
+      github.event_name != 'pull_request' || github.event.pull_request.head.ref == 'dev'
     runs-on: ${{ matrix.runner }}
 
     strategy:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -2,30 +2,26 @@ name: Docker Build
 
 on:
   pull_request:
-    types: [closed]
+    types: [opened, synchronize, reopened]
     branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
-  group: docker-build-dev-to-main
-  cancel-in-progress: false
+  group: docker-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   docker-build-test:
     name: Docker Build Test
-    if: >-
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'dev' &&
-      github.event.pull_request.base.ref == 'main'
+    if: github.event.pull_request.head.ref == 'dev'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out merged revision
+      # The default pull_request checkout is the merge result, which is what merging would produce.
+      - name: Check out the merge result
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The Docker build test ran on pull_request closed, so it only ever reported after the merge it was meant to vet. Required as a merge check, it therefore blocked the pull request forever: the status could not arrive until the merge it was gating had already happened, which is what leaves a promotion waiting for a status to be reported.

It now runs while the pull request is open, against the merge result GitHub already computes, so it reports before the merge and can gate it. The desktop build validation moves for the same reason: catching a broken installer while the promotion can still be stopped is the point of validating it. Runs are now per pull request and supersede themselves, so pushing again does not queue another full build behind the last one.