### PR TITLE
feat: add configurable physical gamepad

### DIFF
--- a/docs/custom-gamepads.md
+++ b/docs/custom-gamepads.md
@@ -30,6 +30,8 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 
 The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at a configurable 1-60 Hz (20 Hz by default) while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
 
+The responsive visualization uses the full built-in pad width on phones and works in portrait or landscape. Web, iOS, and Android use the same browser Gamepad API path; a controller must be paired with the device and a button may need to be pressed after the app gains focus. If the platform WebView does not expose the API, the pad reports that explicitly. Hiding or suspending the app publishes a neutral Joy message before polling pauses.
+
 Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Publish rate, stick deadzone, and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
 
 ## Runtime Flow

--- a/docs/custom-gamepads.md
+++ b/docs/custom-gamepads.md
@@ -14,16 +14,23 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 
 ## Supported Components
 
-| Component | Primary role                                                            |
-| --------- | ----------------------------------------------------------------------- |
-| Joystick  | Publish continuous axes, including Joy, Twist, and PoseStamped mappings |
-| Button    | Publish pressed and released values or indexed Joy buttons              |
-| D-pad     | Publish discrete directional input                                      |
-| Toggle    | Maintain and publish an on/off state                                    |
-| Slider    | Publish a bounded numeric value                                         |
-| Camera    | Display a proxied or ROS-delivered image stream                         |
-| Plot      | Subscribe to numeric fields and render recent samples                   |
-| Heartbeat | Monitor boolean state or recurring messages                             |
+| Component       | Primary role                                                                      |
+| --------------- | --------------------------------------------------------------------------------- |
+| Joystick        | Publish continuous virtual axes, including Joy, Twist, and PoseStamped mappings  |
+| Physical gamepad | Read and visualize a browser-connected Xbox, PlayStation, or Logitech controller |
+| Button          | Publish pressed and released values or indexed Joy buttons                        |
+| D-pad           | Publish discrete directional input                                                |
+| Toggle          | Maintain and publish an on/off state                                              |
+| Slider          | Publish a bounded numeric value                                                   |
+| Camera          | Display a proxied or ROS-delivered image stream                                   |
+| Plot            | Subscribe to numeric fields and render recent samples                             |
+| Heartbeat       | Monitor boolean state or recurring messages                                       |
+
+## Physical Controllers
+
+The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at 20 Hz while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
+
+Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Stick deadzone and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
 
 ## Runtime Flow
 
@@ -43,6 +50,7 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 | Built-in templates and palette           | `src/features/customGamepad/defaultLayouts.ts`                  |
 | Import, export, and persistence          | `src/features/customGamepad/gamepadStorage.ts`                  |
 | ROS message conversion and introspection | `src/features/customGamepad/rosMessageUtils.ts`                 |
+| Physical-controller normalization        | `src/features/customGamepad/physicalGamepad.ts`                 |
 | Editor                                   | `src/features/customGamepad/components/GamepadEditor.tsx`       |
 | Runtime renderer                         | `src/features/customGamepad/components/CustomGamepadLayout.tsx` |
 | Component dispatch and editor shell      | `src/features/customGamepad/components/GamepadComponent.tsx`    |

--- a/docs/custom-gamepads.md
+++ b/docs/custom-gamepads.md
@@ -28,9 +28,9 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 
 ## Physical Controllers
 
-The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at 20 Hz while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
+The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at a configurable 1-60 Hz (20 Hz by default) while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
 
-Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Stick deadzone and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
+Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Publish rate, stick deadzone, and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
 
 ## Runtime Flow
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -46,11 +46,14 @@ Trees are stored in the current browser and can be imported or exported as JSON.
 The lower control area starts empty. Use the `+` button to:
 
 - Clone the built-in dual-joystick and heartbeat template.
+- Clone the built-in physical-gamepad template for an Xbox, PlayStation, or Logitech controller.
 - Create a control pad from an empty grid.
 - Open a control pad saved in this browser.
 - Import a versioned control-pad JSON file.
 
-The editor supports joystick, button, D-pad, toggle, slider, camera, plot, and heartbeat components. Each ROS-aware component can be assigned a topic, message type, field mapping, and component-specific options.
+The editor supports virtual joystick, physical gamepad, button, D-pad, toggle, slider, camera, plot, and heartbeat components. A physical gamepad publishes its complete axes and button state as `sensor_msgs/Joy`; each of its 17 standard buttons can also run an independent topic publish, service call, or action on press and release. The live controller drawing follows both sticks and highlights active buttons. Browsers expose a newly connected controller only after you press one of its buttons.
+
+Choose automatic controller detection for normal use, or force Xbox, PlayStation, or Logitech labels and stick placement. If the controller reports a non-standard browser mapping, Robo-Boy warns you to verify its indices before driving.
 
 Saved pads belong to the current browser profile. Export important layouts before clearing site data.
 

--- a/src/features/customGamepad/components/ComponentPalette.test.tsx
+++ b/src/features/customGamepad/components/ComponentPalette.test.tsx
@@ -12,6 +12,7 @@ vi.mock('./SliderComponent', () => ({ default: () => <span /> }));
 vi.mock('./CameraComponent', () => ({ default: () => <span /> }));
 vi.mock('./PlotComponent', () => ({ default: () => <span /> }));
 vi.mock('./HeartbeatComponent', () => ({ default: () => <span /> }));
