### PR TITLE
ci(workflows): isolate Rust caches per job to avoid glibc mismatch

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -104,6 +104,11 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
+          # rust-cache buckets by the coarse Linux/Windows/macOS runner.os, not the specific
+          # ubuntu-latest vs ubuntu-22.04 image. Without this key, this job's host-target build
+          # scripts (compiled against ubuntu-latest's glibc) could be restored into the Linux
+          # desktop installer job's target/ dir, which is pinned to ubuntu-22.04's older glibc.
+          shared-key: android
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -77,6 +77,12 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
+          # rust-cache buckets by the coarse Linux/Windows/macOS runner.os, not the specific
+          # ubuntu-latest vs ubuntu-22.04 image, so give each matrix leg its own bucket. This
+          # matters most for Linux: it is deliberately pinned to ubuntu-22.04's older glibc, and
+          # without this key it could restore host-target build scripts cached by another Linux
+          # job on ubuntu-latest's newer glibc, which then fail to run here.
+          shared-key: desktop-${{ matrix.artifact }}
 
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
android-build.yml's job (ubuntu-latest, newer glibc) and desktop-build.yml's Linux installer job (pinned to ubuntu-22.04 for compatibility) both cache the same src-tauri -> target workspace via swatinem/rust-cache with no distinguishing key. rust-cache buckets by the coarse Linux/Windows/macOS runner.os, not the specific Ubuntu image, so the Android job's host-target build scripts were restored into the Linux desktop job's target dir and failed there (GLIBC_2.39 not found) — this broke the Linux installer build in the robo-boy-v0.6.1-alpha release, leaving it with no attached assets.

Gives each job its own shared-key so their Rust caches never collide.