### PR TITLE
fix(android): ship optimized signed release APK

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -91,7 +91,9 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Install Android build packages
-        run: sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.0.12077973'
+        run: |
+          sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.0.12077973'
+          echo "${ANDROID_HOME}/build-tools/36.0.0" >> "${GITHUB_PATH}"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,7 +1,7 @@
 name: Android Build
 
-# Every Android change is proved by a signed debug APK that can be installed without a Play signing
-# key. The same workflow is callable by Release Please so the official release carries the APK.
+# The application is compiled with Rust and Android release optimization, then signed with the
+# repository's permanent Android key. Release Please calls the same workflow for published APKs.
 on:
   workflow_call:
     inputs:
@@ -9,6 +9,15 @@ on:
         description: Revision to build. Defaults to the triggering revision.
         type: string
         required: false
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        required: true
+      ANDROID_KEYSTORE_PASSWORD:
+        required: true
+      ANDROID_KEY_ALIAS:
+        required: true
+      ANDROID_KEY_PASSWORD:
+        required: true
   workflow_dispatch:
   push:
     branches: [dev, main]
@@ -53,9 +62,11 @@ jobs:
         run: npm run build:tauri
 
   build:
-    name: Installable debug APK
+    name: Optimized signed APK
     runs-on: ubuntu-latest
     needs: shared-app
+    # Fork pull requests cannot receive the permanent signing key. Their shared app tests still run.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Check out source
@@ -95,20 +106,56 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build installable APK
+      - name: Configure release signing
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!name}" ]; then
+              echo "::error::${name} is not configured"
+              exit 1
+            fi
+          done
+          printf '%s' "${ANDROID_KEYSTORE_BASE64}" | base64 --decode > "${RUNNER_TEMP}/robo-boy-release.jks"
+          chmod 600 "${RUNNER_TEMP}/robo-boy-release.jks"
+          echo "ANDROID_RELEASE_KEYSTORE_PATH=${RUNNER_TEMP}/robo-boy-release.jks" >> "${GITHUB_ENV}"
+
+      - name: Build optimized installable APK
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.12077973
-        # Current Android phones and Wear OS devices are ARM64. Building only that ABI keeps the
-        # downloadable debug artifact practical; developers can build x86_64 locally for emulators.
-        run: npm run android:build -- --debug --ci --target aarch64
+          ANDROID_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        # Current phones are ARM64. One ABI plus the optimized Rust profile avoids shipping the
+        # hundreds of megabytes of symbols present in development builds.
+        run: npm run android:build -- --ci --target aarch64
 
       - name: Verify the build bundles no local panels
         run: npm run check:release-panels
 
+      - name: Verify release identity and signature
+        run: |
+          set -euo pipefail
+          mapfile -t apks < <(find src-tauri/gen/android/app/build/outputs/apk -type f -name '*-release.apk')
+          if [ "${#apks[@]}" -ne 1 ]; then
+            echo "::error::expected one signed release APK, found ${#apks[@]}"
+            exit 1
+          fi
+          apksigner verify --verbose "${apks[0]}"
+          badging="$(aapt dump badging "${apks[0]}")"
+          grep -Fq "package: name='la.tessel.roboboy'" <<< "${badging}"
+          if grep -Fq "package: name='la.tessel.roboboy.debug'" <<< "${badging}"; then
+            echo "::error::release APK still has the debug application id"
+            exit 1
+          fi
+
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: robo-boy-android-debug
+          name: robo-boy-android
           if-no-files-found: error
           retention-days: 14
-          path: src-tauri/gen/android/app/build/outputs/apk/**/*.apk
+          path: src-tauri/gen/android/app/build/outputs/apk/**/*-release.apk

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,6 +64,7 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/android-build.yml
+    secrets: inherit
     with:
       ref: ${{ needs.release-please.outputs.tag_name }}
 
@@ -101,7 +102,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: android
-          pattern: robo-boy-android-debug
+          pattern: robo-boy-android
           merge-multiple: true
 
       # A built installer carries the version in its name, so nothing can link to one before the
@@ -151,7 +152,7 @@ jobs:
             echo "::error::expected one Android APK, found ${#apks[@]}"
             exit 1
           fi