+vi.mock('./PhysicalGamepadComponent', () => ({ default: () => <span /> }));
 
 describe('ComponentPalette touch gestures', () => {
   afterEach(() => vi.useRealTimers());

--- a/src/features/customGamepad/components/ComponentPalette.tsx
+++ b/src/features/customGamepad/components/ComponentPalette.tsx
@@ -9,6 +9,7 @@ import SliderComponent from './SliderComponent';
 import CameraComponent from './CameraComponent';
 import PlotComponent from './PlotComponent';
 import HeartbeatComponent from './HeartbeatComponent';
+import PhysicalGamepadComponent from './PhysicalGamepadComponent';
 import './ComponentPalette.css';
 
 interface ComponentPaletteProps {
@@ -80,7 +81,9 @@ const ComponentPalette: React.FC<ComponentPaletteProps> = ({
             ? { fieldPath: 'data', fieldPaths: ['data'], timeWindowSec: 10, autoScale: true }
             : componentType === 'heartbeat'
               ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
-            : {}
+              : componentType === 'physical-gamepad'
+                ? { physicalGamepadProfile: 'xbox' as const, physicalGamepadDeadzone: 0.08 }
+                : {}
     };
 
     const previewStyle: React.CSSProperties = {
@@ -112,6 +115,7 @@ const ComponentPalette: React.FC<ComponentPaletteProps> = ({
       <div style={containerStyle}>
         {componentType === 'button' && <ButtonComponent {...componentProps} />}
         {componentType === 'joystick' && <JoystickComponent {...componentProps} />}
+        {componentType === 'physical-gamepad' && <PhysicalGamepadComponent {...componentProps} />}
         {componentType === 'dpad' && <DPadComponent {...componentProps} />}
         {componentType === 'toggle' && <ToggleComponent {...componentProps} />}
         {componentType === 'slider' && <SliderComponent {...componentProps} />}

--- a/src/features/customGamepad/components/ComponentPalette.tsx
+++ b/src/features/customGamepad/components/ComponentPalette.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { componentLibrary } from '../defaultLayouts';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ } from '../physicalGamepad';
 import { GamepadComponentConfig } from '../types';
 import ButtonComponent from './ButtonComponent';
 import JoystickComponent from './JoystickComponent';
@@ -82,7 +83,11 @@ const ComponentPalette: React.FC<ComponentPaletteProps> = ({
             : componentType === 'heartbeat'
               ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
               : componentType === 'physical-gamepad'
-                ? { physicalGamepadProfile: 'xbox' as const, physicalGamepadDeadzone: 0.08 }
+                ? {
+                  physicalGamepadProfile: 'xbox' as const,
+                  physicalGamepadDeadzone: 0.08,
+                  physicalGamepadPublishHz: DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+                }
                 : {}
     };
 

--- a/src/features/customGamepad/components/ComponentSettingsModal.css
+++ b/src/features/customGamepad/components/ComponentSettingsModal.css
@@ -28,6 +28,57 @@
   font-family: inherit;
 }
 
+.physical-gamepad-settings .settings-help {
+  margin: -4px 0 12px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.physical-binding-count {
+  color: var(--text-secondary);
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.physical-control-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(82px, 1fr));
+  gap: 7px;
+  margin-bottom: 14px;
+}
+
+.physical-control-picker button {
+  min-height: 36px;
+  padding: 6px 8px;
+  color: var(--text-color);
+  background: var(--background-secondary);
+  border-color: var(--border-color);
+  font-size: 0.78rem;
+}
+
+.physical-control-picker button.configured {
+  border-color: var(--primary-color);
+}
+
+.physical-control-picker button.configured::after {
+  content: ' •';
+  color: var(--primary-color);
+}
+
+.physical-control-picker button.selected {
+  color: var(--button-text-color);
+  background: var(--primary-color);
+  border-color: var(--primary-hover-color);
+}
+
+.physical-control-binding {
+  min-width: 0;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
 /* Modal Header */
 .modal-header {
   display: flex;

--- a/src/features/customGamepad/components/ComponentSettingsModal.css
+++ b/src/features/customGamepad/components/ComponentSettingsModal.css
@@ -571,7 +571,7 @@
 /* Responsive Design */
 @media (max-width: 768px) {
   .component-settings-modal-overlay {
-    padding: 10px;
+    padding: calc(8px + var(--safe-area-top)) 8px calc(8px + var(--safe-area-bottom));
   }
 
   .enhanced-component-settings-modal {
@@ -608,6 +608,27 @@
   .cancel-btn,
   .save-btn {
     width: 100%;
+  }
+
+  .physical-gamepad-settings input:not([type="range"]),
+  .physical-gamepad-settings select,
+  .physical-gamepad-settings textarea {
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .physical-gamepad-settings input[type="range"] {
+    min-height: 44px;
+  }
+
+  .physical-control-picker {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .physical-control-picker button {
+    min-height: 44px;
+    touch-action: manipulation;
   }
 }
 

--- a/src/features/customGamepad/components/ComponentSettingsModal.tsx
+++ b/src/features/customGamepad/components/ComponentSettingsModal.tsx
@@ -10,6 +10,7 @@ import {
 import type { RosOperation } from '../../../utils/rosOperations';
 import RosEventOperationsEditor from './RosEventOperationsEditor';
 import PhysicalGamepadSettings from './PhysicalGamepadSettings';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ, normalizePhysicalGamepadPublishHz } from '../physicalGamepad';
 import RangeSlider from './RangeSlider';
 import ValueControl from './ValueControl';
 import { getDynamicRangeStep, roundToStepPrecision } from '../rangeUtils';
@@ -251,6 +252,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
   const [physicalGamepadProfile, setPhysicalGamepadProfile] = useState<PhysicalGamepadProfile>('auto');
   const [physicalGamepadIndex, setPhysicalGamepadIndex] = useState<number | undefined>();
   const [physicalGamepadDeadzone, setPhysicalGamepadDeadzone] = useState(0.08);
+  const [physicalGamepadPublishHz, setPhysicalGamepadPublishHz] = useState(DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ);
   const [physicalGamepadBindings, setPhysicalGamepadBindings] = useState<Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>>({});
 
   // Camera-specific settings
@@ -434,6 +436,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       setPhysicalGamepadProfile('auto');
       setPhysicalGamepadIndex(undefined);
       setPhysicalGamepadDeadzone(0.08);
+      setPhysicalGamepadPublishHz(DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ);
       setPhysicalGamepadBindings({});
       setHeartbeatMode('boolean');
       setHeartbeatTimeoutMs(2000);
@@ -530,6 +533,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
           setPhysicalGamepadProfile(component.config.physicalGamepadProfile || 'auto');
           setPhysicalGamepadIndex(component.config.physicalGamepadIndex);
           setPhysicalGamepadDeadzone(component.config.physicalGamepadDeadzone ?? 0.08);
+          setPhysicalGamepadPublishHz(normalizePhysicalGamepadPublishHz(component.config.physicalGamepadPublishHz));
           setPhysicalGamepadBindings(component.config.physicalGamepadBindings || {});
         } else if (component.type === 'button') {
           setButtonIndex(component.config.buttonIndex ?? 0);
@@ -778,6 +782,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
         physicalGamepadProfile,
         physicalGamepadIndex,
         physicalGamepadDeadzone: Math.max(0, Math.min(0.5, physicalGamepadDeadzone)),
+        physicalGamepadPublishHz: normalizePhysicalGamepadPublishHz(physicalGamepadPublishHz),
         physicalGamepadBindings,
       };
     } else if (component.type === 'button') {
@@ -939,11 +944,13 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
                 profile={physicalGamepadProfile}
                 preferredIndex={physicalGamepadIndex}
                 deadzone={physicalGamepadDeadzone}
+                publishHz={physicalGamepadPublishHz}
                 bindings={physicalGamepadBindings}
                 ros={ros || null}
                 onProfileChange={setPhysicalGamepadProfile}
                 onPreferredIndexChange={setPhysicalGamepadIndex}
                 onDeadzoneChange={setPhysicalGamepadDeadzone}
+                onPublishHzChange={setPhysicalGamepadPublishHz}
                 onBindingsChange={setPhysicalGamepadBindings}
               />
             </div>

--- a/src/features/customGamepad/components/ComponentSettingsModal.tsx
+++ b/src/features/customGamepad/components/ComponentSettingsModal.tsx
@@ -1,8 +1,15 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import type { Ros } from 'roslib';
-import { GamepadComponentConfig, ROSTopicConfig } from '../types';
+import {
+  GamepadComponentConfig,
+  PhysicalGamepadBinding,
+  PhysicalGamepadControlId,
+  PhysicalGamepadProfile,
+  ROSTopicConfig,
+} from '../types';
 import type { RosOperation } from '../../../utils/rosOperations';
 import RosEventOperationsEditor from './RosEventOperationsEditor';
+import PhysicalGamepadSettings from './PhysicalGamepadSettings';
 import RangeSlider from './RangeSlider';
 import ValueControl from './ValueControl';
 import { getDynamicRangeStep, roundToStepPrecision } from '../rangeUtils';
@@ -137,6 +144,7 @@ const getMessageTypeConfig = (type: string) => {
 // Define allowed message types for each component type
 const COMPONENT_MESSAGE_TYPES: Record<string, string[]> = {
   'joystick': ['sensor_msgs/Joy', 'geometry_msgs/Twist', 'geometry_msgs/TwistStamped', 'geometry_msgs/PoseStamped', 'std_msgs/Float32', 'std_msgs/Float64', 'std_msgs/Int32'],
+  'physical-gamepad': ['sensor_msgs/Joy', 'sensor_msgs/msg/Joy'],
   'button': ['std_msgs/Bool', 'std_msgs/Int32', 'geometry_msgs/Twist', 'geometry_msgs/TwistStamped'],
   'dpad': ['sensor_msgs/Joy', 'geometry_msgs/PoseStamped'],
   'toggle': ['std_msgs/Bool'], // Toggle only supports Boolean
@@ -238,6 +246,12 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
   const [buttonIndex, setButtonIndex] = useState(0);
   const [momentary, setMomentary] = useState(true);
   const [eventOperations, setEventOperations] = useState<Partial<Record<'press' | 'release' | 'on' | 'off', RosOperation>>>({});
+
+  // Physical gamepad-specific settings
+  const [physicalGamepadProfile, setPhysicalGamepadProfile] = useState<PhysicalGamepadProfile>('auto');
+  const [physicalGamepadIndex, setPhysicalGamepadIndex] = useState<number | undefined>();
+  const [physicalGamepadDeadzone, setPhysicalGamepadDeadzone] = useState(0.08);
+  const [physicalGamepadBindings, setPhysicalGamepadBindings] = useState<Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>>({});
 
   // Camera-specific settings
   const [cameraTransport, setCameraTransport] = useState<'proxy' | 'ros'>('proxy');
@@ -354,6 +368,11 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
           defaultMessageType = 'sensor_msgs/Joy';
           defaultField = 'axes';
           break;
+        case 'physical-gamepad':
+          defaultTopic = '/joy';
+          defaultMessageType = 'sensor_msgs/msg/Joy';
+          defaultField = 'axes';
+          break;
         case 'camera':
           defaultTopic = '/camera/image_raw/compressed';
           defaultMessageType = 'sensor_msgs/CompressedImage';
@@ -412,6 +431,10 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       setDpadButtonMapping({ up: 0, right: 1, down: 2, left: 3 });
       setButtonIndex(0);
       setMomentary(true);
+      setPhysicalGamepadProfile('auto');
+      setPhysicalGamepadIndex(undefined);
+      setPhysicalGamepadDeadzone(0.08);
+      setPhysicalGamepadBindings({});
       setHeartbeatMode('boolean');
       setHeartbeatTimeoutMs(2000);
       setHeartbeatFieldPath(action?.field || 'data');
@@ -503,6 +526,11 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
           setPoseStampedOdometryTopic(component.config.poseStampedOdometryTopic || '/odom');
           setPoseStampedOdometryMessageType(component.config.poseStampedOdometryMessageType || 'nav_msgs/Odometry');
           setPoseStampedUseOdometryOrientation(component.config.poseStampedUseOdometryOrientation !== false);
+        } else if (component.type === 'physical-gamepad') {
+          setPhysicalGamepadProfile(component.config.physicalGamepadProfile || 'auto');
+          setPhysicalGamepadIndex(component.config.physicalGamepadIndex);
+          setPhysicalGamepadDeadzone(component.config.physicalGamepadDeadzone ?? 0.08);
+          setPhysicalGamepadBindings(component.config.physicalGamepadBindings || {});
         } else if (component.type === 'button') {
           setButtonIndex(component.config.buttonIndex ?? 0);
           setMomentary(component.config.momentary ?? true);
@@ -644,6 +672,17 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       }
     }
 
+    if (component.type === 'physical-gamepad') {
+      if (!['sensor_msgs/Joy', 'sensor_msgs/msg/Joy'].includes(messageType)) {
+        setErrorMessage('Physical gamepads publish sensor_msgs/Joy messages.');
+        return;
+      }
+      if (field !== 'axes') {
+        setErrorMessage('Physical gamepads publish complete Joy axes and buttons.');
+        return;
+      }
+    }
+
     if (component.type === 'camera' && !CAMERA_MESSAGE_TYPES.includes(messageType)) {
       setErrorMessage('Camera components can only use Image or CompressedImage message types.');
       return;
@@ -733,6 +772,14 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       };
       // Remove legacy maxValue if it exists
       delete updatedConfig.maxValue;
+    } else if (component.type === 'physical-gamepad') {
+      updatedConfig = {
+        ...updatedConfig,
+        physicalGamepadProfile,
+        physicalGamepadIndex,
+        physicalGamepadDeadzone: Math.max(0, Math.min(0.5, physicalGamepadDeadzone)),
+        physicalGamepadBindings,
+      };
     } else if (component.type === 'button') {
       updatedConfig = {
         ...updatedConfig,
@@ -883,6 +930,22 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
                   onChange={setEventOperations}
                 />
               </div>
+            </div>
+          )}
+
+          {component.type === 'physical-gamepad' && (
+            <div className="settings-section">
+              <PhysicalGamepadSettings
+                profile={physicalGamepadProfile}
+                preferredIndex={physicalGamepadIndex}
+                deadzone={physicalGamepadDeadzone}
+                bindings={physicalGamepadBindings}
+                ros={ros || null}
+                onProfileChange={setPhysicalGamepadProfile}
+                onPreferredIndexChange={setPhysicalGamepadIndex}
+                onDeadzoneChange={setPhysicalGamepadDeadzone}
+                onBindingsChange={setPhysicalGamepadBindings}
+              />
             </div>
           )}
 

--- a/src/features/customGamepad/components/GamepadComponent.tsx
+++ b/src/features/customGamepad/components/GamepadComponent.tsx
@@ -9,6 +9,7 @@ import SliderComponent from './SliderComponent';
 import CameraComponent from './CameraComponent';
 import PlotComponent from './PlotComponent';
 import HeartbeatComponent from './HeartbeatComponent';
+import PhysicalGamepadComponent from './PhysicalGamepadComponent';
 import './GamepadComponent.css';
 
 interface GamepadComponentProps {
@@ -361,6 +362,8 @@ const GamepadComponent: React.FC<GamepadComponentProps> = ({
             onTwistAxesChange={onTwistAxesChange}
           />
         );
+      case 'physical-gamepad':
+        return <PhysicalGamepadComponent {...commonProps} />;
       case 'button':
         return <ButtonComponent {...commonProps} />;
       case 'dpad':

--- a/src/features/customGamepad/components/GamepadEditor.tsx
+++ b/src/features/customGamepad/components/GamepadEditor.tsx
@@ -7,6 +7,7 @@ import {
   EditorState
 } from '../types';
 import { componentLibrary } from '../defaultLayouts';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ } from '../physicalGamepad';
 import { generateGamepadId, saveCustomGamepad } from '../gamepadStorage';
 import LayoutRenderer from './CustomGamepadLayout';
 import ComponentPalette from './ComponentPalette';
@@ -146,7 +147,11 @@ const GamepadEditor: React.FC<GamepadEditorProps> = ({
           : componentType === 'heartbeat'
             ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
             : componentType === 'physical-gamepad'
-              ? { physicalGamepadProfile: 'auto' as const, physicalGamepadDeadzone: 0.08 }
+              ? {
+                physicalGamepadProfile: 'auto' as const,
+                physicalGamepadDeadzone: 0.08,
+                physicalGamepadPublishHz: DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+              }
               : componentType === 'dpad'
                 ? { buttonMapping: { up: 0, right: 1, down: 2, left: 3 } }
                 : componentType === 'joystick'

--- a/src/features/customGamepad/components/GamepadEditor.tsx
+++ b/src/features/customGamepad/components/GamepadEditor.tsx
@@ -110,6 +110,9 @@ const GamepadEditor: React.FC<GamepadEditorProps> = ({
       case 'joystick':
         action = { topic: '/joystick', messageType: 'sensor_msgs/Joy', field: 'axes' };
         break;
+      case 'physical-gamepad':
+        action = { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' };
+        break;
       case 'dpad':
         action = { topic: '/dpad', messageType: 'sensor_msgs/Joy', field: 'buttons' };
         break;
@@ -142,11 +145,13 @@ const GamepadEditor: React.FC<GamepadEditorProps> = ({
           ? { fieldPath: 'data', fieldPaths: ['data'], timeWindowSec: 10, autoScale: true, minY: -1, maxY: 1 }
           : componentType === 'heartbeat'
             ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
-          : componentType === 'dpad'
-            ? { buttonMapping: { up: 0, right: 1, down: 2, left: 3 } }
-            : componentType === 'joystick'
-              ? { min: -1, max: 1, sliderMin: -1, sliderMax: 1, axes: ['0', '1'] }
-              : undefined;
+            : componentType === 'physical-gamepad'
+              ? { physicalGamepadProfile: 'auto' as const, physicalGamepadDeadzone: 0.08 }
+              : componentType === 'dpad'
+                ? { buttonMapping: { up: 0, right: 1, down: 2, left: 3 } }
+                : componentType === 'joystick'
+                  ? { min: -1, max: 1, sliderMin: -1, sliderMax: 1, axes: ['0', '1'] }
+                  : undefined;
 
     const newComponent: GamepadComponentConfig = {
       id: `${componentType}-${Date.now()}`,

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.css
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.css
@@ -1,0 +1,118 @@
+.physical-gamepad {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  color: var(--text-color);
+  background: radial-gradient(circle at 50% 40%, var(--background-secondary), var(--card-bg));
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.physical-gamepad-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 18px;
+  padding: 4px 8px 0;
+  color: var(--text-secondary);
+  font-size: clamp(8px, 2.4cqw, 12px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.physical-gamepad-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--secondary-color);
+}
+
+.physical-gamepad-dot.connected {
+  background: var(--primary-color);
+  box-shadow: 0 0 8px var(--primary-color-glow);
+}
+
+.physical-gamepad svg {
+  display: block;
+  width: 100%;
+  height: calc(100% - 22px);
+  min-height: 0;
+}
+
+.physical-gamepad-body {
+  fill: var(--background-secondary);
+  stroke: var(--border-color-light);
+  stroke-width: 4;
+  filter: drop-shadow(0 8px 8px var(--background-dark-transparent));
+}
+
+.physical-control circle,
+.physical-control rect,
+.physical-control path,
+.physical-control:is(circle, rect, path),
+.physical-dpad rect {
+  fill: var(--card-bg);
+  stroke: var(--border-color-light);
+  stroke-width: 2;
+  transition:
+    fill 70ms ease,
+    filter 70ms ease,
+    transform 70ms ease;
+}
+
+.physical-control text {
+  fill: var(--text-color);
+  font-family: var(--font-family-ui);
+  font-size: 10px;
+  font-weight: 700;
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+.physical-control.is-active circle,
+.physical-control.is-active rect,
+.physical-control.is-active path,
+.physical-control.is-active:is(circle, rect, path),
+.physical-control.is-active .stick-knob {
+  fill: var(--primary-color);
+  stroke: var(--primary-hover-color);
+  filter: drop-shadow(0 0 6px var(--primary-color-glow));
+}
+
+.physical-control.is-active text {
+  fill: var(--button-text-color);
+}
+
+.physical-control .stick-well {
+  fill: var(--background-color);
+}
+
+.physical-control .stick-knob {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.physical-gamepad-warning {
+  padding: 0 8px 5px;
+  color: var(--error-color);
+  font-size: 9px;
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .physical-control circle,
+  .physical-control rect,
+  .physical-control path {
+    transition: none;
+  }
+}

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.css
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.css
@@ -1,4 +1,5 @@
 .physical-gamepad {
+  container-type: inline-size;
   width: 100%;
   height: 100%;
   min-width: 0;
@@ -23,7 +24,8 @@
   min-height: 18px;
   padding: 4px 8px 0;
   color: var(--text-secondary);
-  font-size: clamp(8px, 2.4cqw, 12px);
+  font-size: 10px;
+  font-size: clamp(9px, 2.4cqw, 12px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -107,6 +109,23 @@
   color: var(--error-color);
   font-size: 9px;
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  .physical-gamepad {
+    border-radius: 9px;
+  }
+
+  .physical-gamepad-status {
+    min-height: 22px;
+    padding: 5px 7px 0;
+    font-size: 10px;
+  }
+
+  .physical-gamepad-warning {
+    padding: 0 7px 6px;
+    font-size: 10px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
@@ -144,6 +144,33 @@ describe('PhysicalGamepadComponent', () => {
     expect(mocks.unadvertise).toHaveBeenCalledOnce();
   });
 
+  it('publishes neutral input when a phone or browser suspends the page', () => {
+    render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+    runFrame(100);
+    mocks.publish.mockClear();
+
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+
+    expect(mocks.publish).toHaveBeenCalledOnce();
+    expect(mocks.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        axes: [0, 0, 0, 0],
+        buttons: Array(17).fill(0),
+      })
+    );
+  });
+
+  it('explains when a mobile WebView does not expose controller input', () => {
+    Reflect.deleteProperty(navigator, 'getGamepads');
+
+    render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Controller input unavailable on this device');
+    expect(screen.getByText('This browser or app WebView does not expose the Gamepad API.')).toBeInTheDocument();
+    expect(frames).toHaveLength(0);
+  });
+
   it('publishes Joy at the configured rate while keeping button edges immediate', async () => {
     const tenHzConfig: GamepadComponentConfig = {
       ...config,

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GamepadComponentConfig } from '../types';
+import PhysicalGamepadComponent from './PhysicalGamepadComponent';
+
+const mocks = vi.hoisted(() => ({
+  advertise: vi.fn(),
+  publish: vi.fn(),
+  unadvertise: vi.fn(),
+  execute: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('roslib', () => ({
+  default: {
+    Topic: vi.fn(function () {
+      return { advertise: mocks.advertise, publish: mocks.publish, unadvertise: mocks.unadvertise };
+    }),
+    Message: vi.fn(function (value) {
+      return value;
+    }),
+  },
+}));
+
+vi.mock('../../../utils/rosOperations', () => ({ executeRosOperation: mocks.execute }));
+
+const makeGamepad = (pressedIndex?: number, connected = true): Gamepad =>
+  ({
+    axes: [0.5, -0.5, 0.25, -0.25],
+    buttons: Array.from({ length: 17 }, (_, index) => ({
+      pressed: index === pressedIndex,
+      touched: index === pressedIndex,
+      value: index === pressedIndex ? 1 : 0,
+    })),
+    connected,
+    hapticActuators: [],
+    id: 'Sony DualSense Wireless Controller',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 1,
+    vibrationActuator: null,
+  }) as unknown as Gamepad;
+
+const config: GamepadComponentConfig = {
+  id: 'physical',
+  type: 'physical-gamepad',
+  position: { x: 0, y: 0, width: 6, height: 4 },
+  action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
+  config: {
+    physicalGamepadProfile: 'auto',
+    physicalGamepadDeadzone: 0.08,
+    physicalGamepadBindings: {
+      'face-bottom': {
+        press: { kind: 'service', name: '/start', messageType: 'std_srvs/srv/Trigger' },
+        release: { kind: 'topic', name: '/released', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
+      },
+    },
+  },
+};
+
+describe('PhysicalGamepadComponent', () => {
+  let gamepads: Array<Gamepad | null>;
+  let frames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    gamepads = [makeGamepad()];
+    frames = [];
+    mocks.advertise.mockReset();
+    mocks.publish.mockReset();
+    mocks.unadvertise.mockReset();
+    mocks.execute.mockReset().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'getGamepads', {
+      configurable: true,
+      value: vi.fn(() => gamepads as (Gamepad | null)[]),
+    });
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, 'getGamepads');
+  });
+
+  const runFrame = (time: number) =>
+    act(() => {
+      const frame = frames.shift();
+      if (!frame) throw new Error('No animation frame queued');
+      frame(time);
+    });
+
+  it('renders live PlayStation controls, publishes Joy, and dispatches button edges', async () => {
+    render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+    expect(mocks.advertise).toHaveBeenCalledOnce();
+
+    runFrame(100);
+    expect(await screen.findByText(/Sony DualSense Wireless Controller/)).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'playstation gamepad visualization' })).toBeInTheDocument();
+    expect(mocks.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        axes: expect.arrayContaining([expect.closeTo(0.4565, 3), expect.closeTo(-0.4565, 3)]),
+        buttons: expect.arrayContaining([0]),
+      })
+    );
+
+    gamepads = [makeGamepad(0)];
+    runFrame(116);
+    await waitFor(() =>
+      expect(mocks.execute).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ kind: 'service', name: '/start' }),
+        expect.any(AbortSignal)
+      )
+    );
+
+    gamepads = [makeGamepad()];
+    runFrame(132);
+    await waitFor(() =>
+      expect(mocks.execute).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ kind: 'topic', name: '/released' }),
+        expect.any(AbortSignal)
+      )
+    );
+  });
+
+  it('publishes a neutral message when the controller disconnects and cleans up the publisher', () => {
+    const { unmount } = render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+    runFrame(100);
+    gamepads = [];
+    runFrame(116);
+
+    expect(mocks.publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        axes: [0, 0, 0, 0],
+        buttons: Array(17).fill(0),
+      })
+    );
+    unmount();
+    expect(mocks.unadvertise).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
@@ -143,4 +143,25 @@ describe('PhysicalGamepadComponent', () => {
     unmount();
     expect(mocks.unadvertise).toHaveBeenCalledOnce();
   });
+
+  it('publishes Joy at the configured rate while keeping button edges immediate', async () => {
+    const tenHzConfig: GamepadComponentConfig = {
+      ...config,
+      config: { ...config.config, physicalGamepadPublishHz: 10 },
+    };
+    render(<PhysicalGamepadComponent config={tenHzConfig} ros={{} as any} />);
+
+    runFrame(100);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+
+    gamepads = [makeGamepad(0)];
+    runFrame(116);
+    await waitFor(() => expect(mocks.execute).toHaveBeenCalledOnce());
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+
+    runFrame(199);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    runFrame(200);
+    expect(mocks.publish).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
@@ -37,6 +37,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
   const profile = detectPhysicalGamepadProfile(config.config?.physicalGamepadProfile, connection?.id);
   const action = config.action as ROSTopicConfig | undefined;
   const bindings = config.config?.physicalGamepadBindings;
+  const gamepadApiSupported = typeof navigator !== 'undefined' && typeof navigator.getGamepads === 'function';
   const publishIntervalMs = 1000 / normalizePhysicalGamepadPublishHz(config.config?.physicalGamepadPublishHz);
 
   const publishJoy = useCallback(
@@ -83,7 +84,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
   }, [action?.messageType, action?.topic, isEditing, publishJoy, ros]);
 
   useEffect(() => {
-    if (isEditing || typeof navigator.getGamepads !== 'function') return;
+    if (isEditing || !gamepadApiSupported) return;
     let frameId = 0;
     let stopped = false;
 
@@ -96,6 +97,10 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
       connectionKeyRef.current = '';
       setSnapshot(EMPTY_GAMEPAD_SNAPSHOT);
       setConnection(null);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') disconnect();
     };
 
     const poll = (now: number) => {
@@ -136,15 +141,20 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
       frameId = requestAnimationFrame(poll);
     };
 
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', disconnect);
     frameId = requestAnimationFrame(poll);
     return () => {
       stopped = true;
       cancelAnimationFrame(frameId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', disconnect);
       disconnect();
     };
   }, [
     config.config?.physicalGamepadDeadzone,
     config.config?.physicalGamepadIndex,
+    gamepadApiSupported,
     isEditing,
     publishIntervalMs,
     publishJoy,
@@ -179,9 +189,11 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
         <span className={`physical-gamepad-dot ${connection ? 'connected' : ''}`} />
         {isEditing
           ? `${profile} preview`
-          : connection
-            ? `#${connection.index} ${connection.id}`
-            : 'Press a controller button to connect'}
+          : !gamepadApiSupported
+            ? 'Controller input unavailable on this device'
+            : connection
+              ? `#${connection.index} ${connection.id}`
+              : 'Press a controller button to connect'}
       </div>
       <svg viewBox="0 0 400 250" role="img" aria-label={`${profile} gamepad visualization`}>
         <path
@@ -282,6 +294,11 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
       {connection && connection.mapping !== 'standard' && (
         <small className="physical-gamepad-warning">
           Non-standard browser mapping; verify control indices before driving.
+        </small>
+      )}
+      {!isEditing && !gamepadApiSupported && (
+        <small className="physical-gamepad-warning">
+          This browser or app WebView does not expose the Gamepad API.
         </small>
       )}
       {operationError && (

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
@@ -8,6 +8,7 @@ import {
   EMPTY_GAMEPAD_SNAPSHOT,
   findPhysicalGamepad,
   getPhysicalGamepadControlLabel,
+  normalizePhysicalGamepadPublishHz,
   PHYSICAL_GAMEPAD_CONTROLS,
   physicalGamepadSnapshotKey,
   snapshotPhysicalGamepad,
@@ -20,8 +21,6 @@ interface Props {
   ros: Ros;
   isEditing?: boolean;
 }
-
-const JOY_PUBLISH_INTERVAL_MS = 50;
 
 const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = false }) => {
   const [snapshot, setSnapshot] = useState<PhysicalGamepadSnapshot>(EMPTY_GAMEPAD_SNAPSHOT);
@@ -38,6 +37,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
   const profile = detectPhysicalGamepadProfile(config.config?.physicalGamepadProfile, connection?.id);
   const action = config.action as ROSTopicConfig | undefined;
   const bindings = config.config?.physicalGamepadBindings;
+  const publishIntervalMs = 1000 / normalizePhysicalGamepadPublishHz(config.config?.physicalGamepadPublishHz);
 
   const publishJoy = useCallback(
     (next: PhysicalGamepadSnapshot) => {
@@ -129,7 +129,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
         snapshotKeyRef.current = nextKey;
         setSnapshot(next);
       }
-      if (changed || justConnected || now - lastPublishedAtRef.current >= JOY_PUBLISH_INTERVAL_MS) {
+      if (justConnected || now - lastPublishedAtRef.current >= publishIntervalMs) {
         publishJoy(next);
         lastPublishedAtRef.current = now;
       }
@@ -146,6 +146,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
     config.config?.physicalGamepadDeadzone,
     config.config?.physicalGamepadIndex,
     isEditing,
+    publishIntervalMs,
     publishJoy,
     runOperation,
   ]);

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
@@ -1,0 +1,295 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ROSLIB from 'roslib';
+import type { Ros, Topic } from 'roslib';
+import { executeRosOperation } from '../../../utils/rosOperations';
+import type { GamepadComponentConfig, PhysicalGamepadControlId, ROSTopicConfig } from '../types';
+import {
+  detectPhysicalGamepadProfile,
+  EMPTY_GAMEPAD_SNAPSHOT,
+  findPhysicalGamepad,
+  getPhysicalGamepadControlLabel,
+  PHYSICAL_GAMEPAD_CONTROLS,
+  physicalGamepadSnapshotKey,
+  snapshotPhysicalGamepad,
+  type PhysicalGamepadSnapshot,
+} from '../physicalGamepad';
+import './PhysicalGamepadComponent.css';
+
+interface Props {
+  config: GamepadComponentConfig;
+  ros: Ros;
+  isEditing?: boolean;
+}
+
+const JOY_PUBLISH_INTERVAL_MS = 50;
+
+const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = false }) => {
+  const [snapshot, setSnapshot] = useState<PhysicalGamepadSnapshot>(EMPTY_GAMEPAD_SNAPSHOT);
+  const [connection, setConnection] = useState<{ id: string; index: number; mapping: string } | null>(null);
+  const [operationError, setOperationError] = useState('');
+  const topicRef = useRef<Topic | null>(null);
+  const connectedRef = useRef(false);
+  const connectionKeyRef = useRef('');
+  const previousPressedRef = useRef<boolean[]>(Array(17).fill(false));
+  const snapshotKeyRef = useRef('');
+  const lastPublishedAtRef = useRef(0);
+  const operationControllersRef = useRef(new Map<string, AbortController>());
+
+  const profile = detectPhysicalGamepadProfile(config.config?.physicalGamepadProfile, connection?.id);
+  const action = config.action as ROSTopicConfig | undefined;
+  const bindings = config.config?.physicalGamepadBindings;
+
+  const publishJoy = useCallback(
+    (next: PhysicalGamepadSnapshot) => {
+      if (!topicRef.current || isEditing) return;
+      topicRef.current.publish(
+        new ROSLIB.Message({
+          header: { stamp: { secs: 0, nsecs: 0 }, frame_id: '' },
+          axes: next.axes,
+          buttons: next.buttons.map(value => (value > 0.5 ? 1 : 0)),
+        })
+      );
+    },
+    [isEditing]
+  );
+
+  const runOperation = useCallback(
+    (controlId: PhysicalGamepadControlId, event: 'press' | 'release') => {
+      const operation = bindings?.[controlId]?.[event];
+      const key = `${controlId}:${event}`;
+      if (!operation || isEditing || operationControllersRef.current.has(key)) return;
+      const controller = new AbortController();
+      operationControllersRef.current.set(key, controller);
+      void executeRosOperation(ros, operation, controller.signal)
+        .then(() => setOperationError(''))
+        .catch(() => {
+          if (!controller.signal.aborted) setOperationError(`${controlId} ${event} operation failed`);
+        })
+        .finally(() => operationControllersRef.current.delete(key));
+    },
+    [bindings, isEditing, ros]
+  );
+
+  useEffect(() => {
+    if (isEditing || !action?.topic || !action.messageType) return;
+    const topic = new ROSLIB.Topic({ ros, name: action.topic, messageType: action.messageType });
+    topic.advertise();
+    topicRef.current = topic;
+    return () => {
+      if (connectedRef.current) publishJoy(EMPTY_GAMEPAD_SNAPSHOT);
+      topic.unadvertise();
+      if (topicRef.current === topic) topicRef.current = null;
+    };
+  }, [action?.messageType, action?.topic, isEditing, publishJoy, ros]);
+
+  useEffect(() => {
+    if (isEditing || typeof navigator.getGamepads !== 'function') return;
+    let frameId = 0;
+    let stopped = false;
+
+    const disconnect = () => {
+      if (!connectedRef.current) return;
+      connectedRef.current = false;
+      publishJoy(EMPTY_GAMEPAD_SNAPSHOT);
+      previousPressedRef.current = Array(17).fill(false);
+      snapshotKeyRef.current = '';
+      connectionKeyRef.current = '';
+      setSnapshot(EMPTY_GAMEPAD_SNAPSHOT);
+      setConnection(null);
+    };
+
+    const poll = (now: number) => {
+      if (stopped) return;
+      const gamepad = findPhysicalGamepad(navigator.getGamepads(), config.config?.physicalGamepadIndex);
+      if (!gamepad) {
+        disconnect();
+        frameId = requestAnimationFrame(poll);
+        return;
+      }
+
+      const next = snapshotPhysicalGamepad(gamepad, config.config?.physicalGamepadDeadzone);
+      const nextKey = physicalGamepadSnapshotKey(next);
+      const changed = nextKey !== snapshotKeyRef.current;
+      const justConnected = !connectedRef.current;
+      connectedRef.current = true;
+      const connectionKey = `${gamepad.index}:${gamepad.id}:${gamepad.mapping}`;
+      if (connectionKeyRef.current !== connectionKey) {
+        connectionKeyRef.current = connectionKey;
+        setConnection({ id: gamepad.id, index: gamepad.index, mapping: gamepad.mapping });
+      }
+
+      PHYSICAL_GAMEPAD_CONTROLS.forEach(({ id, buttonIndex }) => {
+        const wasPressed = previousPressedRef.current[buttonIndex] ?? false;
+        const isPressed = next.pressed[buttonIndex] ?? false;
+        if (isPressed !== wasPressed) runOperation(id, isPressed ? 'press' : 'release');
+      });
+      previousPressedRef.current = next.pressed;
+
+      if (changed) {
+        snapshotKeyRef.current = nextKey;
+        setSnapshot(next);
+      }
+      if (changed || justConnected || now - lastPublishedAtRef.current >= JOY_PUBLISH_INTERVAL_MS) {
+        publishJoy(next);
+        lastPublishedAtRef.current = now;
+      }
+      frameId = requestAnimationFrame(poll);
+    };
+
+    frameId = requestAnimationFrame(poll);
+    return () => {
+      stopped = true;
+      cancelAnimationFrame(frameId);
+      disconnect();
+    };
+  }, [
+    config.config?.physicalGamepadDeadzone,
+    config.config?.physicalGamepadIndex,
+    isEditing,
+    publishJoy,
+    runOperation,
+  ]);
+
+  useEffect(
+    () => () => {
+      operationControllersRef.current.forEach(controller => controller.abort());
+      operationControllersRef.current.clear();
+    },
+    []
+  );
+
+  const label = useCallback((id: PhysicalGamepadControlId) => getPhysicalGamepadControlLabel(id, profile), [profile]);
+  const active = useCallback(
+    (id: PhysicalGamepadControlId) => {
+      const index = PHYSICAL_GAMEPAD_CONTROLS.find(control => control.id === id)?.buttonIndex ?? -1;
+      return snapshot.pressed[index] || snapshot.buttons[index] > 0.05;
+    },
+    [snapshot]
+  );
+  const stickLayout = profile === 'playstation' ? 'symmetric' : 'offset';
+  const leftStick = useMemo(() => ({ x: snapshot.axes[0] * 10, y: snapshot.axes[1] * 10 }), [snapshot.axes]);
+  const rightStick = useMemo(() => ({ x: snapshot.axes[2] * 10, y: snapshot.axes[3] * 10 }), [snapshot.axes]);
+
+  const controlClass = (id: PhysicalGamepadControlId) => `physical-control ${active(id) ? 'is-active' : ''}`;
+
+  return (
+    <div className={`physical-gamepad physical-gamepad-${profile}`}>
+      <div className="physical-gamepad-status" role="status">
+        <span className={`physical-gamepad-dot ${connection ? 'connected' : ''}`} />
+        {isEditing
+          ? `${profile} preview`
+          : connection
+            ? `#${connection.index} ${connection.id}`
+            : 'Press a controller button to connect'}
+      </div>
+      <svg viewBox="0 0 400 250" role="img" aria-label={`${profile} gamepad visualization`}>
+        <path
+          className="physical-gamepad-body"
+          d="M108 45 C55 42 28 83 22 157 C18 211 43 235 72 210 L116 171 H284 L328 210 C357 235 382 211 378 157 C372 83 345 42 292 45 Z"
+        />
+        <g className={controlClass('left-trigger')}>
+          <rect x="79" y="28" width="55" height="20" rx="8" />
+          <text x="106" y="42">
+            {label('left-trigger')}
+          </text>
+        </g>
+        <g className={controlClass('right-trigger')}>
+          <rect x="266" y="28" width="55" height="20" rx="8" />
+          <text x="294" y="42">
+            {label('right-trigger')}
+          </text>
+        </g>
+        <g className={controlClass('left-bumper')}>
+          <rect x="68" y="48" width="72" height="18" rx="7" />
+          <text x="104" y="61">
+            {label('left-bumper')}
+          </text>
+        </g>
+        <g className={controlClass('right-bumper')}>
+          <rect x="260" y="48" width="72" height="18" rx="7" />
+          <text x="296" y="61">
+            {label('right-bumper')}
+          </text>
+        </g>
+
+        <g
+          transform={stickLayout === 'symmetric' ? 'translate(138 171)' : 'translate(115 113)'}
+          className={controlClass('left-stick')}
+        >
+          <circle className="stick-well" r="30" />
+          <circle className="stick-knob" r="20" transform={`translate(${leftStick.x} ${leftStick.y})`} />
+          <text y="5">{label('left-stick')}</text>
+        </g>
+        <g
+          transform={stickLayout === 'symmetric' ? 'translate(262 171)' : 'translate(245 169)'}
+          className={controlClass('right-stick')}
+        >
+          <circle className="stick-well" r="30" />
+          <circle className="stick-knob" r="20" transform={`translate(${rightStick.x} ${rightStick.y})`} />
+          <text y="5">{label('right-stick')}</text>
+        </g>
+
+        <g
+          transform={stickLayout === 'symmetric' ? 'translate(82 112)' : 'translate(138 171)'}
+          className="physical-dpad"
+        >
+          <path className={controlClass('dpad-up')} d="M-13 -34 H13 V-9 H-13 Z" />
+          <path className={controlClass('dpad-down')} d="M-13 9 H13 V34 H-13 Z" />
+          <path className={controlClass('dpad-left')} d="M-34 -13 H-9 V13 H-34 Z" />
+          <path className={controlClass('dpad-right')} d="M9 -13 H34 V13 H9 Z" />
+          <rect x="-13" y="-13" width="26" height="26" />
+        </g>
+
+        <g className="physical-face-buttons" transform="translate(305 111)">
+          <g transform="translate(0 31)" className={controlClass('face-bottom')}>
+            <circle r="17" />
+            <text y="5">{label('face-bottom')}</text>
+          </g>
+          <g transform="translate(31 0)" className={controlClass('face-right')}>
+            <circle r="17" />
+            <text y="5">{label('face-right')}</text>
+          </g>
+          <g transform="translate(-31 0)" className={controlClass('face-left')}>
+            <circle r="17" />
+            <text y="5">{label('face-left')}</text>
+          </g>
+          <g transform="translate(0 -31)" className={controlClass('face-top')}>
+            <circle r="17" />
+            <text y="5">{label('face-top')}</text>
+          </g>
+        </g>
+
+        <g className={controlClass('select')}>
+          <rect x="163" y="103" width="27" height="15" rx="7" />
+          <text x="176.5" y="114">
+            {label('select')}
+          </text>
+        </g>
+        <g className={controlClass('start')}>
+          <rect x="210" y="103" width="27" height="15" rx="7" />
+          <text x="223.5" y="114">
+            {label('start')}
+          </text>
+        </g>
+        <g className={controlClass('home')}>
+          <circle cx="200" cy="82" r="14" />
+          <text x="200" y="86">
+            {label('home')}
+          </text>
+        </g>
+      </svg>
+      {connection && connection.mapping !== 'standard' && (
+        <small className="physical-gamepad-warning">
+          Non-standard browser mapping; verify control indices before driving.
+        </small>
+      )}
+      {operationError && (
+        <small className="physical-gamepad-warning" role="alert">
+          {operationError}
+        </small>
+      )}
+    </div>
+  );
+};
+
+export default PhysicalGamepadComponent;

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import PhysicalGamepadSettings from './PhysicalGamepadSettings';
+
+vi.mock('./RosEventOperationsEditor', () => ({
+  default: ({ onChange }: { onChange: (value: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onChange({
+          press: { kind: 'topic', name: '/pressed', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
+        })
+      }
+    >
+      Configure selected
+    </button>
+  ),
+}));
+
+describe('PhysicalGamepadSettings', () => {
+  it('offers all standard buttons and saves operations under the selected control', () => {
+    const onBindingsChange = vi.fn();
+    render(
+      <PhysicalGamepadSettings
+        profile="playstation"
+        deadzone={0.08}
+        bindings={{}}
+        ros={null}
+        onProfileChange={vi.fn()}
+        onPreferredIndexChange={vi.fn()}
+        onDeadzoneChange={vi.fn()}
+        onBindingsChange={onBindingsChange}
+      />
+    );
+
+    const picker = screen.getByRole('list', { name: 'Physical controller buttons' });
+    expect(within(picker).getAllByRole('button')).toHaveLength(17);
+    fireEvent.click(within(picker).getByRole('button', { name: '○' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Configure selected' }));
+
+    expect(onBindingsChange).toHaveBeenCalledWith({
+      'face-right': {
+        press: { kind: 'topic', name: '/pressed', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
+      },
+    });
+  });
+});

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
@@ -21,15 +21,18 @@ vi.mock('./RosEventOperationsEditor', () => ({
 describe('PhysicalGamepadSettings', () => {
   it('offers all standard buttons and saves operations under the selected control', () => {
     const onBindingsChange = vi.fn();
+    const onPublishHzChange = vi.fn();
     render(
       <PhysicalGamepadSettings
         profile="playstation"
         deadzone={0.08}
+        publishHz={20}
         bindings={{}}
         ros={null}
         onProfileChange={vi.fn()}
         onPreferredIndexChange={vi.fn()}
         onDeadzoneChange={vi.fn()}
+        onPublishHzChange={onPublishHzChange}
         onBindingsChange={onBindingsChange}
       />
     );
@@ -44,5 +47,10 @@ describe('PhysicalGamepadSettings', () => {
         press: { kind: 'topic', name: '/pressed', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
       },
     });
+
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Joy publish rate (Hz)' }), {
+      target: { value: '30' },
+    });
+    expect(onPublishHzChange).toHaveBeenCalledWith(30);
   });
 });

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
@@ -1,7 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import type { Ros } from 'roslib';
 import type { RosOperation } from '../../../utils/rosOperations';
-import { getPhysicalGamepadControlLabel, PHYSICAL_GAMEPAD_CONTROLS } from '../physicalGamepad';
+import {
+  getPhysicalGamepadControlLabel,
+  MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+  MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+  PHYSICAL_GAMEPAD_CONTROLS,
+} from '../physicalGamepad';
 import type { PhysicalGamepadBinding, PhysicalGamepadControlId, PhysicalGamepadProfile } from '../types';
 import RosEventOperationsEditor from './RosEventOperationsEditor';
 
@@ -9,11 +14,13 @@ interface Props {
   profile: PhysicalGamepadProfile;
   preferredIndex?: number;
   deadzone: number;
+  publishHz: number;
   bindings: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
   ros: Ros | null;
   onProfileChange: (value: PhysicalGamepadProfile) => void;
   onPreferredIndexChange: (value: number | undefined) => void;
   onDeadzoneChange: (value: number) => void;
+  onPublishHzChange: (value: number) => void;
   onBindingsChange: (value: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>) => void;
 }
 
@@ -21,11 +28,13 @@ const PhysicalGamepadSettings: React.FC<Props> = ({
   profile,
   preferredIndex,
   deadzone,
+  publishHz,
   bindings,
   ros,
   onProfileChange,
   onPreferredIndexChange,
   onDeadzoneChange,
+  onPublishHzChange,
   onBindingsChange,
 }) => {
   const [selectedControl, setSelectedControl] = useState<PhysicalGamepadControlId>('face-bottom');
@@ -85,6 +94,21 @@ const PhysicalGamepadSettings: React.FC<Props> = ({
           value={deadzone}
           onChange={event => onDeadzoneChange(Number(event.target.value))}
         />
+      </div>
+      <div className="setting-group">
+        <label htmlFor="physical-gamepad-publish-hz">Joy publish rate (Hz)</label>
+        <input
+          id="physical-gamepad-publish-hz"
+          type="number"
+          min={MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ}
+          max={MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ}
+          step="1"
+          value={publishHz}
+          onChange={event => onPublishHzChange(Number(event.target.value))}
+        />
+        <small className="settings-help">
+          {MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ}-{MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ} Hz. Button operations still run immediately.
+        </small>
       </div>
 
       <h4>

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
@@ -1,0 +1,125 @@
+import React, { useMemo, useState } from 'react';
+import type { Ros } from 'roslib';
+import type { RosOperation } from '../../../utils/rosOperations';
+import { getPhysicalGamepadControlLabel, PHYSICAL_GAMEPAD_CONTROLS } from '../physicalGamepad';
+import type { PhysicalGamepadBinding, PhysicalGamepadControlId, PhysicalGamepadProfile } from '../types';
+import RosEventOperationsEditor from './RosEventOperationsEditor';
+
+interface Props {
+  profile: PhysicalGamepadProfile;
+  preferredIndex?: number;
+  deadzone: number;
+  bindings: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
+  ros: Ros | null;
+  onProfileChange: (value: PhysicalGamepadProfile) => void;
+  onPreferredIndexChange: (value: number | undefined) => void;
+  onDeadzoneChange: (value: number) => void;
+  onBindingsChange: (value: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>) => void;
+}
+
+const PhysicalGamepadSettings: React.FC<Props> = ({
+  profile,
+  preferredIndex,
+  deadzone,
+  bindings,
+  ros,
+  onProfileChange,
+  onPreferredIndexChange,
+  onDeadzoneChange,
+  onBindingsChange,
+}) => {
+  const [selectedControl, setSelectedControl] = useState<PhysicalGamepadControlId>('face-bottom');
+  const labelsProfile = profile === 'auto' ? 'xbox' : profile;
+  const selectedLabel = getPhysicalGamepadControlLabel(selectedControl, labelsProfile);
+  const configuredCount = useMemo(
+    () => Object.values(bindings).filter(binding => binding?.press || binding?.release).length,
+    [bindings]
+  );
+
+  const updateSelectedBinding = (operations: Partial<Record<'press' | 'release', RosOperation>>) => {
+    const next = { ...bindings };
+    if (!operations.press && !operations.release) delete next[selectedControl];
+    else next[selectedControl] = operations;
+    onBindingsChange(next);
+  };
+
+  return (
+    <div className="physical-gamepad-settings">
+      <h4>Physical Controller</h4>
+      <div className="settings-row">
+        <div className="setting-group">
+          <label htmlFor="physical-gamepad-profile">Button labels and layout</label>
+          <select
+            id="physical-gamepad-profile"
+            value={profile}
+            onChange={event => onProfileChange(event.target.value as PhysicalGamepadProfile)}
+          >
+            <option value="auto">Auto detect</option>
+            <option value="xbox">Xbox / XInput</option>
+            <option value="playstation">PlayStation</option>
+            <option value="logitech">Logitech</option>
+          </select>
+        </div>
+        <div className="setting-group">
+          <label htmlFor="physical-gamepad-index">Controller index</label>
+          <input
+            id="physical-gamepad-index"
+            type="number"
+            min="0"
+            placeholder="Auto (first connected)"
+            value={preferredIndex ?? ''}
+            onChange={event =>
+              onPreferredIndexChange(event.target.value === '' ? undefined : Number(event.target.value))
+            }
+          />
+        </div>
+      </div>
+      <div className="setting-group">
+        <label htmlFor="physical-gamepad-deadzone">Stick deadzone: {deadzone.toFixed(2)}</label>
+        <input
+          id="physical-gamepad-deadzone"
+          type="range"
+          min="0"
+          max="0.5"
+          step="0.01"
+          value={deadzone}
+          onChange={event => onDeadzoneChange(Number(event.target.value))}
+        />
+      </div>
+
+      <h4>
+        Button Operations <span className="physical-binding-count">{configuredCount}/17 configured</span>
+      </h4>
+      <p className="settings-help">
+        Select any standard controller button, then assign independent press and release topic, service, or action
+        operations.
+      </p>
+      <div className="physical-control-picker" role="list" aria-label="Physical controller buttons">
+        {PHYSICAL_GAMEPAD_CONTROLS.map(({ id }) => {
+          const configured = Boolean(bindings[id]?.press || bindings[id]?.release);
+          return (
+            <button
+              key={id}
+              type="button"
+              className={`${selectedControl === id ? 'selected' : ''} ${configured ? 'configured' : ''}`}
+              onClick={() => setSelectedControl(id)}
+            >
+              {getPhysicalGamepadControlLabel(id, labelsProfile)}
+            </button>
+          );
+        })}
+      </div>
+      <fieldset className="physical-control-binding">
+        <legend>{selectedLabel}</legend>
+        <RosEventOperationsEditor
+          events={['press', 'release']}
+          value={bindings[selectedControl] || {}}
+          ros={ros}
+          onChange={updateSelectedBinding}
+        />
+      </fieldset>
+    </div>
+  );
+};
+
+export default PhysicalGamepadSettings;

--- a/src/features/customGamepad/defaultLayouts.test.ts
+++ b/src/features/customGamepad/defaultLayouts.test.ts
@@ -35,7 +35,7 @@ describe('defaultLayouts', () => {
     expect(defaultPhysicalGamepadLayout.components[0]).toMatchObject({
       type: 'physical-gamepad',
       action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
-      config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08 },
+      config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08, physicalGamepadPublishHz: 20 },
     });
   });
 

--- a/src/features/customGamepad/defaultLayouts.test.ts
+++ b/src/features/customGamepad/defaultLayouts.test.ts
@@ -3,6 +3,7 @@ import {
   componentLibrary,
   defaultDualJoystickHeartbeatLayout,
   defaultGamepadLibrary,
+  defaultPhysicalGamepadLayout,
 } from './defaultLayouts';
 import type { CustomGamepadLayout, GamepadLibraryItem } from './types';
 
@@ -17,13 +18,24 @@ describe('defaultLayouts', () => {
     expect(layout.metadata.version).toBeTruthy();
   };
 
-  it('provides one generic dual-joystick heartbeat template', () => {
+  it('provides the generic and physical-controller templates', () => {
     validateLayout(defaultDualJoystickHeartbeatLayout);
-    expect(defaultGamepadLibrary).toHaveLength(1);
+    validateLayout(defaultPhysicalGamepadLayout);
+    expect(defaultGamepadLibrary).toHaveLength(2);
     expect(defaultGamepadLibrary[0]).toMatchObject({
       id: 'dual-joystick-heartbeat',
       name: 'Dual Joystick + Heartbeat',
       isDefault: true,
+    });
+    expect(defaultGamepadLibrary[1]).toMatchObject({
+      id: 'physical-gamepad',
+      name: 'Physical Gamepad',
+      isDefault: true,
+    });
+    expect(defaultPhysicalGamepadLayout.components[0]).toMatchObject({
+      type: 'physical-gamepad',
+      action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
+      config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08 },
     });
   });
 
@@ -69,6 +81,7 @@ describe('defaultLayouts', () => {
   it('keeps all editor component types available', () => {
     expect(componentLibrary.map(component => component.type)).toEqual([
       'joystick',
+      'physical-gamepad',
       'button',
       'dpad',
       'toggle',

--- a/src/features/customGamepad/defaultLayouts.test.ts
+++ b/src/features/customGamepad/defaultLayouts.test.ts
@@ -34,6 +34,7 @@ describe('defaultLayouts', () => {
     });
     expect(defaultPhysicalGamepadLayout.components[0]).toMatchObject({
       type: 'physical-gamepad',
+      position: { x: 0, y: 0, width: 8, height: 4 },
       action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
       config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08, physicalGamepadPublishHz: 20 },
     });

--- a/src/features/customGamepad/defaultLayouts.ts
+++ b/src/features/customGamepad/defaultLayouts.ts
@@ -77,7 +77,7 @@ export const defaultPhysicalGamepadLayout: CustomGamepadLayout = {
     {
       id: 'physical-gamepad',
       type: 'physical-gamepad',
-      position: { x: 1, y: 0, width: 6, height: 4 },
+      position: { x: 0, y: 0, width: 8, height: 4 },
       label: 'Physical Gamepad',
       action: {
         topic: '/joy',

--- a/src/features/customGamepad/defaultLayouts.ts
+++ b/src/features/customGamepad/defaultLayouts.ts
@@ -1,4 +1,5 @@
 import { CustomGamepadLayout, GamepadLibraryItem } from './types';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ } from './physicalGamepad';
 
 // Generic ROS Joy starting point.
 export const defaultDualJoystickHeartbeatLayout: CustomGamepadLayout = {
@@ -86,6 +87,7 @@ export const defaultPhysicalGamepadLayout: CustomGamepadLayout = {
       config: {
         physicalGamepadProfile: 'auto',
         physicalGamepadDeadzone: 0.08,
+        physicalGamepadPublishHz: DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ,
       },
     },
   ],

--- a/src/features/customGamepad/defaultLayouts.ts
+++ b/src/features/customGamepad/defaultLayouts.ts
@@ -66,6 +66,40 @@ export const defaultDualJoystickHeartbeatLayout: CustomGamepadLayout = {
   }
 };
 
+export const defaultPhysicalGamepadLayout: CustomGamepadLayout = {
+  id: 'default-physical-gamepad',
+  name: 'Physical Gamepad',
+  description: 'Live Xbox, PlayStation, or Logitech controller with configurable ROS controls',
+  gridSize: { width: 8, height: 4 },
+  cellSize: 80,
+  components: [
+    {
+      id: 'physical-gamepad',
+      type: 'physical-gamepad',
+      position: { x: 1, y: 0, width: 6, height: 4 },
+      label: 'Physical Gamepad',
+      action: {
+        topic: '/joy',
+        messageType: 'sensor_msgs/msg/Joy',
+        field: 'axes',
+      },
+      config: {
+        physicalGamepadProfile: 'auto',
+        physicalGamepadDeadzone: 0.08,
+      },
+    },
+  ],
+  rosConfig: {
+    defaultTopic: '/joy',
+    defaultMessageType: 'sensor_msgs/msg/Joy',
+  },
+  metadata: {
+    created: new Date().toISOString(),
+    modified: new Date().toISOString(),
+    version: '1.0.0',
+  },
+};
+
 // Default library items
 export const defaultGamepadLibrary: GamepadLibraryItem[] = [
   {
@@ -74,6 +108,13 @@ export const defaultGamepadLibrary: GamepadLibraryItem[] = [
     description: 'Generic four-axis Joy controller with a heartbeat monitor',
     layout: defaultDualJoystickHeartbeatLayout,
     isDefault: true
+  },
+  {
+    id: 'physical-gamepad',
+    name: 'Physical Gamepad',
+    description: 'Live Xbox, PlayStation, or Logitech controller with configurable ROS controls',
+    layout: defaultPhysicalGamepadLayout,
+    isDefault: true,
   }
 ];
 
@@ -85,6 +126,13 @@ export const componentLibrary = [
     description: 'Analog stick for continuous control',
     defaultSize: { width: 2, height: 2 },
     icon: '🕹️'
+  },
+  {
+    type: 'physical-gamepad' as const,
+    name: 'Physical Gamepad',
+    description: 'Connected Xbox, PlayStation, or Logitech controller',
+    defaultSize: { width: 6, height: 4 },
+    icon: '🎮'
   },
   {
     type: 'button' as const,

--- a/src/features/customGamepad/physicalGamepad.test.ts
+++ b/src/features/customGamepad/physicalGamepad.test.ts
@@ -4,6 +4,7 @@ import {
   detectPhysicalGamepadProfile,
   findPhysicalGamepad,
   getPhysicalGamepadControlLabel,
+  normalizePhysicalGamepadPublishHz,
   snapshotPhysicalGamepad,
 } from './physicalGamepad';
 
@@ -34,6 +35,14 @@ describe('physical gamepad normalization', () => {
     expect(applyGamepadDeadzone(0.07, 0.08)).toBe(0);
     expect(applyGamepadDeadzone(-0.54, 0.08)).toBeCloseTo(-0.5);
     expect(applyGamepadDeadzone(2, 0.08)).toBe(1);
+  });
+
+  it('defaults and clamps the Joy publish rate', () => {
+    expect(normalizePhysicalGamepadPublishHz(undefined)).toBe(20);
+    expect(normalizePhysicalGamepadPublishHz(Number.NaN)).toBe(20);
+    expect(normalizePhysicalGamepadPublishHz(0)).toBe(1);
+    expect(normalizePhysicalGamepadPublishHz(30)).toBe(30);
+    expect(normalizePhysicalGamepadPublishHz(120)).toBe(60);
   });
 
   it('normalizes the standard four axes and seventeen buttons', () => {

--- a/src/features/customGamepad/physicalGamepad.test.ts
+++ b/src/features/customGamepad/physicalGamepad.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyGamepadDeadzone,
+  detectPhysicalGamepadProfile,
+  findPhysicalGamepad,
+  getPhysicalGamepadControlLabel,
+  snapshotPhysicalGamepad,
+} from './physicalGamepad';
+
+const makeGamepad = (overrides: Partial<Gamepad> = {}): Gamepad =>
+  ({
+    axes: [0, 0, 0, 0],
+    buttons: Array.from({ length: 17 }, () => ({ pressed: false, touched: false, value: 0 })),
+    connected: true,
+    hapticActuators: [],
+    id: 'Xbox Wireless Controller',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 1,
+    vibrationActuator: null,
+    ...overrides,
+  }) as Gamepad;
+
+describe('physical gamepad normalization', () => {
+  it('detects the supported controller families while honoring an explicit profile', () => {
+    expect(detectPhysicalGamepadProfile('auto', 'Sony DualSense Wireless Controller')).toBe('playstation');
+    expect(detectPhysicalGamepadProfile('auto', 'Logitech Gamepad F710')).toBe('logitech');
+    expect(detectPhysicalGamepadProfile('auto', 'Microsoft X-Box One pad')).toBe('xbox');
+    expect(detectPhysicalGamepadProfile('playstation', 'Logitech F310')).toBe('playstation');
+    expect(getPhysicalGamepadControlLabel('face-bottom', 'playstation')).toBe('×');
+  });
+
+  it('applies and rescales a configurable deadzone', () => {
+    expect(applyGamepadDeadzone(0.07, 0.08)).toBe(0);
+    expect(applyGamepadDeadzone(-0.54, 0.08)).toBeCloseTo(-0.5);
+    expect(applyGamepadDeadzone(2, 0.08)).toBe(1);
+  });
+
+  it('normalizes the standard four axes and seventeen buttons', () => {
+    const buttons = Array.from({ length: 17 }, (_, index) => ({
+      pressed: index === 4,
+      touched: index === 4,
+      value: index === 4 ? 1 : 0,
+    }));
+    const snapshot = snapshotPhysicalGamepad(makeGamepad({ axes: [0.54, -0.54, 0.07, 1], buttons }), 0.08);
+
+    expect(snapshot.axes).toEqual([0.5, -0.5, 0, 1]);
+    expect(snapshot.pressed[4]).toBe(true);
+    expect(snapshot.buttons).toHaveLength(17);
+  });
+
+  it('selects a preferred connected controller or the first connected controller', () => {
+    const first = makeGamepad({ index: 0 });
+    const second = makeGamepad({ id: 'Second', index: 2 });
+    const pads = [first, null, second];
+    expect(findPhysicalGamepad(pads)).toBe(first);
+    expect(findPhysicalGamepad(pads, 2)).toBe(second);
+    expect(findPhysicalGamepad(pads, 1)).toBeNull();
+  });
+});

--- a/src/features/customGamepad/physicalGamepad.ts
+++ b/src/features/customGamepad/physicalGamepad.ts
@@ -1,0 +1,139 @@
+import type { PhysicalGamepadControlId, PhysicalGamepadProfile } from './types';
+
+export const PHYSICAL_GAMEPAD_CONTROLS: ReadonlyArray<{
+  id: PhysicalGamepadControlId;
+  buttonIndex: number;
+}> = [
+  { id: 'face-bottom', buttonIndex: 0 },
+  { id: 'face-right', buttonIndex: 1 },
+  { id: 'face-left', buttonIndex: 2 },
+  { id: 'face-top', buttonIndex: 3 },
+  { id: 'left-bumper', buttonIndex: 4 },
+  { id: 'right-bumper', buttonIndex: 5 },
+  { id: 'left-trigger', buttonIndex: 6 },
+  { id: 'right-trigger', buttonIndex: 7 },
+  { id: 'select', buttonIndex: 8 },
+  { id: 'start', buttonIndex: 9 },
+  { id: 'left-stick', buttonIndex: 10 },
+  { id: 'right-stick', buttonIndex: 11 },
+  { id: 'dpad-up', buttonIndex: 12 },
+  { id: 'dpad-down', buttonIndex: 13 },
+  { id: 'dpad-left', buttonIndex: 14 },
+  { id: 'dpad-right', buttonIndex: 15 },
+  { id: 'home', buttonIndex: 16 },
+];
+
+const PROFILE_LABELS: Record<Exclude<PhysicalGamepadProfile, 'auto'>, Record<PhysicalGamepadControlId, string>> = {
+  xbox: {
+    'face-bottom': 'A',
+    'face-right': 'B',
+    'face-left': 'X',
+    'face-top': 'Y',
+    'left-bumper': 'LB',
+    'right-bumper': 'RB',
+    'left-trigger': 'LT',
+    'right-trigger': 'RT',
+    select: 'View',
+    start: 'Menu',
+    'left-stick': 'LS',
+    'right-stick': 'RS',
+    'dpad-up': 'D-pad Up',
+    'dpad-down': 'D-pad Down',
+    'dpad-left': 'D-pad Left',
+    'dpad-right': 'D-pad Right',
+    home: 'Xbox',
+  },
+  playstation: {
+    'face-bottom': '×',
+    'face-right': '○',
+    'face-left': '□',
+    'face-top': '△',
+    'left-bumper': 'L1',
+    'right-bumper': 'R1',
+    'left-trigger': 'L2',
+    'right-trigger': 'R2',
+    select: 'Create',
+    start: 'Options',
+    'left-stick': 'L3',
+    'right-stick': 'R3',
+    'dpad-up': 'D-pad Up',
+    'dpad-down': 'D-pad Down',
+    'dpad-left': 'D-pad Left',
+    'dpad-right': 'D-pad Right',
+    home: 'PS',
+  },
+  logitech: {
+    'face-bottom': 'A',
+    'face-right': 'B',
+    'face-left': 'X',
+    'face-top': 'Y',
+    'left-bumper': 'LB',
+    'right-bumper': 'RB',
+    'left-trigger': 'LT',
+    'right-trigger': 'RT',
+    select: 'Back',
+    start: 'Start',
+    'left-stick': 'L',
+    'right-stick': 'R',
+    'dpad-up': 'D-pad Up',
+    'dpad-down': 'D-pad Down',
+    'dpad-left': 'D-pad Left',
+    'dpad-right': 'D-pad Right',
+    home: 'Mode',
+  },
+};
+
+export interface PhysicalGamepadSnapshot {
+  axes: [number, number, number, number];
+  buttons: number[];
+  pressed: boolean[];
+}
+
+export const EMPTY_GAMEPAD_SNAPSHOT: PhysicalGamepadSnapshot = {
+  axes: [0, 0, 0, 0],
+  buttons: Array(17).fill(0),
+  pressed: Array(17).fill(false),
+};
+
+export const detectPhysicalGamepadProfile = (
+  requested: PhysicalGamepadProfile | undefined,
+  gamepadId = ''
+): Exclude<PhysicalGamepadProfile, 'auto'> => {
+  if (requested && requested !== 'auto') return requested;
+  const id = gamepadId.toLowerCase();
+  if (/playstation|dualshock|dualsense|sony|wireless controller/.test(id)) return 'playstation';
+  if (/logitech|f310|f510|f710/.test(id)) return 'logitech';
+  return 'xbox';
+};
+
+export const getPhysicalGamepadControlLabel = (
+  controlId: PhysicalGamepadControlId,
+  profile: Exclude<PhysicalGamepadProfile, 'auto'>
+): string => PROFILE_LABELS[profile][controlId];
+
+export const applyGamepadDeadzone = (value: number, deadzone: number): number => {
+  const safeValue = Number.isFinite(value) ? Math.max(-1, Math.min(1, value)) : 0;
+  const safeDeadzone = Number.isFinite(deadzone) ? Math.max(0, Math.min(0.95, deadzone)) : 0.08;
+  const magnitude = Math.abs(safeValue);
+  if (magnitude <= safeDeadzone) return 0;
+  return Math.sign(safeValue) * ((magnitude - safeDeadzone) / (1 - safeDeadzone));
+};
+
+export const snapshotPhysicalGamepad = (gamepad: Gamepad, deadzone = 0.08): PhysicalGamepadSnapshot => ({
+  axes: [0, 1, 2, 3].map(index =>
+    applyGamepadDeadzone(gamepad.axes[index] ?? 0, deadzone)
+  ) as PhysicalGamepadSnapshot['axes'],
+  buttons: PHYSICAL_GAMEPAD_CONTROLS.map(({ buttonIndex }) => gamepad.buttons[buttonIndex]?.value ?? 0),
+  pressed: PHYSICAL_GAMEPAD_CONTROLS.map(({ buttonIndex }) => gamepad.buttons[buttonIndex]?.pressed ?? false),
+});
+
+export const findPhysicalGamepad = (gamepads: ArrayLike<Gamepad | null>, preferredIndex?: number): Gamepad | null => {
+  if (preferredIndex !== undefined && preferredIndex >= 0) {
+    const preferred = gamepads[preferredIndex];
+    return preferred?.connected ? preferred : null;
+  }
+  return Array.from(gamepads).find((gamepad): gamepad is Gamepad => Boolean(gamepad?.connected)) ?? null;
+};
+
+export const physicalGamepadSnapshotKey = (snapshot: PhysicalGamepadSnapshot): string =>
+  [...snapshot.axes.map(value => value.toFixed(3)), ...snapshot.buttons.map(value => value.toFixed(2))].join(',');

--- a/src/features/customGamepad/physicalGamepad.ts
+++ b/src/features/customGamepad/physicalGamepad.ts
@@ -1,5 +1,15 @@
 import type { PhysicalGamepadControlId, PhysicalGamepadProfile } from './types';
 
+export const DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ = 20;
+export const MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ = 1;
+export const MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ = 60;
+
+export const normalizePhysicalGamepadPublishHz = (value: number | undefined): number => {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) return DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ;
+  return Math.max(MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ, Math.min(MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ, numericValue));
+};
+
 export const PHYSICAL_GAMEPAD_CONTROLS: ReadonlyArray<{
   id: PhysicalGamepadControlId;
   buttonIndex: number;

--- a/src/features/customGamepad/types.ts
+++ b/src/features/customGamepad/types.ts
@@ -93,6 +93,7 @@ export interface GamepadComponentConfig {
     physicalGamepadProfile?: PhysicalGamepadProfile;
     physicalGamepadIndex?: number;
     physicalGamepadDeadzone?: number;
+    physicalGamepadPublishHz?: number;
     physicalGamepadBindings?: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
 
     // Button specific

--- a/src/features/customGamepad/types.ts
+++ b/src/features/customGamepad/types.ts
@@ -1,5 +1,33 @@
 // Types for the custom gamepad system
 
+import type { RosOperation } from '../../utils/rosOperations';
+
+export type PhysicalGamepadProfile = 'auto' | 'xbox' | 'playstation' | 'logitech';
+
+export type PhysicalGamepadControlId =
+  | 'face-bottom'
+  | 'face-right'
+  | 'face-left'
+  | 'face-top'
+  | 'left-bumper'
+  | 'right-bumper'
+  | 'left-trigger'
+  | 'right-trigger'
+  | 'select'
+  | 'start'
+  | 'left-stick'
+  | 'right-stick'
+  | 'dpad-up'
+  | 'dpad-down'
+  | 'dpad-left'
+  | 'dpad-right'
+  | 'home';
+
+export interface PhysicalGamepadBinding {
+  press?: RosOperation;
+  release?: RosOperation;
+}
+
 export interface GridPosition {
   x: number;
   y: number;
@@ -33,7 +61,7 @@ export enum ComponentInteractionMode {
 
 export interface GamepadComponentConfig {
   id: string;
-  type: 'joystick' | 'button' | 'dpad' | 'toggle' | 'slider' | 'camera' | 'plot' | 'heartbeat';
+  type: 'joystick' | 'physical-gamepad' | 'button' | 'dpad' | 'toggle' | 'slider' | 'camera' | 'plot' | 'heartbeat';
   position: GridPosition;
   label?: string;
   action?: ComponentAction;
@@ -60,6 +88,12 @@ export interface GamepadComponentConfig {
     poseStampedOdometryMessageType?: string;
     poseStampedUseOdometryOrientation?: boolean;
     twistStampedFrameId?: string;
+
+    // Physical gamepad specific
+    physicalGamepadProfile?: PhysicalGamepadProfile;
+    physicalGamepadIndex?: number;
+    physicalGamepadDeadzone?: number;
+    physicalGamepadBindings?: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
 
     // Button specific
     buttonIndex?: number;
@@ -176,5 +210,4 @@ export interface EditorState {
   cellSize: number;
   showGrid: boolean;
   snapToGrid: boolean;
-} 
-import type { RosOperation } from '../../utils/rosOperations';
+}


### PR DESCRIPTION
## Summary
- Add a physical-gamepad custom panel component using the browser Gamepad API (Xbox/PlayStation/Logitech auto-detection, configurable deadzone, per-button press/release operations)
- Add a configurable Joy publish rate (1-60 Hz, default 20 Hz)
- Optimize the panel and its settings for mobile: full-width built-in layout, safe-area padding, 44px touch targets, 16px inputs (avoids iOS zoom), explicit message when the Gamepad API is unavailable, and neutral Joy publication on tab hide/suspend

## Test plan
- [x] Full test suite (`npm run test:run`): 885 passed, 12 skipped
- [x] `npm run lint`: clean
- [x] Focused Playwright visual QA at 390x844 and 360x800 (mocked ROS connection): full-width pad rendering and the settings modal's button-operations picker grid both confirmed with no overflow
- [x] Android ARM64 debug APK build verified