-          cp "${apks[0]}" android/Robo-Boy-android-debug.apk
+          cp "${apks[0]}" android/Robo-Boy-android.apk
 
       - name: Attach installers to the GitHub release
         env:

--- a/docs/android.md
+++ b/docs/android.md
@@ -54,8 +54,14 @@ npm run android:build -- --debug --target aarch64
 adb install -r src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk
 ```
 
-The debug APK is signed with Android's development key. Production Play Store delivery needs a
-private release signing key and is intentionally not configured in this sandbox.
+The debug APK is signed with Android's development key and installs as
+`la.tessel.roboboy.debug`, alongside the production app. It is intentionally large because it
+retains Rust native symbols for diagnosis.
+
+Production builds use the package id `la.tessel.roboboy`, enable Android/Rust size optimization,
+and must use the permanent project signing key. Local release signing reads these environment
+variables: `ANDROID_RELEASE_KEYSTORE_PATH`, `ANDROID_RELEASE_KEYSTORE_PASSWORD`,
+`ANDROID_RELEASE_KEY_ALIAS`, and `ANDROID_RELEASE_KEY_PASSWORD`. Never commit the key or passwords.
 
 ## Connect To ROS
 
@@ -78,9 +84,11 @@ control is used; denying it leaves the rest of Robo-Boy usable.
 
 ## CI APK
 
-The **Android Build** workflow builds the same project on every pull request and push to `main`.
-Its `robo-boy-android-debug` artifact contains a signed, installable APK and needs no repository
-secrets. Download the artifact from the workflow run, unzip it, and install it with `adb install`.
+The **Android Build** workflow builds the same project on every pull request and push to `dev` or
+`main`. Its `robo-boy-android` artifact contains the optimized, production-signed APK. The signing
+key and passwords are repository secrets; losing that key prevents existing installations from
+accepting future updates. Download the artifact from the workflow run, unzip it, and install it
+with `adb install`.
 
 ## Wear OS Direction
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,3 +22,12 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2.11.3", features = [] }
 tauri-plugin-http = "2"
+
+# Mobile bundles pay for the Rust shell byte-for-byte. Keep production artifacts compact while
+# preserving debug profiles for local diagnosis.
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -13,6 +13,17 @@ val tauriProperties = Properties().apply {
     }
 }
 
+val releaseKeystorePath = System.getenv("ANDROID_RELEASE_KEYSTORE_PATH")
+val releaseKeystorePassword = System.getenv("ANDROID_RELEASE_KEYSTORE_PASSWORD")
+val releaseKeyAlias = System.getenv("ANDROID_RELEASE_KEY_ALIAS")
+val releaseKeyPassword = System.getenv("ANDROID_RELEASE_KEY_PASSWORD")
+val hasReleaseSigning = listOf(
+    releaseKeystorePath,
+    releaseKeystorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword,
+).all { !it.isNullOrBlank() }
+
 android {
     compileSdk = 36
     namespace = "la.tessel.roboboy"
@@ -25,6 +36,16 @@ android {
         targetSdk = 36
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
+    }
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("production") {
+                storeFile = file(checkNotNull(releaseKeystorePath))
+                storePassword = releaseKeystorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
     }
     buildTypes {
         getByName("debug") {
@@ -41,6 +62,7 @@ android {
             }
         }
         getByName("release") {
+            if (hasReleaseSigning) signingConfig = signingConfigs.getByName("production")
             isMinifyEnabled = true
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }


### PR DESCRIPTION
## Summary

- build the Android artifact as an optimized release APK instead of a debug APK
- use the production package `la.tessel.roboboy` and app label `Robo-Boy`
- sign CI and release APKs with repository secrets and verify the resulting signature/package
- publish the stable artifact name `Robo-Boy-android.apk`
- reduce the ARM64 APK from about 169 MB (debug) to about 11 MB (optimized release)

## Verification

- 25 Android/mobile frontend tests pass
- ESLint passes
- optimized ARM64 release APK builds locally
- APK Signature Scheme v2 verification passes
- package and label verified as `la.tessel.roboboy` / `Robo-Boy`

The exact CI-built APK will be installed and tested on a Samsung phone before merge.