### PR TITLE
feat: promote stream gateway and physical gamepad updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
     depends_on:
       - app
       - ollama-relay
-      - webrtc-relay
       - ros-stack
     networks:
       - app-net
@@ -68,9 +67,16 @@ services:
       - ./infra/caddy/OllamaRelay.Caddyfile:/etc/caddy/Caddyfile:ro
       - ollama-relay-socket:/run/ollama-relay
 
-  # MediaMTX runs on the host network so its ICE candidates include physical
-  # and VPN interfaces. This relay exposes only its HTTP/WHEP signaling API to
-  # Caddy through a Unix socket shared with the bridge network.
+  # Part of the web deployment, beside Caddy, for a media gateway Robo-Boy does not run. Only a
+  # browser needs it, and only because two things are true at once: an HTTPS page cannot fetch the
+  # gateway's plaintext port, and the gateway's ports are not reachable from Caddy's bridge network
+  # the way rosbridge and the video server are. Running on the host network sidesteps both -- it
+  # reaches the gateway on loopback and hands the result to Caddy over a Unix socket.
+  #
+  # It is not part of the ROS side and nothing there depends on it: `up -d ros-stack` starts the
+  # robot services alone, and the packaged apps address the gateway directly without passing
+  # through here at all. A deployment whose firewall lets the bridge reach the gateway, and whose
+  # gateway admits that subnet, can drop this service and point WEBRTC_UPSTREAM straight at it.
   webrtc-relay:
     image: caddy:latest
     restart: unless-stopped

--- a/docs/application.md
+++ b/docs/application.md
@@ -73,6 +73,43 @@ Compatibility mode disables WebKit's DMABUF renderer for that launch.
 
 On Windows, the desktop webview keeps Wry's default disabled Edge UI features and adds GPU rasterization hints through `additionalBrowserArgs` in `src-tauri/tauri.conf.json`. Desktop devtools are disabled in the packaged webview config to keep the runtime closer to production performance.
 
+## WebRTC On The Linux Desktop
+
+The desktop shell renders in the system's WebKitGTK rather than a webview Robo-Boy ships, so whether
+WebRTC exists at all is the distribution's build choice. Where it is compiled out there is no
+`RTCPeerConnection`, and a panel that plays a WHEP stream fails on that missing reference rather than
+on the network. Ubuntu 26.04 is one such distribution, in both its GTK3 (`webkit2gtk-4.1`) and GTK4
+(`webkitgtk-6.0`) builds.
+
+Check the host before assuming a stream problem is a stream problem:
+
+```bash
+strings "$(ldconfig -p | awk '/libwebkit2gtk-4.1.so.0/{print $NF; exit}')" | grep -qx webrtcbin && echo "WebRTC available" || echo "WebRTC not built into this WebKitGTK"
+```
+
+Installing GStreamer's WebRTC plugins does not change the answer. WebKitGTK negotiates through
+GStreamer, so a host needs those elements *as well*, but when the engine was built without the
+backend it never names them and no amount of plugins makes the API appear.
+
+WebKitGTK also leaves `enable-webrtc` off by default, so the shell turns it on as the main window is
+created. That is required wherever the backend is compiled in, and harmless where it is not.
+
+Browsers carry their own WebRTC stack, so the same panel works in the web build on the same machine.
+This is a WebKitGTK property, not a desktop one: the Windows, macOS, iOS and Android shells all use
+engines with WebRTC compiled in.
+
+A panel does not have to give up where it is missing. The stream gateway can publish the same H.264
+over HLS -- `hls: true` in its configuration -- and Robo-Boy names that as the `webrtcHls` endpoint,
+which a panel may declare alongside `webrtcWhep`. Every one of these engines has Media Source
+Extensions even where it has no WebRTC, so a panel can feed the buffer itself and play the same
+camera; the official WebRTC panel does exactly that when `RTCPeerConnection` is missing. Latency is
+seconds rather than milliseconds, so it is a fallback and not the path to prefer.
+
+One trap if you write such a panel: a panel's frame has an opaque origin, so the object URL a player
+would normally make for its MediaSource comes back as `blob:null/...` and a media element refuses to
+load it. Attach the source with `srcObject` instead, which needs no URL. The camera view avoids all
+of this by reading the MJPEG endpoint, which needs neither WebRTC nor Media Source Extensions.
+
 ## Build An Installer
 
 That is the local equivalent of what CI runs for a release. Official installers for Linux, macOS, and

--- a/docs/custom-gamepads.md
+++ b/docs/custom-gamepads.md
@@ -30,6 +30,8 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 
 The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at a configurable 1-60 Hz (20 Hz by default) while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
 
+The responsive visualization uses the full built-in pad width on phones and works in portrait or landscape. Web, iOS, and Android use the same browser Gamepad API path; a controller must be paired with the device and a button may need to be pressed after the app gains focus. If the platform WebView does not expose the API, the pad reports that explicitly. Hiding or suspending the app publishes a neutral Joy message before polling pauses.
+
 Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Publish rate, stick deadzone, and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
 
 ## Runtime Flow

--- a/docs/custom-gamepads.md
+++ b/docs/custom-gamepads.md
@@ -14,16 +14,23 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 
 ## Supported Components
 
-| Component | Primary role                                                            |
-| --------- | ----------------------------------------------------------------------- |
-| Joystick  | Publish continuous axes, including Joy, Twist, and PoseStamped mappings |
-| Button    | Publish pressed and released values or indexed Joy buttons              |
-| D-pad     | Publish discrete directional input                                      |
-| Toggle    | Maintain and publish an on/off state                                    |
-| Slider    | Publish a bounded numeric value                                         |
-| Camera    | Display a proxied or ROS-delivered image stream                         |
-| Plot      | Subscribe to numeric fields and render recent samples                   |
-| Heartbeat | Monitor boolean state or recurring messages                             |
+| Component       | Primary role                                                                      |
+| --------------- | --------------------------------------------------------------------------------- |
+| Joystick        | Publish continuous virtual axes, including Joy, Twist, and PoseStamped mappings  |
+| Physical gamepad | Read and visualize a browser-connected Xbox, PlayStation, or Logitech controller |
+| Button          | Publish pressed and released values or indexed Joy buttons                        |
+| D-pad           | Publish discrete directional input                                                |
+| Toggle          | Maintain and publish an on/off state                                              |
+| Slider          | Publish a bounded numeric value                                                   |
+| Camera          | Display a proxied or ROS-delivered image stream                                   |
+| Plot            | Subscribe to numeric fields and render recent samples                             |
+| Heartbeat       | Monitor boolean state or recurring messages                                       |
+
+## Physical Controllers
+
+The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at 20 Hz while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
+
+Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Stick deadzone and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
 
 ## Runtime Flow
 
@@ -43,6 +50,7 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 | Built-in templates and palette           | `src/features/customGamepad/defaultLayouts.ts`                  |
 | Import, export, and persistence          | `src/features/customGamepad/gamepadStorage.ts`                  |
 | ROS message conversion and introspection | `src/features/customGamepad/rosMessageUtils.ts`                 |
+| Physical-controller normalization        | `src/features/customGamepad/physicalGamepad.ts`                 |
 | Editor                                   | `src/features/customGamepad/components/GamepadEditor.tsx`       |
 | Runtime renderer                         | `src/features/customGamepad/components/CustomGamepadLayout.tsx` |
 | Component dispatch and editor shell      | `src/features/customGamepad/components/GamepadComponent.tsx`    |

--- a/docs/custom-gamepads.md
+++ b/docs/custom-gamepads.md
@@ -28,9 +28,9 @@ Layouts are stored in `localStorage` under `robo-boy-custom-gamepads`. Exported 
 
 ## Physical Controllers
 
-The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at 20 Hz while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
+The physical-gamepad component uses the browser's standard Gamepad API mapping: four axes and 17 buttons. It can auto-detect Xbox/XInput, PlayStation, and Logitech IDs or use an explicitly selected visual profile. It publishes a complete `sensor_msgs/Joy` message at a configurable 1-60 Hz (20 Hz by default) while connected and immediately publishes a neutral message when the controller disappears or the component unmounts.
 
-Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Stick deadzone and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
+Each standard button—including triggers, stick clicks, D-pad directions, center buttons, and home—has independent press and release operations. Operations reuse the same topic, service, and action executor as ordinary pad buttons. Publish rate, stick deadzone, and a preferred browser controller index are saved with the layout. Non-standard browser mappings are displayed with a warning because their raw axis and button order is device- and browser-specific.
 
 ## Runtime Flow
 

--- a/docs/custom-panels.md
+++ b/docs/custom-panels.md
@@ -122,13 +122,18 @@ Staging prefers that file when it exists and falls back to the tracked configura
 command changes. Then build the desktop app and its installer:
 
 ```bash
-npm run build:tauri:panels
-npm run tauri build -- --bundles deb
+npm run panels:stage-local
+ROBOBOY_PUBLIC_DIR="$PWD/.panel-stage/public" npm run tauri build -- --bundles deb
 ```
 
-`build:tauri:panels` stages the panels into a generated public tree and builds the frontend from it, so the
-bundles ship inside the binary. Use `-- --config <path>` on any `*:panels` command to stage a different
-selection. Staging prints which configuration it used.
+Staging writes the panels into a generated public tree and prints which configuration it used. Keeping
+`ROBOBOY_PUBLIC_DIR` in the environment for the second command is what makes them ship: `tauri build` runs its
+own `beforeBuildCommand`, which rebuilds the frontend and would otherwise take the empty `public/panels`,
+discarding everything staged and producing an installer with no panels in it and no error to say so.
+
+`npm run build:tauri:panels` stages and builds the frontend alone, which is enough to run it in a browser but
+does not produce an installer. Use `-- --config <path>` on any `*:panels` command to stage a different
+selection.
 
 ### What happens on first run
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ The stack starts:
 - `ros-stack`: ROS 2, rosapi, rosbridge, and `web_video_server` on the host network.
 - `caddy`: HTTP/HTTPS entry point and reverse proxy.
 - `ollama-relay`: transport-only adapter from Caddy's Unix socket to the configured external Ollama API.
-- `webrtc-relay`: host-network adapter from Caddy's Unix socket to MediaMTX's WHEP signaling API.
+- `webrtc-relay`: part of the web deployment beside Caddy. A transport to a media gateway Robo-Boy does not run, needed only by browsers.
 - Ollama is external to the Compose stack and is reached through the same-origin `/ollama` proxy.
 
 Changes under `src/` should hot reload. Rebuild after changing files under `infra/`, Compose files, or ROS dependencies:
@@ -91,13 +91,29 @@ a CORS rejection, include `tauri://*,http://tauri.localhost,https://tauri.localh
 
 In the browser app, Quick Connect and Domain ID use the Caddy proxy. The advanced Host or IP field accepts any hostname, DNS name, VPN name, IPv4 address, IPv6 address, or URL that resolves from the client machine. The Ports fields control rosbridge, video, and mesh ports for direct host connections and default to the matching `VITE_*_PORT` values. It connects directly to that host in `auto` mode when it differs from the frontend host. Use `VITE_WEB_BACKEND_MODE=proxy` to force all browser connections through Caddy.
 
-The optional camera gateway is reached through the same-origin `/webrtc` route for WHEP signaling. Caddy reaches
-host-network MediaMTX through `webrtc-relay` and a shared Unix socket, avoiding Docker host-gateway firewall
-differences. Its ICE media port is negotiated by WebRTC and must be reachable directly from clients (the Genesis
-gateway uses UDP `8189`). RTSP remains a direct gateway service on port `8554` for native clients; browsers use
-WHEP/WebRTC instead.
-The gateway control API stays bound to host loopback. The relay exposes only `GET /webrtc/_discovery/paths`,
-which maps to MediaMTX's active-path listing; configuration and mutation endpoints are not proxied.
+The camera gateway is external. Robo-Boy starts no media server and does not care which one you run: a
+simulator provides one, or you run your own. **The packaged desktop and mobile apps never go through Robo-Boy
+to reach it** — they address the gateway directly — so a client connected to nothing but the ROS stack still
+gets WebRTC, provided a gateway is reachable from it.
+
+Only browsers need Robo-Boy in the path, because an HTTPS page may not fetch the gateway's plaintext port. The
+same-origin `/webrtc` route serves them, and its upstream is a deployment choice:
+
+| Upstream                 | Requires                                                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `webrtc-relay` (default) | Nothing of the host: it runs beside Caddy and reaches the gateway on loopback.                                                                                            |
+| The gateway directly     | `WEBRTC_UPSTREAM` and `WEBRTC_DISCOVERY_UPSTREAM`, a firewall that lets Caddy's bridge reach the gateway's ports, and a gateway whose API allowlist includes that subnet. |
+
+The relay belongs to the web deployment, not to the robot side. `docker compose up -d ros-stack` starts the ROS
+services alone and nothing there depends on it, while a packaged client addresses the gateway directly. Without
+a gateway running anywhere, `/webrtc` returns a proxy error and the panel reports no streams; nothing else in
+Robo-Boy is affected.
+
+Exactly one read-only resource is exposed: `GET /webrtc/_discovery/paths`, mapped to the gateway's active-path
+listing, with any other method refused. The relay carries signaling and that resource on separate sockets, so
+the pass-through route cannot reach the control API by asking for it. ICE media is negotiated separately and
+never passes through Caddy, so the gateway's ICE port (UDP `8189` by default) must be reachable directly from
+clients. RTSP stays a direct gateway service on `8554` for native clients; browsers use WHEP instead.
 
 Normal development discovers an empty tracked registry at `public/panels/installed.json`. Run
 `npm run dev:panels` to verify and stage the local repositories selected by

--- a/docs/external-panels.md
+++ b/docs/external-panels.md
@@ -210,14 +210,24 @@ workspace imports cannot create them. ROS messages are normalized
 to JSON at this boundary, so non-finite ROS floating-point values become `null` without dropping the rest of the
 message; non-JSON and oversized payloads are rejected. Network requests accept only
 declared exact HTTPS origins, `self`, or the visibly broad `https:` grant. Host endpoint grants are narrower:
-`videoStream`, for example, permits only its known discovery and WHEP routes rather than the complete service
-origin. Redirect targets are checked, ambient credentials are omitted, privileged headers are blocked, response
-headers are filtered, responses are size-capped, and concurrent requests time out. The sandbox has no parent DOM,
+each permits only the routes beneath the endpoint the runtime resolved, rather than the complete service origin.
+`webrtcWhep`, `webrtcDiscovery` and `webrtcHls` name the WebRTC stream gateway, which is a deployment of its own
+and needs nothing else of Robo-Boy running; where it lives is decided in `src/runtime/runtimeConfig.tsx` and
+configurable through `VITE_WEBRTC_PORT`, `VITE_WEBRTC_DISCOVERY_PORT` and `VITE_WEBRTC_HLS_PORT`, so no caller
+writes its ports down. `webrtcHls` carries the same stream for a webview that cannot speak WebRTC at all -- see
+[WebRTC on the Linux desktop](application.md#webrtc-on-the-linux-desktop) -- and is empty where the gateway is
+not directly addressable, which is every browser behind the proxy. `videoStream` reaches the same gateway for
+panels published before it had endpoints of its own. Redirect targets are checked, ambient credentials are omitted, privileged headers are blocked, response
+headers are filtered, responses are size-capped, and concurrent requests time out. A response is carried as
+bytes, so `arrayBuffer()` returns exactly what the server sent and `text()` and `json()` are readings of it; a
+panel that plays media or reads any other binary format needs no way out of the sandbox to do it. The sandbox has no parent DOM,
 Robo-Boy storage, cookies, or raw host objects.
 
 The iframe permits form event handling so panel configuration forms can submit to their own JavaScript listeners.
 Its CSP keeps `form-action 'none'`, so native form navigation and form-data submission outside the sandbox remain
-blocked.
+blocked. It is also granted `autoplay`: the sandbox's opaque origin makes it cross-origin, which withholds
+playback by default, and a panel showing a stream would otherwise be refused playback it never asked a person
+for.
 
 Broker request and subscription identifiers are scoped to each private `MessagePort` and do not depend on secure-
 context-only browser APIs. SDK ROS subscriptions therefore behave the same on `localhost`, plain-HTTP LAN addresses,
@@ -349,7 +359,7 @@ Install the type-only SDK directly from its versioned GitHub release:
 ```bash
 cd my-roboboy-panel
 npm install --save-dev \
-  https://github.com/tessel-la/robo-boy/releases/download/panel-sdk-v2.0.0/tessel-la-roboboy-panel-sdk-2.0.0.tgz
+  https://github.com/tessel-la/robo-boy/releases/download/panel-sdk-v2.1.0/tessel-la-roboboy-panel-sdk-2.1.0.tgz
 ```
 
 After building `dist/index.js`, calculate its SRI value and copy the complete `sha256-...` value into the panel

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -46,11 +46,14 @@ Trees are stored in the current browser and can be imported or exported as JSON.
 The lower control area starts empty. Use the `+` button to:
 
 - Clone the built-in dual-joystick and heartbeat template.
+- Clone the built-in physical-gamepad template for an Xbox, PlayStation, or Logitech controller.
 - Create a control pad from an empty grid.
 - Open a control pad saved in this browser.
 - Import a versioned control-pad JSON file.
 
-The editor supports joystick, button, D-pad, toggle, slider, camera, plot, and heartbeat components. Each ROS-aware component can be assigned a topic, message type, field mapping, and component-specific options.
+The editor supports virtual joystick, physical gamepad, button, D-pad, toggle, slider, camera, plot, and heartbeat components. A physical gamepad publishes its complete axes and button state as `sensor_msgs/Joy`; each of its 17 standard buttons can also run an independent topic publish, service call, or action on press and release. The live controller drawing follows both sticks and highlights active buttons. Browsers expose a newly connected controller only after you press one of its buttons.
+
+Choose automatic controller detection for normal use, or force Xbox, PlayStation, or Logitech labels and stick placement. If the controller reports a non-standard browser mapping, Robo-Boy warns you to verify its indices before driving.
 
 Saved pads belong to the current browser profile. Export important layouts before clearing site data.
 

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -31,11 +31,30 @@
 		reverse_proxy {$BACKEND_HOST:host.docker.internal}:{$VIDEO_STREAM_PORT:8080}
 	}
 
-	# MediaMTX WebRTC/WHEP signaling. WebRTC media is negotiated separately
-	# over the gateway's advertised ICE port (UDP 8189 by default).
+	# WHEP signaling for whatever media gateway this deployment runs. Robo-Boy starts none, and the
+	# packaged apps address one directly without passing through here; a browser cannot, because an
+	# HTTPS page may not fetch the gateway's plaintext port.
+	#
+	# The upstream defaults to the optional relay, which needs nothing of the host. Point these at
+	# the gateway instead where the firewall lets this network reach it and the gateway's API
+	# accepts this subnet.
+	#
+	# One read-only resource is exposed. The rest of the control API, which can change
+	# configuration and drop sessions, is not mapped into this namespace at all.
+	handle /webrtc/_discovery/paths {
+		@get method GET
+		handle @get {
+			rewrite * /v3/paths/list
+			reverse_proxy {$WEBRTC_DISCOVERY_UPSTREAM:unix//run/webrtc-relay/api.sock}
+		}
+		respond "Method not allowed" 405
+	}
+
+	# WebRTC media is negotiated separately over the gateway's advertised ICE port (UDP 8189 by
+	# default) and never passes through this proxy.
 	handle /webrtc* {
 		uri strip_prefix /webrtc
-		reverse_proxy unix//run/webrtc-relay/webrtc.sock {
+		reverse_proxy {$WEBRTC_UPSTREAM:unix//run/webrtc-relay/whep.sock} {
 			# MediaMTX returns an origin-relative WHEP session URL. Restore the
 			# public prefix so the panel's DELETE cleanup reaches this handler.
 			header_down Location ^/(.*)$ /webrtc/$1
@@ -97,10 +116,19 @@
 		reverse_proxy {$BACKEND_HOST:host.docker.internal}:{$VIDEO_STREAM_PORT:8080}
 	}
 
-	# Proxy WHEP signaling to the backend media gateway.
+	# WHEP signaling for the deployment's media gateway; see the HTTPS block.
+	handle /webrtc/_discovery/paths {
+		@get method GET
+		handle @get {
+			rewrite * /v3/paths/list
+			reverse_proxy {$WEBRTC_DISCOVERY_UPSTREAM:unix//run/webrtc-relay/api.sock}
+		}
+		respond "Method not allowed" 405
+	}
+
 	handle /webrtc* {
 		uri strip_prefix /webrtc
-		reverse_proxy unix//run/webrtc-relay/webrtc.sock {
+		reverse_proxy {$WEBRTC_UPSTREAM:unix//run/webrtc-relay/whep.sock} {
 			header_down Location ^/(.*)$ /webrtc/$1
 		}
 	}

--- a/infra/caddy/WebRtcRelay.Caddyfile
+++ b/infra/caddy/WebRtcRelay.Caddyfile
@@ -3,24 +3,26 @@
 	auto_https off
 }
 
-# MediaMTX uses host networking so it can expose ICE candidates on physical
-# and VPN interfaces. Bridge the signaling API back to the public proxy over a
-# Unix socket instead of depending on host-gateway firewall behavior.
+# Transport only, to a gateway Robo-Boy does not run. Loopback here means no bridge-to-host firewall
+# rule and no allowlist entry for a Docker subnet is needed on either side; a deployment that has
+# arranged both can leave this out and point the proxy straight at the gateway.
+#
+# Signaling and the control API are carried on separate sockets so that the public proxy's
+# pass-through route cannot reach the control API by asking for it.
 :80 {
-	bind unix//run/webrtc-relay/webrtc.sock|0666
+	bind unix//run/webrtc-relay/whep.sock|0666
+	reverse_proxy {$WEBRTC_BACKEND_URL:http://127.0.0.1:8889}
+}
 
-	# Expose one read-only discovery resource. The rest of MediaMTX's control
-	# API remains loopback-only and is not reachable through Robo-Boy.
-	handle /_discovery/paths {
-		@get method GET
-		handle @get {
-			rewrite * /v3/paths/list
-			reverse_proxy {$WEBRTC_DISCOVERY_BACKEND_URL:http://127.0.0.1:9997}
-		}
-		respond "Method not allowed" 405
+:81 {
+	bind unix//run/webrtc-relay/api.sock|0666
+
+	# Exactly the one resource the proxy maps here, and nothing the control API can otherwise do.
+	handle /v3/paths/list {
+		reverse_proxy {$WEBRTC_DISCOVERY_BACKEND_URL:http://127.0.0.1:9997}
 	}
 
 	handle {
-		reverse_proxy {$WEBRTC_BACKEND_URL:http://127.0.0.1:8889}
+		respond "Not found" 404
 	}
 }

--- a/panel-sdk/README.md
+++ b/panel-sdk/README.md
@@ -8,7 +8,7 @@ export one default `RoboBoyPanelDefinition` from their ESM entry point:
 
 ```sh
 npm install --save-dev \
-  https://github.com/tessel-la/robo-boy/releases/download/panel-sdk-v2.0.0/tessel-la-roboboy-panel-sdk-2.0.0.tgz
+  https://github.com/tessel-la/robo-boy/releases/download/panel-sdk-v2.1.0/tessel-la-roboboy-panel-sdk-2.1.0.tgz
 ```
 
 The SDK is distributed as an npm-compatible tarball attached to the matching versioned GitHub release. It is not
@@ -18,7 +18,10 @@ tarball integrity so replacement bytes fail installation.
 The complete authoring and deployment guide lives in the
 [Robo-Boy repository](https://github.com/tessel-la/robo-boy/blob/main/docs/external-panels.md).
 
-API `2.0.0` is the source contract in the Robo-Boy repository. Panel instances execute in an opaque-origin
+API `2.0.0` is the source contract in the Robo-Boy repository. Package `2.1.0` adds the `webrtcWhep` and
+`webrtcDiscovery` host endpoints, so a panel that wants the stream gateway can ask for it by name instead of
+inferring it from the video server. `videoStream` still reaches the gateway for panels written before those
+existed, so nothing published against `2.0.0` needs changing. Panel instances execute in an opaque-origin
 sandbox and must implement both `mount` and `unmount`. ROS, network, storage, viewport, connection, and theme access
 are host-owned services; raw Robo-Boy objects are not exposed to panel code. Direct HTTP calls are blocked by the
 sandbox CSP, so network access must use the reviewed `context.network` allowlist.

--- a/panel-sdk/index.d.ts
+++ b/panel-sdk/index.d.ts
@@ -15,7 +15,15 @@ export type RoboBoyPanelCapability =
   | 'camera'
   | 'microphone';
 
-export type RoboBoyHostEndpoint = 'videoStream';
+/**
+ * Named host services a panel may ask for.
+ *
+ * `webrtcWhep`, `webrtcDiscovery` and `webrtcHls` are the stream gateway, which is a deployment of
+ * its own and need not be running beside anything else. `webrtcHls` carries the same stream for
+ * webviews that cannot speak WebRTC, and is empty where the gateway is not directly addressable.
+ * `videoStream` also reaches the gateway, for panels written before it had endpoints of its own.
+ */
+export type RoboBoyHostEndpoint = 'videoStream' | 'webrtcWhep' | 'webrtcDiscovery' | 'webrtcHls';
 
 export interface RoboBoyPanelRosPermissions {
   discover?: boolean;
@@ -222,6 +230,8 @@ export interface RoboBoyPanelNetworkResponse {
   };
   text(): Promise<string>;
   json<T extends RoboBoyJsonValue = RoboBoyJsonValue>(): Promise<T>;
+  /** The response as bytes, for media and anything else that is not text. */
+  arrayBuffer(): Promise<ArrayBuffer>;
 }
 
 export interface RoboBoyPanelNetwork {

--- a/panel-sdk/package.json
+++ b/panel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tessel-la/roboboy-panel-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Type-only public API for independently developed Robo-Boy panels",
   "license": "MIT",
   "repository": {

--- a/scripts/install-panels.mjs
+++ b/scripts/install-panels.mjs
@@ -23,7 +23,7 @@ const CAPABILITIES = new Set([
   'camera',
   'microphone',
 ]);
-const HOST_ENDPOINTS = new Set(['videoStream']);
+const HOST_ENDPOINTS = new Set(['videoStream', 'webrtcWhep', 'webrtcDiscovery', 'webrtcHls']);
 const ROS_RESOURCE = /^\/[A-Za-z0-9_~{}*][A-Za-z0-9_~{}/*-]*$/;
 
 export class InstallError extends Error {}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2695,6 +2695,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-http",
+ "webkit2gtk",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,11 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2.11.3", features = [] }
 tauri-plugin-http = "2"
 
+# Reaches the WebKitGTK settings behind the Linux webview. Same crate and version the webview
+# layer already builds, so this adds no second copy of it.
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = { version = "2.0.2", features = ["v2_38"] }
+
 # Mobile bundles pay for the Rust shell byte-for-byte. Keep production artifacts compact while
 # preserving debug profiles for local diagnosis.
 [profile.release]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub fn run() {
     .plugin(tauri_plugin_http::init())
     .setup(|app| {
       configure_ui_zoom(app);
+      configure_webrtc(app);
 
       Ok(())
     })
@@ -76,6 +77,38 @@ fn configure_ui_zoom(app: &tauri::App) {
 
 #[cfg(mobile)]
 fn configure_ui_zoom(_app: &tauri::App) {}
+
+/// Linux only. WebKitGTK compiles the WebRTC bindings in but leaves the setting off, so the webview
+/// defines no RTCPeerConnection at all and a panel streaming over WHEP fails on the reference
+/// rather than on the connection. Every other platform's webview exposes it already.
+///
+/// Turning it on is necessary but not sufficient: the engine negotiates through GStreamer, so a
+/// host also needs the WebRTC elements installed (gstreamer1.0-plugins-bad and gstreamer1.0-nice on
+/// Debian and Ubuntu). Without them the setting applies and the API stays undefined.
+#[cfg(target_os = "linux")]
+fn configure_webrtc(app: &tauri::App) {
+  use tauri::Manager;
+
+  let Some(webview_window) = app.get_webview_window("main") else {
+    return;
+  };
+
+  let result = webview_window.with_webview(|webview| {
+    use webkit2gtk::{SettingsExt, WebViewExt};
+
+    match webview.inner().settings() {
+      Some(settings) => settings.set_enable_webrtc(true),
+      None => eprintln!("[Robo-Boy] webview exposed no settings; WebRTC stays disabled"),
+    }
+  });
+
+  if let Err(error) = result {
+    eprintln!("[Robo-Boy] failed to enable WebRTC in the webview: {error}");
+  }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_webrtc(_app: &tauri::App) {}
 
 #[cfg(target_os = "linux")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/components/MainControlView.tsx
+++ b/src/components/MainControlView.tsx
@@ -1013,6 +1013,9 @@ const MainControlView: React.FC<MainControlViewProps> = ({ connectionParams, onD
       target: runtimeEndpoints.mode,
       endpoints: {
         videoStream: runtimeEndpoints.videoStreamBaseUrl,
+        webrtcWhep: runtimeEndpoints.webrtcWhepBaseUrl,
+        webrtcDiscovery: runtimeEndpoints.webrtcDiscoveryUrl,
+        webrtcHls: runtimeEndpoints.webrtcHlsBaseUrl,
       },
     }),
     [runtimeEndpoints]

--- a/src/features/customGamepad/components/ComponentPalette.test.tsx
+++ b/src/features/customGamepad/components/ComponentPalette.test.tsx
@@ -12,6 +12,7 @@ vi.mock('./SliderComponent', () => ({ default: () => <span /> }));
 vi.mock('./CameraComponent', () => ({ default: () => <span /> }));
 vi.mock('./PlotComponent', () => ({ default: () => <span /> }));
 vi.mock('./HeartbeatComponent', () => ({ default: () => <span /> }));
+vi.mock('./PhysicalGamepadComponent', () => ({ default: () => <span /> }));
 
 describe('ComponentPalette touch gestures', () => {
   afterEach(() => vi.useRealTimers());

--- a/src/features/customGamepad/components/ComponentPalette.tsx
+++ b/src/features/customGamepad/components/ComponentPalette.tsx
@@ -9,6 +9,7 @@ import SliderComponent from './SliderComponent';
 import CameraComponent from './CameraComponent';
 import PlotComponent from './PlotComponent';
 import HeartbeatComponent from './HeartbeatComponent';
+import PhysicalGamepadComponent from './PhysicalGamepadComponent';
 import './ComponentPalette.css';
 
 interface ComponentPaletteProps {
@@ -80,7 +81,9 @@ const ComponentPalette: React.FC<ComponentPaletteProps> = ({
             ? { fieldPath: 'data', fieldPaths: ['data'], timeWindowSec: 10, autoScale: true }
             : componentType === 'heartbeat'
               ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
-            : {}
+              : componentType === 'physical-gamepad'
+                ? { physicalGamepadProfile: 'xbox' as const, physicalGamepadDeadzone: 0.08 }
+                : {}
     };
 
     const previewStyle: React.CSSProperties = {
@@ -112,6 +115,7 @@ const ComponentPalette: React.FC<ComponentPaletteProps> = ({
       <div style={containerStyle}>
         {componentType === 'button' && <ButtonComponent {...componentProps} />}
         {componentType === 'joystick' && <JoystickComponent {...componentProps} />}
+        {componentType === 'physical-gamepad' && <PhysicalGamepadComponent {...componentProps} />}
         {componentType === 'dpad' && <DPadComponent {...componentProps} />}
         {componentType === 'toggle' && <ToggleComponent {...componentProps} />}
         {componentType === 'slider' && <SliderComponent {...componentProps} />}

--- a/src/features/customGamepad/components/ComponentPalette.tsx
+++ b/src/features/customGamepad/components/ComponentPalette.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { componentLibrary } from '../defaultLayouts';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ } from '../physicalGamepad';
 import { GamepadComponentConfig } from '../types';
 import ButtonComponent from './ButtonComponent';
 import JoystickComponent from './JoystickComponent';
@@ -82,7 +83,11 @@ const ComponentPalette: React.FC<ComponentPaletteProps> = ({
             : componentType === 'heartbeat'
               ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
               : componentType === 'physical-gamepad'
-                ? { physicalGamepadProfile: 'xbox' as const, physicalGamepadDeadzone: 0.08 }
+                ? {
+                  physicalGamepadProfile: 'xbox' as const,
+                  physicalGamepadDeadzone: 0.08,
+                  physicalGamepadPublishHz: DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+                }
                 : {}
     };
 

--- a/src/features/customGamepad/components/ComponentSettingsModal.css
+++ b/src/features/customGamepad/components/ComponentSettingsModal.css
@@ -28,6 +28,57 @@
   font-family: inherit;
 }
 
+.physical-gamepad-settings .settings-help {
+  margin: -4px 0 12px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.physical-binding-count {
+  color: var(--text-secondary);
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.physical-control-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(82px, 1fr));
+  gap: 7px;
+  margin-bottom: 14px;
+}
+
+.physical-control-picker button {
+  min-height: 36px;
+  padding: 6px 8px;
+  color: var(--text-color);
+  background: var(--background-secondary);
+  border-color: var(--border-color);
+  font-size: 0.78rem;
+}
+
+.physical-control-picker button.configured {
+  border-color: var(--primary-color);
+}
+
+.physical-control-picker button.configured::after {
+  content: ' •';
+  color: var(--primary-color);
+}
+
+.physical-control-picker button.selected {
+  color: var(--button-text-color);
+  background: var(--primary-color);
+  border-color: var(--primary-hover-color);
+}
+
+.physical-control-binding {
+  min-width: 0;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
 /* Modal Header */
 .modal-header {
   display: flex;

--- a/src/features/customGamepad/components/ComponentSettingsModal.css
+++ b/src/features/customGamepad/components/ComponentSettingsModal.css
@@ -571,7 +571,7 @@
 /* Responsive Design */
 @media (max-width: 768px) {
   .component-settings-modal-overlay {
-    padding: 10px;
+    padding: calc(8px + var(--safe-area-top)) 8px calc(8px + var(--safe-area-bottom));
   }
 
   .enhanced-component-settings-modal {
@@ -608,6 +608,27 @@
   .cancel-btn,
   .save-btn {
     width: 100%;
+  }
+
+  .physical-gamepad-settings input:not([type="range"]),
+  .physical-gamepad-settings select,
+  .physical-gamepad-settings textarea {
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .physical-gamepad-settings input[type="range"] {
+    min-height: 44px;
+  }
+
+  .physical-control-picker {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .physical-control-picker button {
+    min-height: 44px;
+    touch-action: manipulation;
   }
 }
 

--- a/src/features/customGamepad/components/ComponentSettingsModal.tsx
+++ b/src/features/customGamepad/components/ComponentSettingsModal.tsx
@@ -10,6 +10,7 @@ import {
 import type { RosOperation } from '../../../utils/rosOperations';
 import RosEventOperationsEditor from './RosEventOperationsEditor';
 import PhysicalGamepadSettings from './PhysicalGamepadSettings';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ, normalizePhysicalGamepadPublishHz } from '../physicalGamepad';
 import RangeSlider from './RangeSlider';
 import ValueControl from './ValueControl';
 import { getDynamicRangeStep, roundToStepPrecision } from '../rangeUtils';
@@ -251,6 +252,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
   const [physicalGamepadProfile, setPhysicalGamepadProfile] = useState<PhysicalGamepadProfile>('auto');
   const [physicalGamepadIndex, setPhysicalGamepadIndex] = useState<number | undefined>();
   const [physicalGamepadDeadzone, setPhysicalGamepadDeadzone] = useState(0.08);
+  const [physicalGamepadPublishHz, setPhysicalGamepadPublishHz] = useState(DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ);
   const [physicalGamepadBindings, setPhysicalGamepadBindings] = useState<Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>>({});
 
   // Camera-specific settings
@@ -434,6 +436,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       setPhysicalGamepadProfile('auto');
       setPhysicalGamepadIndex(undefined);
       setPhysicalGamepadDeadzone(0.08);
+      setPhysicalGamepadPublishHz(DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ);
       setPhysicalGamepadBindings({});
       setHeartbeatMode('boolean');
       setHeartbeatTimeoutMs(2000);
@@ -530,6 +533,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
           setPhysicalGamepadProfile(component.config.physicalGamepadProfile || 'auto');
           setPhysicalGamepadIndex(component.config.physicalGamepadIndex);
           setPhysicalGamepadDeadzone(component.config.physicalGamepadDeadzone ?? 0.08);
+          setPhysicalGamepadPublishHz(normalizePhysicalGamepadPublishHz(component.config.physicalGamepadPublishHz));
           setPhysicalGamepadBindings(component.config.physicalGamepadBindings || {});
         } else if (component.type === 'button') {
           setButtonIndex(component.config.buttonIndex ?? 0);
@@ -778,6 +782,7 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
         physicalGamepadProfile,
         physicalGamepadIndex,
         physicalGamepadDeadzone: Math.max(0, Math.min(0.5, physicalGamepadDeadzone)),
+        physicalGamepadPublishHz: normalizePhysicalGamepadPublishHz(physicalGamepadPublishHz),
         physicalGamepadBindings,
       };
     } else if (component.type === 'button') {
@@ -939,11 +944,13 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
                 profile={physicalGamepadProfile}
                 preferredIndex={physicalGamepadIndex}
                 deadzone={physicalGamepadDeadzone}
+                publishHz={physicalGamepadPublishHz}
                 bindings={physicalGamepadBindings}
                 ros={ros || null}
                 onProfileChange={setPhysicalGamepadProfile}
                 onPreferredIndexChange={setPhysicalGamepadIndex}
                 onDeadzoneChange={setPhysicalGamepadDeadzone}
+                onPublishHzChange={setPhysicalGamepadPublishHz}
                 onBindingsChange={setPhysicalGamepadBindings}
               />
             </div>

--- a/src/features/customGamepad/components/ComponentSettingsModal.tsx
+++ b/src/features/customGamepad/components/ComponentSettingsModal.tsx
@@ -1,8 +1,15 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import type { Ros } from 'roslib';
-import { GamepadComponentConfig, ROSTopicConfig } from '../types';
+import {
+  GamepadComponentConfig,
+  PhysicalGamepadBinding,
+  PhysicalGamepadControlId,
+  PhysicalGamepadProfile,
+  ROSTopicConfig,
+} from '../types';
 import type { RosOperation } from '../../../utils/rosOperations';
 import RosEventOperationsEditor from './RosEventOperationsEditor';
+import PhysicalGamepadSettings from './PhysicalGamepadSettings';
 import RangeSlider from './RangeSlider';
 import ValueControl from './ValueControl';
 import { getDynamicRangeStep, roundToStepPrecision } from '../rangeUtils';
@@ -137,6 +144,7 @@ const getMessageTypeConfig = (type: string) => {
 // Define allowed message types for each component type
 const COMPONENT_MESSAGE_TYPES: Record<string, string[]> = {
   'joystick': ['sensor_msgs/Joy', 'geometry_msgs/Twist', 'geometry_msgs/TwistStamped', 'geometry_msgs/PoseStamped', 'std_msgs/Float32', 'std_msgs/Float64', 'std_msgs/Int32'],
+  'physical-gamepad': ['sensor_msgs/Joy', 'sensor_msgs/msg/Joy'],
   'button': ['std_msgs/Bool', 'std_msgs/Int32', 'geometry_msgs/Twist', 'geometry_msgs/TwistStamped'],
   'dpad': ['sensor_msgs/Joy', 'geometry_msgs/PoseStamped'],
   'toggle': ['std_msgs/Bool'], // Toggle only supports Boolean
@@ -238,6 +246,12 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
   const [buttonIndex, setButtonIndex] = useState(0);
   const [momentary, setMomentary] = useState(true);
   const [eventOperations, setEventOperations] = useState<Partial<Record<'press' | 'release' | 'on' | 'off', RosOperation>>>({});
+
+  // Physical gamepad-specific settings
+  const [physicalGamepadProfile, setPhysicalGamepadProfile] = useState<PhysicalGamepadProfile>('auto');
+  const [physicalGamepadIndex, setPhysicalGamepadIndex] = useState<number | undefined>();
+  const [physicalGamepadDeadzone, setPhysicalGamepadDeadzone] = useState(0.08);
+  const [physicalGamepadBindings, setPhysicalGamepadBindings] = useState<Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>>({});
 
   // Camera-specific settings
   const [cameraTransport, setCameraTransport] = useState<'proxy' | 'ros'>('proxy');
@@ -354,6 +368,11 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
           defaultMessageType = 'sensor_msgs/Joy';
           defaultField = 'axes';
           break;
+        case 'physical-gamepad':
+          defaultTopic = '/joy';
+          defaultMessageType = 'sensor_msgs/msg/Joy';
+          defaultField = 'axes';
+          break;
         case 'camera':
           defaultTopic = '/camera/image_raw/compressed';
           defaultMessageType = 'sensor_msgs/CompressedImage';
@@ -412,6 +431,10 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       setDpadButtonMapping({ up: 0, right: 1, down: 2, left: 3 });
       setButtonIndex(0);
       setMomentary(true);
+      setPhysicalGamepadProfile('auto');
+      setPhysicalGamepadIndex(undefined);
+      setPhysicalGamepadDeadzone(0.08);
+      setPhysicalGamepadBindings({});
       setHeartbeatMode('boolean');
       setHeartbeatTimeoutMs(2000);
       setHeartbeatFieldPath(action?.field || 'data');
@@ -503,6 +526,11 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
           setPoseStampedOdometryTopic(component.config.poseStampedOdometryTopic || '/odom');
           setPoseStampedOdometryMessageType(component.config.poseStampedOdometryMessageType || 'nav_msgs/Odometry');
           setPoseStampedUseOdometryOrientation(component.config.poseStampedUseOdometryOrientation !== false);
+        } else if (component.type === 'physical-gamepad') {
+          setPhysicalGamepadProfile(component.config.physicalGamepadProfile || 'auto');
+          setPhysicalGamepadIndex(component.config.physicalGamepadIndex);
+          setPhysicalGamepadDeadzone(component.config.physicalGamepadDeadzone ?? 0.08);
+          setPhysicalGamepadBindings(component.config.physicalGamepadBindings || {});
         } else if (component.type === 'button') {
           setButtonIndex(component.config.buttonIndex ?? 0);
           setMomentary(component.config.momentary ?? true);
@@ -644,6 +672,17 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       }
     }
 
+    if (component.type === 'physical-gamepad') {
+      if (!['sensor_msgs/Joy', 'sensor_msgs/msg/Joy'].includes(messageType)) {
+        setErrorMessage('Physical gamepads publish sensor_msgs/Joy messages.');
+        return;
+      }
+      if (field !== 'axes') {
+        setErrorMessage('Physical gamepads publish complete Joy axes and buttons.');
+        return;
+      }
+    }
+
     if (component.type === 'camera' && !CAMERA_MESSAGE_TYPES.includes(messageType)) {
       setErrorMessage('Camera components can only use Image or CompressedImage message types.');
       return;
@@ -733,6 +772,14 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
       };
       // Remove legacy maxValue if it exists
       delete updatedConfig.maxValue;
+    } else if (component.type === 'physical-gamepad') {
+      updatedConfig = {
+        ...updatedConfig,
+        physicalGamepadProfile,
+        physicalGamepadIndex,
+        physicalGamepadDeadzone: Math.max(0, Math.min(0.5, physicalGamepadDeadzone)),
+        physicalGamepadBindings,
+      };
     } else if (component.type === 'button') {
       updatedConfig = {
         ...updatedConfig,
@@ -883,6 +930,22 @@ const ComponentSettingsModal: React.FC<ComponentSettingsModalProps> = ({
                   onChange={setEventOperations}
                 />
               </div>
+            </div>
+          )}
+
+          {component.type === 'physical-gamepad' && (
+            <div className="settings-section">
+              <PhysicalGamepadSettings
+                profile={physicalGamepadProfile}
+                preferredIndex={physicalGamepadIndex}
+                deadzone={physicalGamepadDeadzone}
+                bindings={physicalGamepadBindings}
+                ros={ros || null}
+                onProfileChange={setPhysicalGamepadProfile}
+                onPreferredIndexChange={setPhysicalGamepadIndex}
+                onDeadzoneChange={setPhysicalGamepadDeadzone}
+                onBindingsChange={setPhysicalGamepadBindings}
+              />
             </div>
           )}
 

--- a/src/features/customGamepad/components/GamepadComponent.tsx
+++ b/src/features/customGamepad/components/GamepadComponent.tsx
@@ -9,6 +9,7 @@ import SliderComponent from './SliderComponent';
 import CameraComponent from './CameraComponent';
 import PlotComponent from './PlotComponent';
 import HeartbeatComponent from './HeartbeatComponent';
+import PhysicalGamepadComponent from './PhysicalGamepadComponent';
 import './GamepadComponent.css';
 
 interface GamepadComponentProps {
@@ -361,6 +362,8 @@ const GamepadComponent: React.FC<GamepadComponentProps> = ({
             onTwistAxesChange={onTwistAxesChange}
           />
         );
+      case 'physical-gamepad':
+        return <PhysicalGamepadComponent {...commonProps} />;
       case 'button':
         return <ButtonComponent {...commonProps} />;
       case 'dpad':

--- a/src/features/customGamepad/components/GamepadEditor.tsx
+++ b/src/features/customGamepad/components/GamepadEditor.tsx
@@ -7,6 +7,7 @@ import {
   EditorState
 } from '../types';
 import { componentLibrary } from '../defaultLayouts';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ } from '../physicalGamepad';
 import { generateGamepadId, saveCustomGamepad } from '../gamepadStorage';
 import LayoutRenderer from './CustomGamepadLayout';
 import ComponentPalette from './ComponentPalette';
@@ -146,7 +147,11 @@ const GamepadEditor: React.FC<GamepadEditorProps> = ({
           : componentType === 'heartbeat'
             ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
             : componentType === 'physical-gamepad'
-              ? { physicalGamepadProfile: 'auto' as const, physicalGamepadDeadzone: 0.08 }
+              ? {
+                physicalGamepadProfile: 'auto' as const,
+                physicalGamepadDeadzone: 0.08,
+                physicalGamepadPublishHz: DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+              }
               : componentType === 'dpad'
                 ? { buttonMapping: { up: 0, right: 1, down: 2, left: 3 } }
                 : componentType === 'joystick'

--- a/src/features/customGamepad/components/GamepadEditor.tsx
+++ b/src/features/customGamepad/components/GamepadEditor.tsx
@@ -110,6 +110,9 @@ const GamepadEditor: React.FC<GamepadEditorProps> = ({
       case 'joystick':
         action = { topic: '/joystick', messageType: 'sensor_msgs/Joy', field: 'axes' };
         break;
+      case 'physical-gamepad':
+        action = { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' };
+        break;
       case 'dpad':
         action = { topic: '/dpad', messageType: 'sensor_msgs/Joy', field: 'buttons' };
         break;
@@ -142,11 +145,13 @@ const GamepadEditor: React.FC<GamepadEditorProps> = ({
           ? { fieldPath: 'data', fieldPaths: ['data'], timeWindowSec: 10, autoScale: true, minY: -1, maxY: 1 }
           : componentType === 'heartbeat'
             ? { heartbeatMode: 'boolean' as const, heartbeatTimeoutMs: 2000, heartbeatFieldPath: 'data' }
-          : componentType === 'dpad'
-            ? { buttonMapping: { up: 0, right: 1, down: 2, left: 3 } }
-            : componentType === 'joystick'
-              ? { min: -1, max: 1, sliderMin: -1, sliderMax: 1, axes: ['0', '1'] }
-              : undefined;
+            : componentType === 'physical-gamepad'
+              ? { physicalGamepadProfile: 'auto' as const, physicalGamepadDeadzone: 0.08 }
+              : componentType === 'dpad'
+                ? { buttonMapping: { up: 0, right: 1, down: 2, left: 3 } }
+                : componentType === 'joystick'
+                  ? { min: -1, max: 1, sliderMin: -1, sliderMax: 1, axes: ['0', '1'] }
+                  : undefined;
 
     const newComponent: GamepadComponentConfig = {
       id: `${componentType}-${Date.now()}`,

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.css
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.css
@@ -1,0 +1,118 @@
+.physical-gamepad {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  color: var(--text-color);
+  background: radial-gradient(circle at 50% 40%, var(--background-secondary), var(--card-bg));
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.physical-gamepad-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 18px;
+  padding: 4px 8px 0;
+  color: var(--text-secondary);
+  font-size: clamp(8px, 2.4cqw, 12px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.physical-gamepad-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--secondary-color);
+}
+
+.physical-gamepad-dot.connected {
+  background: var(--primary-color);
+  box-shadow: 0 0 8px var(--primary-color-glow);
+}
+
+.physical-gamepad svg {
+  display: block;
+  width: 100%;
+  height: calc(100% - 22px);
+  min-height: 0;
+}
+
+.physical-gamepad-body {
+  fill: var(--background-secondary);
+  stroke: var(--border-color-light);
+  stroke-width: 4;
+  filter: drop-shadow(0 8px 8px var(--background-dark-transparent));
+}
+
+.physical-control circle,
+.physical-control rect,
+.physical-control path,
+.physical-control:is(circle, rect, path),
+.physical-dpad rect {
+  fill: var(--card-bg);
+  stroke: var(--border-color-light);
+  stroke-width: 2;
+  transition:
+    fill 70ms ease,
+    filter 70ms ease,
+    transform 70ms ease;
+}
+
+.physical-control text {
+  fill: var(--text-color);
+  font-family: var(--font-family-ui);
+  font-size: 10px;
+  font-weight: 700;
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+.physical-control.is-active circle,
+.physical-control.is-active rect,
+.physical-control.is-active path,
+.physical-control.is-active:is(circle, rect, path),
+.physical-control.is-active .stick-knob {
+  fill: var(--primary-color);
+  stroke: var(--primary-hover-color);
+  filter: drop-shadow(0 0 6px var(--primary-color-glow));
+}
+
+.physical-control.is-active text {
+  fill: var(--button-text-color);
+}
+
+.physical-control .stick-well {
+  fill: var(--background-color);
+}
+
+.physical-control .stick-knob {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.physical-gamepad-warning {
+  padding: 0 8px 5px;
+  color: var(--error-color);
+  font-size: 9px;
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .physical-control circle,
+  .physical-control rect,
+  .physical-control path {
+    transition: none;
+  }
+}

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.css
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.css
@@ -1,4 +1,5 @@
 .physical-gamepad {
+  container-type: inline-size;
   width: 100%;
   height: 100%;
   min-width: 0;
@@ -23,7 +24,8 @@
   min-height: 18px;
   padding: 4px 8px 0;
   color: var(--text-secondary);
-  font-size: clamp(8px, 2.4cqw, 12px);
+  font-size: 10px;
+  font-size: clamp(9px, 2.4cqw, 12px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -107,6 +109,23 @@
   color: var(--error-color);
   font-size: 9px;
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  .physical-gamepad {
+    border-radius: 9px;
+  }
+
+  .physical-gamepad-status {
+    min-height: 22px;
+    padding: 5px 7px 0;
+    font-size: 10px;
+  }
+
+  .physical-gamepad-warning {
+    padding: 0 7px 6px;
+    font-size: 10px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
@@ -144,6 +144,33 @@ describe('PhysicalGamepadComponent', () => {
     expect(mocks.unadvertise).toHaveBeenCalledOnce();
   });
 
+  it('publishes neutral input when a phone or browser suspends the page', () => {
+    render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+    runFrame(100);
+    mocks.publish.mockClear();
+
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+
+    expect(mocks.publish).toHaveBeenCalledOnce();
+    expect(mocks.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        axes: [0, 0, 0, 0],
+        buttons: Array(17).fill(0),
+      })
+    );
+  });
+
+  it('explains when a mobile WebView does not expose controller input', () => {
+    Reflect.deleteProperty(navigator, 'getGamepads');
+
+    render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Controller input unavailable on this device');
+    expect(screen.getByText('This browser or app WebView does not expose the Gamepad API.')).toBeInTheDocument();
+    expect(frames).toHaveLength(0);
+  });
+
   it('publishes Joy at the configured rate while keeping button edges immediate', async () => {
     const tenHzConfig: GamepadComponentConfig = {
       ...config,

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GamepadComponentConfig } from '../types';
+import PhysicalGamepadComponent from './PhysicalGamepadComponent';
+
+const mocks = vi.hoisted(() => ({
+  advertise: vi.fn(),
+  publish: vi.fn(),
+  unadvertise: vi.fn(),
+  execute: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('roslib', () => ({
+  default: {
+    Topic: vi.fn(function () {
+      return { advertise: mocks.advertise, publish: mocks.publish, unadvertise: mocks.unadvertise };
+    }),
+    Message: vi.fn(function (value) {
+      return value;
+    }),
+  },
+}));
+
+vi.mock('../../../utils/rosOperations', () => ({ executeRosOperation: mocks.execute }));
+
+const makeGamepad = (pressedIndex?: number, connected = true): Gamepad =>
+  ({
+    axes: [0.5, -0.5, 0.25, -0.25],
+    buttons: Array.from({ length: 17 }, (_, index) => ({
+      pressed: index === pressedIndex,
+      touched: index === pressedIndex,
+      value: index === pressedIndex ? 1 : 0,
+    })),
+    connected,
+    hapticActuators: [],
+    id: 'Sony DualSense Wireless Controller',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 1,
+    vibrationActuator: null,
+  }) as unknown as Gamepad;
+
+const config: GamepadComponentConfig = {
+  id: 'physical',
+  type: 'physical-gamepad',
+  position: { x: 0, y: 0, width: 6, height: 4 },
+  action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
+  config: {
+    physicalGamepadProfile: 'auto',
+    physicalGamepadDeadzone: 0.08,
+    physicalGamepadBindings: {
+      'face-bottom': {
+        press: { kind: 'service', name: '/start', messageType: 'std_srvs/srv/Trigger' },
+        release: { kind: 'topic', name: '/released', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
+      },
+    },
+  },
+};
+
+describe('PhysicalGamepadComponent', () => {
+  let gamepads: Array<Gamepad | null>;
+  let frames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    gamepads = [makeGamepad()];
+    frames = [];
+    mocks.advertise.mockReset();
+    mocks.publish.mockReset();
+    mocks.unadvertise.mockReset();
+    mocks.execute.mockReset().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'getGamepads', {
+      configurable: true,
+      value: vi.fn(() => gamepads as (Gamepad | null)[]),
+    });
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(navigator, 'getGamepads');
+  });
+
+  const runFrame = (time: number) =>
+    act(() => {
+      const frame = frames.shift();
+      if (!frame) throw new Error('No animation frame queued');
+      frame(time);
+    });
+
+  it('renders live PlayStation controls, publishes Joy, and dispatches button edges', async () => {
+    render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+    expect(mocks.advertise).toHaveBeenCalledOnce();
+
+    runFrame(100);
+    expect(await screen.findByText(/Sony DualSense Wireless Controller/)).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'playstation gamepad visualization' })).toBeInTheDocument();
+    expect(mocks.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        axes: expect.arrayContaining([expect.closeTo(0.4565, 3), expect.closeTo(-0.4565, 3)]),
+        buttons: expect.arrayContaining([0]),
+      })
+    );
+
+    gamepads = [makeGamepad(0)];
+    runFrame(116);
+    await waitFor(() =>
+      expect(mocks.execute).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ kind: 'service', name: '/start' }),
+        expect.any(AbortSignal)
+      )
+    );
+
+    gamepads = [makeGamepad()];
+    runFrame(132);
+    await waitFor(() =>
+      expect(mocks.execute).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ kind: 'topic', name: '/released' }),
+        expect.any(AbortSignal)
+      )
+    );
+  });
+
+  it('publishes a neutral message when the controller disconnects and cleans up the publisher', () => {
+    const { unmount } = render(<PhysicalGamepadComponent config={config} ros={{} as any} />);
+    runFrame(100);
+    gamepads = [];
+    runFrame(116);
+
+    expect(mocks.publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        axes: [0, 0, 0, 0],
+        buttons: Array(17).fill(0),
+      })
+    );
+    unmount();
+    expect(mocks.unadvertise).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.test.tsx
@@ -143,4 +143,25 @@ describe('PhysicalGamepadComponent', () => {
     unmount();
     expect(mocks.unadvertise).toHaveBeenCalledOnce();
   });
+
+  it('publishes Joy at the configured rate while keeping button edges immediate', async () => {
+    const tenHzConfig: GamepadComponentConfig = {
+      ...config,
+      config: { ...config.config, physicalGamepadPublishHz: 10 },
+    };
+    render(<PhysicalGamepadComponent config={tenHzConfig} ros={{} as any} />);
+
+    runFrame(100);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+
+    gamepads = [makeGamepad(0)];
+    runFrame(116);
+    await waitFor(() => expect(mocks.execute).toHaveBeenCalledOnce());
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+
+    runFrame(199);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    runFrame(200);
+    expect(mocks.publish).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
@@ -37,6 +37,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
   const profile = detectPhysicalGamepadProfile(config.config?.physicalGamepadProfile, connection?.id);
   const action = config.action as ROSTopicConfig | undefined;
   const bindings = config.config?.physicalGamepadBindings;
+  const gamepadApiSupported = typeof navigator !== 'undefined' && typeof navigator.getGamepads === 'function';
   const publishIntervalMs = 1000 / normalizePhysicalGamepadPublishHz(config.config?.physicalGamepadPublishHz);
 
   const publishJoy = useCallback(
@@ -83,7 +84,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
   }, [action?.messageType, action?.topic, isEditing, publishJoy, ros]);
 
   useEffect(() => {
-    if (isEditing || typeof navigator.getGamepads !== 'function') return;
+    if (isEditing || !gamepadApiSupported) return;
     let frameId = 0;
     let stopped = false;
 
@@ -96,6 +97,10 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
       connectionKeyRef.current = '';
       setSnapshot(EMPTY_GAMEPAD_SNAPSHOT);
       setConnection(null);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') disconnect();
     };
 
     const poll = (now: number) => {
@@ -136,15 +141,20 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
       frameId = requestAnimationFrame(poll);
     };
 
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', disconnect);
     frameId = requestAnimationFrame(poll);
     return () => {
       stopped = true;
       cancelAnimationFrame(frameId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', disconnect);
       disconnect();
     };
   }, [
     config.config?.physicalGamepadDeadzone,
     config.config?.physicalGamepadIndex,
+    gamepadApiSupported,
     isEditing,
     publishIntervalMs,
     publishJoy,
@@ -179,9 +189,11 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
         <span className={`physical-gamepad-dot ${connection ? 'connected' : ''}`} />
         {isEditing
           ? `${profile} preview`
-          : connection
-            ? `#${connection.index} ${connection.id}`
-            : 'Press a controller button to connect'}
+          : !gamepadApiSupported
+            ? 'Controller input unavailable on this device'
+            : connection
+              ? `#${connection.index} ${connection.id}`
+              : 'Press a controller button to connect'}
       </div>
       <svg viewBox="0 0 400 250" role="img" aria-label={`${profile} gamepad visualization`}>
         <path
@@ -282,6 +294,11 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
       {connection && connection.mapping !== 'standard' && (
         <small className="physical-gamepad-warning">
           Non-standard browser mapping; verify control indices before driving.
+        </small>
+      )}
+      {!isEditing && !gamepadApiSupported && (
+        <small className="physical-gamepad-warning">
+          This browser or app WebView does not expose the Gamepad API.
         </small>
       )}
       {operationError && (

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
@@ -8,6 +8,7 @@ import {
   EMPTY_GAMEPAD_SNAPSHOT,
   findPhysicalGamepad,
   getPhysicalGamepadControlLabel,
+  normalizePhysicalGamepadPublishHz,
   PHYSICAL_GAMEPAD_CONTROLS,
   physicalGamepadSnapshotKey,
   snapshotPhysicalGamepad,
@@ -20,8 +21,6 @@ interface Props {
   ros: Ros;
   isEditing?: boolean;
 }
-
-const JOY_PUBLISH_INTERVAL_MS = 50;
 
 const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = false }) => {
   const [snapshot, setSnapshot] = useState<PhysicalGamepadSnapshot>(EMPTY_GAMEPAD_SNAPSHOT);
@@ -38,6 +37,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
   const profile = detectPhysicalGamepadProfile(config.config?.physicalGamepadProfile, connection?.id);
   const action = config.action as ROSTopicConfig | undefined;
   const bindings = config.config?.physicalGamepadBindings;
+  const publishIntervalMs = 1000 / normalizePhysicalGamepadPublishHz(config.config?.physicalGamepadPublishHz);
 
   const publishJoy = useCallback(
     (next: PhysicalGamepadSnapshot) => {
@@ -129,7 +129,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
         snapshotKeyRef.current = nextKey;
         setSnapshot(next);
       }
-      if (changed || justConnected || now - lastPublishedAtRef.current >= JOY_PUBLISH_INTERVAL_MS) {
+      if (justConnected || now - lastPublishedAtRef.current >= publishIntervalMs) {
         publishJoy(next);
         lastPublishedAtRef.current = now;
       }
@@ -146,6 +146,7 @@ const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = fa
     config.config?.physicalGamepadDeadzone,
     config.config?.physicalGamepadIndex,
     isEditing,
+    publishIntervalMs,
     publishJoy,
     runOperation,
   ]);

--- a/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadComponent.tsx
@@ -1,0 +1,295 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ROSLIB from 'roslib';
+import type { Ros, Topic } from 'roslib';
+import { executeRosOperation } from '../../../utils/rosOperations';
+import type { GamepadComponentConfig, PhysicalGamepadControlId, ROSTopicConfig } from '../types';
+import {
+  detectPhysicalGamepadProfile,
+  EMPTY_GAMEPAD_SNAPSHOT,
+  findPhysicalGamepad,
+  getPhysicalGamepadControlLabel,
+  PHYSICAL_GAMEPAD_CONTROLS,
+  physicalGamepadSnapshotKey,
+  snapshotPhysicalGamepad,
+  type PhysicalGamepadSnapshot,
+} from '../physicalGamepad';
+import './PhysicalGamepadComponent.css';
+
+interface Props {
+  config: GamepadComponentConfig;
+  ros: Ros;
+  isEditing?: boolean;
+}
+
+const JOY_PUBLISH_INTERVAL_MS = 50;
+
+const PhysicalGamepadComponent: React.FC<Props> = ({ config, ros, isEditing = false }) => {
+  const [snapshot, setSnapshot] = useState<PhysicalGamepadSnapshot>(EMPTY_GAMEPAD_SNAPSHOT);
+  const [connection, setConnection] = useState<{ id: string; index: number; mapping: string } | null>(null);
+  const [operationError, setOperationError] = useState('');
+  const topicRef = useRef<Topic | null>(null);
+  const connectedRef = useRef(false);
+  const connectionKeyRef = useRef('');
+  const previousPressedRef = useRef<boolean[]>(Array(17).fill(false));
+  const snapshotKeyRef = useRef('');
+  const lastPublishedAtRef = useRef(0);
+  const operationControllersRef = useRef(new Map<string, AbortController>());
+
+  const profile = detectPhysicalGamepadProfile(config.config?.physicalGamepadProfile, connection?.id);
+  const action = config.action as ROSTopicConfig | undefined;
+  const bindings = config.config?.physicalGamepadBindings;
+
+  const publishJoy = useCallback(
+    (next: PhysicalGamepadSnapshot) => {
+      if (!topicRef.current || isEditing) return;
+      topicRef.current.publish(
+        new ROSLIB.Message({
+          header: { stamp: { secs: 0, nsecs: 0 }, frame_id: '' },
+          axes: next.axes,
+          buttons: next.buttons.map(value => (value > 0.5 ? 1 : 0)),
+        })
+      );
+    },
+    [isEditing]
+  );
+
+  const runOperation = useCallback(
+    (controlId: PhysicalGamepadControlId, event: 'press' | 'release') => {
+      const operation = bindings?.[controlId]?.[event];
+      const key = `${controlId}:${event}`;
+      if (!operation || isEditing || operationControllersRef.current.has(key)) return;
+      const controller = new AbortController();
+      operationControllersRef.current.set(key, controller);
+      void executeRosOperation(ros, operation, controller.signal)
+        .then(() => setOperationError(''))
+        .catch(() => {
+          if (!controller.signal.aborted) setOperationError(`${controlId} ${event} operation failed`);
+        })
+        .finally(() => operationControllersRef.current.delete(key));
+    },
+    [bindings, isEditing, ros]
+  );
+
+  useEffect(() => {
+    if (isEditing || !action?.topic || !action.messageType) return;
+    const topic = new ROSLIB.Topic({ ros, name: action.topic, messageType: action.messageType });
+    topic.advertise();
+    topicRef.current = topic;
+    return () => {
+      if (connectedRef.current) publishJoy(EMPTY_GAMEPAD_SNAPSHOT);
+      topic.unadvertise();
+      if (topicRef.current === topic) topicRef.current = null;
+    };
+  }, [action?.messageType, action?.topic, isEditing, publishJoy, ros]);
+
+  useEffect(() => {
+    if (isEditing || typeof navigator.getGamepads !== 'function') return;
+    let frameId = 0;
+    let stopped = false;
+
+    const disconnect = () => {
+      if (!connectedRef.current) return;
+      connectedRef.current = false;
+      publishJoy(EMPTY_GAMEPAD_SNAPSHOT);
+      previousPressedRef.current = Array(17).fill(false);
+      snapshotKeyRef.current = '';
+      connectionKeyRef.current = '';
+      setSnapshot(EMPTY_GAMEPAD_SNAPSHOT);
+      setConnection(null);
+    };
+
+    const poll = (now: number) => {
+      if (stopped) return;
+      const gamepad = findPhysicalGamepad(navigator.getGamepads(), config.config?.physicalGamepadIndex);
+      if (!gamepad) {
+        disconnect();
+        frameId = requestAnimationFrame(poll);
+        return;
+      }
+
+      const next = snapshotPhysicalGamepad(gamepad, config.config?.physicalGamepadDeadzone);
+      const nextKey = physicalGamepadSnapshotKey(next);
+      const changed = nextKey !== snapshotKeyRef.current;
+      const justConnected = !connectedRef.current;
+      connectedRef.current = true;
+      const connectionKey = `${gamepad.index}:${gamepad.id}:${gamepad.mapping}`;
+      if (connectionKeyRef.current !== connectionKey) {
+        connectionKeyRef.current = connectionKey;
+        setConnection({ id: gamepad.id, index: gamepad.index, mapping: gamepad.mapping });
+      }
+
+      PHYSICAL_GAMEPAD_CONTROLS.forEach(({ id, buttonIndex }) => {
+        const wasPressed = previousPressedRef.current[buttonIndex] ?? false;
+        const isPressed = next.pressed[buttonIndex] ?? false;
+        if (isPressed !== wasPressed) runOperation(id, isPressed ? 'press' : 'release');
+      });
+      previousPressedRef.current = next.pressed;
+
+      if (changed) {
+        snapshotKeyRef.current = nextKey;
+        setSnapshot(next);
+      }
+      if (changed || justConnected || now - lastPublishedAtRef.current >= JOY_PUBLISH_INTERVAL_MS) {
+        publishJoy(next);
+        lastPublishedAtRef.current = now;
+      }
+      frameId = requestAnimationFrame(poll);
+    };
+
+    frameId = requestAnimationFrame(poll);
+    return () => {
+      stopped = true;
+      cancelAnimationFrame(frameId);
+      disconnect();
+    };
+  }, [
+    config.config?.physicalGamepadDeadzone,
+    config.config?.physicalGamepadIndex,
+    isEditing,
+    publishJoy,
+    runOperation,
+  ]);
+
+  useEffect(
+    () => () => {
+      operationControllersRef.current.forEach(controller => controller.abort());
+      operationControllersRef.current.clear();
+    },
+    []
+  );
+
+  const label = useCallback((id: PhysicalGamepadControlId) => getPhysicalGamepadControlLabel(id, profile), [profile]);
+  const active = useCallback(
+    (id: PhysicalGamepadControlId) => {
+      const index = PHYSICAL_GAMEPAD_CONTROLS.find(control => control.id === id)?.buttonIndex ?? -1;
+      return snapshot.pressed[index] || snapshot.buttons[index] > 0.05;
+    },
+    [snapshot]
+  );
+  const stickLayout = profile === 'playstation' ? 'symmetric' : 'offset';
+  const leftStick = useMemo(() => ({ x: snapshot.axes[0] * 10, y: snapshot.axes[1] * 10 }), [snapshot.axes]);
+  const rightStick = useMemo(() => ({ x: snapshot.axes[2] * 10, y: snapshot.axes[3] * 10 }), [snapshot.axes]);
+
+  const controlClass = (id: PhysicalGamepadControlId) => `physical-control ${active(id) ? 'is-active' : ''}`;
+
+  return (
+    <div className={`physical-gamepad physical-gamepad-${profile}`}>
+      <div className="physical-gamepad-status" role="status">
+        <span className={`physical-gamepad-dot ${connection ? 'connected' : ''}`} />
+        {isEditing
+          ? `${profile} preview`
+          : connection
+            ? `#${connection.index} ${connection.id}`
+            : 'Press a controller button to connect'}
+      </div>
+      <svg viewBox="0 0 400 250" role="img" aria-label={`${profile} gamepad visualization`}>
+        <path
+          className="physical-gamepad-body"
+          d="M108 45 C55 42 28 83 22 157 C18 211 43 235 72 210 L116 171 H284 L328 210 C357 235 382 211 378 157 C372 83 345 42 292 45 Z"
+        />
+        <g className={controlClass('left-trigger')}>
+          <rect x="79" y="28" width="55" height="20" rx="8" />
+          <text x="106" y="42">
+            {label('left-trigger')}
+          </text>
+        </g>
+        <g className={controlClass('right-trigger')}>
+          <rect x="266" y="28" width="55" height="20" rx="8" />
+          <text x="294" y="42">
+            {label('right-trigger')}
+          </text>
+        </g>
+        <g className={controlClass('left-bumper')}>
+          <rect x="68" y="48" width="72" height="18" rx="7" />
+          <text x="104" y="61">
+            {label('left-bumper')}
+          </text>
+        </g>
+        <g className={controlClass('right-bumper')}>
+          <rect x="260" y="48" width="72" height="18" rx="7" />
+          <text x="296" y="61">
+            {label('right-bumper')}
+          </text>
+        </g>
+
+        <g
+          transform={stickLayout === 'symmetric' ? 'translate(138 171)' : 'translate(115 113)'}
+          className={controlClass('left-stick')}
+        >
+          <circle className="stick-well" r="30" />
+          <circle className="stick-knob" r="20" transform={`translate(${leftStick.x} ${leftStick.y})`} />
+          <text y="5">{label('left-stick')}</text>
+        </g>
+        <g
+          transform={stickLayout === 'symmetric' ? 'translate(262 171)' : 'translate(245 169)'}
+          className={controlClass('right-stick')}
+        >
+          <circle className="stick-well" r="30" />
+          <circle className="stick-knob" r="20" transform={`translate(${rightStick.x} ${rightStick.y})`} />
+          <text y="5">{label('right-stick')}</text>
+        </g>
+
+        <g
+          transform={stickLayout === 'symmetric' ? 'translate(82 112)' : 'translate(138 171)'}
+          className="physical-dpad"
+        >
+          <path className={controlClass('dpad-up')} d="M-13 -34 H13 V-9 H-13 Z" />
+          <path className={controlClass('dpad-down')} d="M-13 9 H13 V34 H-13 Z" />
+          <path className={controlClass('dpad-left')} d="M-34 -13 H-9 V13 H-34 Z" />
+          <path className={controlClass('dpad-right')} d="M9 -13 H34 V13 H9 Z" />
+          <rect x="-13" y="-13" width="26" height="26" />
+        </g>
+
+        <g className="physical-face-buttons" transform="translate(305 111)">
+          <g transform="translate(0 31)" className={controlClass('face-bottom')}>
+            <circle r="17" />
+            <text y="5">{label('face-bottom')}</text>
+          </g>
+          <g transform="translate(31 0)" className={controlClass('face-right')}>
+            <circle r="17" />
+            <text y="5">{label('face-right')}</text>
+          </g>
+          <g transform="translate(-31 0)" className={controlClass('face-left')}>
+            <circle r="17" />
+            <text y="5">{label('face-left')}</text>
+          </g>
+          <g transform="translate(0 -31)" className={controlClass('face-top')}>
+            <circle r="17" />
+            <text y="5">{label('face-top')}</text>
+          </g>
+        </g>
+
+        <g className={controlClass('select')}>
+          <rect x="163" y="103" width="27" height="15" rx="7" />
+          <text x="176.5" y="114">
+            {label('select')}
+          </text>
+        </g>
+        <g className={controlClass('start')}>
+          <rect x="210" y="103" width="27" height="15" rx="7" />
+          <text x="223.5" y="114">
+            {label('start')}
+          </text>
+        </g>
+        <g className={controlClass('home')}>
+          <circle cx="200" cy="82" r="14" />
+          <text x="200" y="86">
+            {label('home')}
+          </text>
+        </g>
+      </svg>
+      {connection && connection.mapping !== 'standard' && (
+        <small className="physical-gamepad-warning">
+          Non-standard browser mapping; verify control indices before driving.
+        </small>
+      )}
+      {operationError && (
+        <small className="physical-gamepad-warning" role="alert">
+          {operationError}
+        </small>
+      )}
+    </div>
+  );
+};
+
+export default PhysicalGamepadComponent;

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import PhysicalGamepadSettings from './PhysicalGamepadSettings';
+
+vi.mock('./RosEventOperationsEditor', () => ({
+  default: ({ onChange }: { onChange: (value: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onChange({
+          press: { kind: 'topic', name: '/pressed', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
+        })
+      }
+    >
+      Configure selected
+    </button>
+  ),
+}));
+
+describe('PhysicalGamepadSettings', () => {
+  it('offers all standard buttons and saves operations under the selected control', () => {
+    const onBindingsChange = vi.fn();
+    render(
+      <PhysicalGamepadSettings
+        profile="playstation"
+        deadzone={0.08}
+        bindings={{}}
+        ros={null}
+        onProfileChange={vi.fn()}
+        onPreferredIndexChange={vi.fn()}
+        onDeadzoneChange={vi.fn()}
+        onBindingsChange={onBindingsChange}
+      />
+    );
+
+    const picker = screen.getByRole('list', { name: 'Physical controller buttons' });
+    expect(within(picker).getAllByRole('button')).toHaveLength(17);
+    fireEvent.click(within(picker).getByRole('button', { name: '○' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Configure selected' }));
+
+    expect(onBindingsChange).toHaveBeenCalledWith({
+      'face-right': {
+        press: { kind: 'topic', name: '/pressed', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
+      },
+    });
+  });
+});

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.test.tsx
@@ -21,15 +21,18 @@ vi.mock('./RosEventOperationsEditor', () => ({
 describe('PhysicalGamepadSettings', () => {
   it('offers all standard buttons and saves operations under the selected control', () => {
     const onBindingsChange = vi.fn();
+    const onPublishHzChange = vi.fn();
     render(
       <PhysicalGamepadSettings
         profile="playstation"
         deadzone={0.08}
+        publishHz={20}
         bindings={{}}
         ros={null}
         onProfileChange={vi.fn()}
         onPreferredIndexChange={vi.fn()}
         onDeadzoneChange={vi.fn()}
+        onPublishHzChange={onPublishHzChange}
         onBindingsChange={onBindingsChange}
       />
     );
@@ -44,5 +47,10 @@ describe('PhysicalGamepadSettings', () => {
         press: { kind: 'topic', name: '/pressed', messageType: 'std_msgs/msg/Bool', payload: { data: true } },
       },
     });
+
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Joy publish rate (Hz)' }), {
+      target: { value: '30' },
+    });
+    expect(onPublishHzChange).toHaveBeenCalledWith(30);
   });
 });

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
@@ -1,7 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import type { Ros } from 'roslib';
 import type { RosOperation } from '../../../utils/rosOperations';
-import { getPhysicalGamepadControlLabel, PHYSICAL_GAMEPAD_CONTROLS } from '../physicalGamepad';
+import {
+  getPhysicalGamepadControlLabel,
+  MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+  MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ,
+  PHYSICAL_GAMEPAD_CONTROLS,
+} from '../physicalGamepad';
 import type { PhysicalGamepadBinding, PhysicalGamepadControlId, PhysicalGamepadProfile } from '../types';
 import RosEventOperationsEditor from './RosEventOperationsEditor';
 
@@ -9,11 +14,13 @@ interface Props {
   profile: PhysicalGamepadProfile;
   preferredIndex?: number;
   deadzone: number;
+  publishHz: number;
   bindings: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
   ros: Ros | null;
   onProfileChange: (value: PhysicalGamepadProfile) => void;
   onPreferredIndexChange: (value: number | undefined) => void;
   onDeadzoneChange: (value: number) => void;
+  onPublishHzChange: (value: number) => void;
   onBindingsChange: (value: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>) => void;
 }
 
@@ -21,11 +28,13 @@ const PhysicalGamepadSettings: React.FC<Props> = ({
   profile,
   preferredIndex,
   deadzone,
+  publishHz,
   bindings,
   ros,
   onProfileChange,
   onPreferredIndexChange,
   onDeadzoneChange,
+  onPublishHzChange,
   onBindingsChange,
 }) => {
   const [selectedControl, setSelectedControl] = useState<PhysicalGamepadControlId>('face-bottom');
@@ -85,6 +94,21 @@ const PhysicalGamepadSettings: React.FC<Props> = ({
           value={deadzone}
           onChange={event => onDeadzoneChange(Number(event.target.value))}
         />
+      </div>
+      <div className="setting-group">
+        <label htmlFor="physical-gamepad-publish-hz">Joy publish rate (Hz)</label>
+        <input
+          id="physical-gamepad-publish-hz"
+          type="number"
+          min={MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ}
+          max={MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ}
+          step="1"
+          value={publishHz}
+          onChange={event => onPublishHzChange(Number(event.target.value))}
+        />
+        <small className="settings-help">
+          {MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ}-{MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ} Hz. Button operations still run immediately.
+        </small>
       </div>
 
       <h4>

--- a/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
+++ b/src/features/customGamepad/components/PhysicalGamepadSettings.tsx
@@ -1,0 +1,125 @@
+import React, { useMemo, useState } from 'react';
+import type { Ros } from 'roslib';
+import type { RosOperation } from '../../../utils/rosOperations';
+import { getPhysicalGamepadControlLabel, PHYSICAL_GAMEPAD_CONTROLS } from '../physicalGamepad';
+import type { PhysicalGamepadBinding, PhysicalGamepadControlId, PhysicalGamepadProfile } from '../types';
+import RosEventOperationsEditor from './RosEventOperationsEditor';
+
+interface Props {
+  profile: PhysicalGamepadProfile;
+  preferredIndex?: number;
+  deadzone: number;
+  bindings: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
+  ros: Ros | null;
+  onProfileChange: (value: PhysicalGamepadProfile) => void;
+  onPreferredIndexChange: (value: number | undefined) => void;
+  onDeadzoneChange: (value: number) => void;
+  onBindingsChange: (value: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>) => void;
+}
+
+const PhysicalGamepadSettings: React.FC<Props> = ({
+  profile,
+  preferredIndex,
+  deadzone,
+  bindings,
+  ros,
+  onProfileChange,
+  onPreferredIndexChange,
+  onDeadzoneChange,
+  onBindingsChange,
+}) => {
+  const [selectedControl, setSelectedControl] = useState<PhysicalGamepadControlId>('face-bottom');
+  const labelsProfile = profile === 'auto' ? 'xbox' : profile;
+  const selectedLabel = getPhysicalGamepadControlLabel(selectedControl, labelsProfile);
+  const configuredCount = useMemo(
+    () => Object.values(bindings).filter(binding => binding?.press || binding?.release).length,
+    [bindings]
+  );
+
+  const updateSelectedBinding = (operations: Partial<Record<'press' | 'release', RosOperation>>) => {
+    const next = { ...bindings };
+    if (!operations.press && !operations.release) delete next[selectedControl];
+    else next[selectedControl] = operations;
+    onBindingsChange(next);
+  };
+
+  return (
+    <div className="physical-gamepad-settings">
+      <h4>Physical Controller</h4>
+      <div className="settings-row">
+        <div className="setting-group">
+          <label htmlFor="physical-gamepad-profile">Button labels and layout</label>
+          <select
+            id="physical-gamepad-profile"
+            value={profile}
+            onChange={event => onProfileChange(event.target.value as PhysicalGamepadProfile)}
+          >
+            <option value="auto">Auto detect</option>
+            <option value="xbox">Xbox / XInput</option>
+            <option value="playstation">PlayStation</option>
+            <option value="logitech">Logitech</option>
+          </select>
+        </div>
+        <div className="setting-group">
+          <label htmlFor="physical-gamepad-index">Controller index</label>
+          <input
+            id="physical-gamepad-index"
+            type="number"
+            min="0"
+            placeholder="Auto (first connected)"
+            value={preferredIndex ?? ''}
+            onChange={event =>
+              onPreferredIndexChange(event.target.value === '' ? undefined : Number(event.target.value))
+            }
+          />
+        </div>
+      </div>
+      <div className="setting-group">
+        <label htmlFor="physical-gamepad-deadzone">Stick deadzone: {deadzone.toFixed(2)}</label>
+        <input
+          id="physical-gamepad-deadzone"
+          type="range"
+          min="0"
+          max="0.5"
+          step="0.01"
+          value={deadzone}
+          onChange={event => onDeadzoneChange(Number(event.target.value))}
+        />
+      </div>
+
+      <h4>
+        Button Operations <span className="physical-binding-count">{configuredCount}/17 configured</span>
+      </h4>
+      <p className="settings-help">
+        Select any standard controller button, then assign independent press and release topic, service, or action
+        operations.
+      </p>
+      <div className="physical-control-picker" role="list" aria-label="Physical controller buttons">
+        {PHYSICAL_GAMEPAD_CONTROLS.map(({ id }) => {
+          const configured = Boolean(bindings[id]?.press || bindings[id]?.release);
+          return (
+            <button
+              key={id}
+              type="button"
+              className={`${selectedControl === id ? 'selected' : ''} ${configured ? 'configured' : ''}`}
+              onClick={() => setSelectedControl(id)}
+            >
+              {getPhysicalGamepadControlLabel(id, labelsProfile)}
+            </button>
+          );
+        })}
+      </div>
+      <fieldset className="physical-control-binding">
+        <legend>{selectedLabel}</legend>
+        <RosEventOperationsEditor
+          events={['press', 'release']}
+          value={bindings[selectedControl] || {}}
+          ros={ros}
+          onChange={updateSelectedBinding}
+        />
+      </fieldset>
+    </div>
+  );
+};
+
+export default PhysicalGamepadSettings;

--- a/src/features/customGamepad/defaultLayouts.test.ts
+++ b/src/features/customGamepad/defaultLayouts.test.ts
@@ -35,7 +35,7 @@ describe('defaultLayouts', () => {
     expect(defaultPhysicalGamepadLayout.components[0]).toMatchObject({
       type: 'physical-gamepad',
       action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
-      config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08 },
+      config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08, physicalGamepadPublishHz: 20 },
     });
   });
 

--- a/src/features/customGamepad/defaultLayouts.test.ts
+++ b/src/features/customGamepad/defaultLayouts.test.ts
@@ -3,6 +3,7 @@ import {
   componentLibrary,
   defaultDualJoystickHeartbeatLayout,
   defaultGamepadLibrary,
+  defaultPhysicalGamepadLayout,
 } from './defaultLayouts';
 import type { CustomGamepadLayout, GamepadLibraryItem } from './types';
 
@@ -17,13 +18,24 @@ describe('defaultLayouts', () => {
     expect(layout.metadata.version).toBeTruthy();
   };
 
-  it('provides one generic dual-joystick heartbeat template', () => {
+  it('provides the generic and physical-controller templates', () => {
     validateLayout(defaultDualJoystickHeartbeatLayout);
-    expect(defaultGamepadLibrary).toHaveLength(1);
+    validateLayout(defaultPhysicalGamepadLayout);
+    expect(defaultGamepadLibrary).toHaveLength(2);
     expect(defaultGamepadLibrary[0]).toMatchObject({
       id: 'dual-joystick-heartbeat',
       name: 'Dual Joystick + Heartbeat',
       isDefault: true,
+    });
+    expect(defaultGamepadLibrary[1]).toMatchObject({
+      id: 'physical-gamepad',
+      name: 'Physical Gamepad',
+      isDefault: true,
+    });
+    expect(defaultPhysicalGamepadLayout.components[0]).toMatchObject({
+      type: 'physical-gamepad',
+      action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
+      config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08 },
     });
   });
 
@@ -69,6 +81,7 @@ describe('defaultLayouts', () => {
   it('keeps all editor component types available', () => {
     expect(componentLibrary.map(component => component.type)).toEqual([
       'joystick',
+      'physical-gamepad',
       'button',
       'dpad',
       'toggle',

--- a/src/features/customGamepad/defaultLayouts.test.ts
+++ b/src/features/customGamepad/defaultLayouts.test.ts
@@ -34,6 +34,7 @@ describe('defaultLayouts', () => {
     });
     expect(defaultPhysicalGamepadLayout.components[0]).toMatchObject({
       type: 'physical-gamepad',
+      position: { x: 0, y: 0, width: 8, height: 4 },
       action: { topic: '/joy', messageType: 'sensor_msgs/msg/Joy', field: 'axes' },
       config: { physicalGamepadProfile: 'auto', physicalGamepadDeadzone: 0.08, physicalGamepadPublishHz: 20 },
     });

--- a/src/features/customGamepad/defaultLayouts.ts
+++ b/src/features/customGamepad/defaultLayouts.ts
@@ -77,7 +77,7 @@ export const defaultPhysicalGamepadLayout: CustomGamepadLayout = {
     {
       id: 'physical-gamepad',
       type: 'physical-gamepad',
-      position: { x: 1, y: 0, width: 6, height: 4 },
+      position: { x: 0, y: 0, width: 8, height: 4 },
       label: 'Physical Gamepad',
       action: {
         topic: '/joy',

--- a/src/features/customGamepad/defaultLayouts.ts
+++ b/src/features/customGamepad/defaultLayouts.ts
@@ -1,4 +1,5 @@
 import { CustomGamepadLayout, GamepadLibraryItem } from './types';
+import { DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ } from './physicalGamepad';
 
 // Generic ROS Joy starting point.
 export const defaultDualJoystickHeartbeatLayout: CustomGamepadLayout = {
@@ -86,6 +87,7 @@ export const defaultPhysicalGamepadLayout: CustomGamepadLayout = {
       config: {
         physicalGamepadProfile: 'auto',
         physicalGamepadDeadzone: 0.08,
+        physicalGamepadPublishHz: DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ,
       },
     },
   ],

--- a/src/features/customGamepad/defaultLayouts.ts
+++ b/src/features/customGamepad/defaultLayouts.ts
@@ -66,6 +66,40 @@ export const defaultDualJoystickHeartbeatLayout: CustomGamepadLayout = {
   }
 };
 
+export const defaultPhysicalGamepadLayout: CustomGamepadLayout = {
+  id: 'default-physical-gamepad',
+  name: 'Physical Gamepad',
+  description: 'Live Xbox, PlayStation, or Logitech controller with configurable ROS controls',
+  gridSize: { width: 8, height: 4 },
+  cellSize: 80,
+  components: [
+    {
+      id: 'physical-gamepad',
+      type: 'physical-gamepad',
+      position: { x: 1, y: 0, width: 6, height: 4 },
+      label: 'Physical Gamepad',
+      action: {
+        topic: '/joy',
+        messageType: 'sensor_msgs/msg/Joy',
+        field: 'axes',
+      },
+      config: {
+        physicalGamepadProfile: 'auto',
+        physicalGamepadDeadzone: 0.08,
+      },
+    },
+  ],
+  rosConfig: {
+    defaultTopic: '/joy',
+    defaultMessageType: 'sensor_msgs/msg/Joy',
+  },
+  metadata: {
+    created: new Date().toISOString(),
+    modified: new Date().toISOString(),
+    version: '1.0.0',
+  },
+};
+
 // Default library items
 export const defaultGamepadLibrary: GamepadLibraryItem[] = [
   {
@@ -74,6 +108,13 @@ export const defaultGamepadLibrary: GamepadLibraryItem[] = [
     description: 'Generic four-axis Joy controller with a heartbeat monitor',
     layout: defaultDualJoystickHeartbeatLayout,
     isDefault: true
+  },
+  {
+    id: 'physical-gamepad',
+    name: 'Physical Gamepad',
+    description: 'Live Xbox, PlayStation, or Logitech controller with configurable ROS controls',
+    layout: defaultPhysicalGamepadLayout,
+    isDefault: true,
   }
 ];
 
@@ -85,6 +126,13 @@ export const componentLibrary = [
     description: 'Analog stick for continuous control',
     defaultSize: { width: 2, height: 2 },
     icon: '🕹️'
+  },
+  {
+    type: 'physical-gamepad' as const,
+    name: 'Physical Gamepad',
+    description: 'Connected Xbox, PlayStation, or Logitech controller',
+    defaultSize: { width: 6, height: 4 },
+    icon: '🎮'
   },
   {
     type: 'button' as const,

--- a/src/features/customGamepad/physicalGamepad.test.ts
+++ b/src/features/customGamepad/physicalGamepad.test.ts
@@ -4,6 +4,7 @@ import {
   detectPhysicalGamepadProfile,
   findPhysicalGamepad,
   getPhysicalGamepadControlLabel,
+  normalizePhysicalGamepadPublishHz,
   snapshotPhysicalGamepad,
 } from './physicalGamepad';
 
@@ -34,6 +35,14 @@ describe('physical gamepad normalization', () => {
     expect(applyGamepadDeadzone(0.07, 0.08)).toBe(0);
     expect(applyGamepadDeadzone(-0.54, 0.08)).toBeCloseTo(-0.5);
     expect(applyGamepadDeadzone(2, 0.08)).toBe(1);
+  });
+
+  it('defaults and clamps the Joy publish rate', () => {
+    expect(normalizePhysicalGamepadPublishHz(undefined)).toBe(20);
+    expect(normalizePhysicalGamepadPublishHz(Number.NaN)).toBe(20);
+    expect(normalizePhysicalGamepadPublishHz(0)).toBe(1);
+    expect(normalizePhysicalGamepadPublishHz(30)).toBe(30);
+    expect(normalizePhysicalGamepadPublishHz(120)).toBe(60);
   });
 
   it('normalizes the standard four axes and seventeen buttons', () => {

--- a/src/features/customGamepad/physicalGamepad.test.ts
+++ b/src/features/customGamepad/physicalGamepad.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyGamepadDeadzone,
+  detectPhysicalGamepadProfile,
+  findPhysicalGamepad,
+  getPhysicalGamepadControlLabel,
+  snapshotPhysicalGamepad,
+} from './physicalGamepad';
+
+const makeGamepad = (overrides: Partial<Gamepad> = {}): Gamepad =>
+  ({
+    axes: [0, 0, 0, 0],
+    buttons: Array.from({ length: 17 }, () => ({ pressed: false, touched: false, value: 0 })),
+    connected: true,
+    hapticActuators: [],
+    id: 'Xbox Wireless Controller',
+    index: 0,
+    mapping: 'standard',
+    timestamp: 1,
+    vibrationActuator: null,
+    ...overrides,
+  }) as Gamepad;
+
+describe('physical gamepad normalization', () => {
+  it('detects the supported controller families while honoring an explicit profile', () => {
+    expect(detectPhysicalGamepadProfile('auto', 'Sony DualSense Wireless Controller')).toBe('playstation');
+    expect(detectPhysicalGamepadProfile('auto', 'Logitech Gamepad F710')).toBe('logitech');
+    expect(detectPhysicalGamepadProfile('auto', 'Microsoft X-Box One pad')).toBe('xbox');
+    expect(detectPhysicalGamepadProfile('playstation', 'Logitech F310')).toBe('playstation');
+    expect(getPhysicalGamepadControlLabel('face-bottom', 'playstation')).toBe('×');
+  });
+
+  it('applies and rescales a configurable deadzone', () => {
+    expect(applyGamepadDeadzone(0.07, 0.08)).toBe(0);
+    expect(applyGamepadDeadzone(-0.54, 0.08)).toBeCloseTo(-0.5);
+    expect(applyGamepadDeadzone(2, 0.08)).toBe(1);
+  });
+
+  it('normalizes the standard four axes and seventeen buttons', () => {
+    const buttons = Array.from({ length: 17 }, (_, index) => ({
+      pressed: index === 4,
+      touched: index === 4,
+      value: index === 4 ? 1 : 0,
+    }));
+    const snapshot = snapshotPhysicalGamepad(makeGamepad({ axes: [0.54, -0.54, 0.07, 1], buttons }), 0.08);
+
+    expect(snapshot.axes).toEqual([0.5, -0.5, 0, 1]);
+    expect(snapshot.pressed[4]).toBe(true);
+    expect(snapshot.buttons).toHaveLength(17);
+  });
+
+  it('selects a preferred connected controller or the first connected controller', () => {
+    const first = makeGamepad({ index: 0 });
+    const second = makeGamepad({ id: 'Second', index: 2 });
+    const pads = [first, null, second];
+    expect(findPhysicalGamepad(pads)).toBe(first);
+    expect(findPhysicalGamepad(pads, 2)).toBe(second);
+    expect(findPhysicalGamepad(pads, 1)).toBeNull();
+  });
+});

--- a/src/features/customGamepad/physicalGamepad.ts
+++ b/src/features/customGamepad/physicalGamepad.ts
@@ -1,0 +1,139 @@
+import type { PhysicalGamepadControlId, PhysicalGamepadProfile } from './types';
+
+export const PHYSICAL_GAMEPAD_CONTROLS: ReadonlyArray<{
+  id: PhysicalGamepadControlId;
+  buttonIndex: number;
+}> = [
+  { id: 'face-bottom', buttonIndex: 0 },
+  { id: 'face-right', buttonIndex: 1 },
+  { id: 'face-left', buttonIndex: 2 },
+  { id: 'face-top', buttonIndex: 3 },
+  { id: 'left-bumper', buttonIndex: 4 },
+  { id: 'right-bumper', buttonIndex: 5 },
+  { id: 'left-trigger', buttonIndex: 6 },
+  { id: 'right-trigger', buttonIndex: 7 },
+  { id: 'select', buttonIndex: 8 },
+  { id: 'start', buttonIndex: 9 },
+  { id: 'left-stick', buttonIndex: 10 },
+  { id: 'right-stick', buttonIndex: 11 },
+  { id: 'dpad-up', buttonIndex: 12 },
+  { id: 'dpad-down', buttonIndex: 13 },
+  { id: 'dpad-left', buttonIndex: 14 },
+  { id: 'dpad-right', buttonIndex: 15 },
+  { id: 'home', buttonIndex: 16 },
+];
+
+const PROFILE_LABELS: Record<Exclude<PhysicalGamepadProfile, 'auto'>, Record<PhysicalGamepadControlId, string>> = {
+  xbox: {
+    'face-bottom': 'A',
+    'face-right': 'B',
+    'face-left': 'X',
+    'face-top': 'Y',
+    'left-bumper': 'LB',
+    'right-bumper': 'RB',
+    'left-trigger': 'LT',
+    'right-trigger': 'RT',
+    select: 'View',
+    start: 'Menu',
+    'left-stick': 'LS',
+    'right-stick': 'RS',
+    'dpad-up': 'D-pad Up',
+    'dpad-down': 'D-pad Down',
+    'dpad-left': 'D-pad Left',
+    'dpad-right': 'D-pad Right',
+    home: 'Xbox',
+  },
+  playstation: {
+    'face-bottom': '×',
+    'face-right': '○',
+    'face-left': '□',
+    'face-top': '△',
+    'left-bumper': 'L1',
+    'right-bumper': 'R1',
+    'left-trigger': 'L2',
+    'right-trigger': 'R2',
+    select: 'Create',
+    start: 'Options',
+    'left-stick': 'L3',
+    'right-stick': 'R3',
+    'dpad-up': 'D-pad Up',
+    'dpad-down': 'D-pad Down',
+    'dpad-left': 'D-pad Left',
+    'dpad-right': 'D-pad Right',
+    home: 'PS',
+  },
+  logitech: {
+    'face-bottom': 'A',
+    'face-right': 'B',
+    'face-left': 'X',
+    'face-top': 'Y',
+    'left-bumper': 'LB',
+    'right-bumper': 'RB',
+    'left-trigger': 'LT',
+    'right-trigger': 'RT',
+    select: 'Back',
+    start: 'Start',
+    'left-stick': 'L',
+    'right-stick': 'R',
+    'dpad-up': 'D-pad Up',
+    'dpad-down': 'D-pad Down',
+    'dpad-left': 'D-pad Left',
+    'dpad-right': 'D-pad Right',
+    home: 'Mode',
+  },
+};
+
+export interface PhysicalGamepadSnapshot {
+  axes: [number, number, number, number];
+  buttons: number[];
+  pressed: boolean[];
+}
+
+export const EMPTY_GAMEPAD_SNAPSHOT: PhysicalGamepadSnapshot = {
+  axes: [0, 0, 0, 0],
+  buttons: Array(17).fill(0),
+  pressed: Array(17).fill(false),
+};
+
+export const detectPhysicalGamepadProfile = (
+  requested: PhysicalGamepadProfile | undefined,
+  gamepadId = ''
+): Exclude<PhysicalGamepadProfile, 'auto'> => {
+  if (requested && requested !== 'auto') return requested;
+  const id = gamepadId.toLowerCase();
+  if (/playstation|dualshock|dualsense|sony|wireless controller/.test(id)) return 'playstation';
+  if (/logitech|f310|f510|f710/.test(id)) return 'logitech';
+  return 'xbox';
+};
+
+export const getPhysicalGamepadControlLabel = (
+  controlId: PhysicalGamepadControlId,
+  profile: Exclude<PhysicalGamepadProfile, 'auto'>
+): string => PROFILE_LABELS[profile][controlId];
+
+export const applyGamepadDeadzone = (value: number, deadzone: number): number => {
+  const safeValue = Number.isFinite(value) ? Math.max(-1, Math.min(1, value)) : 0;
+  const safeDeadzone = Number.isFinite(deadzone) ? Math.max(0, Math.min(0.95, deadzone)) : 0.08;
+  const magnitude = Math.abs(safeValue);
+  if (magnitude <= safeDeadzone) return 0;
+  return Math.sign(safeValue) * ((magnitude - safeDeadzone) / (1 - safeDeadzone));
+};
+
+export const snapshotPhysicalGamepad = (gamepad: Gamepad, deadzone = 0.08): PhysicalGamepadSnapshot => ({
+  axes: [0, 1, 2, 3].map(index =>
+    applyGamepadDeadzone(gamepad.axes[index] ?? 0, deadzone)
+  ) as PhysicalGamepadSnapshot['axes'],
+  buttons: PHYSICAL_GAMEPAD_CONTROLS.map(({ buttonIndex }) => gamepad.buttons[buttonIndex]?.value ?? 0),
+  pressed: PHYSICAL_GAMEPAD_CONTROLS.map(({ buttonIndex }) => gamepad.buttons[buttonIndex]?.pressed ?? false),
+});
+
+export const findPhysicalGamepad = (gamepads: ArrayLike<Gamepad | null>, preferredIndex?: number): Gamepad | null => {
+  if (preferredIndex !== undefined && preferredIndex >= 0) {
+    const preferred = gamepads[preferredIndex];
+    return preferred?.connected ? preferred : null;
+  }
+  return Array.from(gamepads).find((gamepad): gamepad is Gamepad => Boolean(gamepad?.connected)) ?? null;
+};
+
+export const physicalGamepadSnapshotKey = (snapshot: PhysicalGamepadSnapshot): string =>
+  [...snapshot.axes.map(value => value.toFixed(3)), ...snapshot.buttons.map(value => value.toFixed(2))].join(',');

--- a/src/features/customGamepad/physicalGamepad.ts
+++ b/src/features/customGamepad/physicalGamepad.ts
@@ -1,5 +1,15 @@
 import type { PhysicalGamepadControlId, PhysicalGamepadProfile } from './types';
 
+export const DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ = 20;
+export const MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ = 1;
+export const MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ = 60;
+
+export const normalizePhysicalGamepadPublishHz = (value: number | undefined): number => {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) return DEFAULT_PHYSICAL_GAMEPAD_PUBLISH_HZ;
+  return Math.max(MIN_PHYSICAL_GAMEPAD_PUBLISH_HZ, Math.min(MAX_PHYSICAL_GAMEPAD_PUBLISH_HZ, numericValue));
+};
+
 export const PHYSICAL_GAMEPAD_CONTROLS: ReadonlyArray<{
   id: PhysicalGamepadControlId;
   buttonIndex: number;

--- a/src/features/customGamepad/types.ts
+++ b/src/features/customGamepad/types.ts
@@ -93,6 +93,7 @@ export interface GamepadComponentConfig {
     physicalGamepadProfile?: PhysicalGamepadProfile;
     physicalGamepadIndex?: number;
     physicalGamepadDeadzone?: number;
+    physicalGamepadPublishHz?: number;
     physicalGamepadBindings?: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
 
     // Button specific

--- a/src/features/customGamepad/types.ts
+++ b/src/features/customGamepad/types.ts
@@ -1,5 +1,33 @@
 // Types for the custom gamepad system
 
+import type { RosOperation } from '../../utils/rosOperations';
+
+export type PhysicalGamepadProfile = 'auto' | 'xbox' | 'playstation' | 'logitech';
+
+export type PhysicalGamepadControlId =
+  | 'face-bottom'
+  | 'face-right'
+  | 'face-left'
+  | 'face-top'
+  | 'left-bumper'
+  | 'right-bumper'
+  | 'left-trigger'
+  | 'right-trigger'
+  | 'select'
+  | 'start'
+  | 'left-stick'
+  | 'right-stick'
+  | 'dpad-up'
+  | 'dpad-down'
+  | 'dpad-left'
+  | 'dpad-right'
+  | 'home';
+
+export interface PhysicalGamepadBinding {
+  press?: RosOperation;
+  release?: RosOperation;
+}
+
 export interface GridPosition {
   x: number;
   y: number;
@@ -33,7 +61,7 @@ export enum ComponentInteractionMode {
 
 export interface GamepadComponentConfig {
   id: string;
-  type: 'joystick' | 'button' | 'dpad' | 'toggle' | 'slider' | 'camera' | 'plot' | 'heartbeat';
+  type: 'joystick' | 'physical-gamepad' | 'button' | 'dpad' | 'toggle' | 'slider' | 'camera' | 'plot' | 'heartbeat';
   position: GridPosition;
   label?: string;
   action?: ComponentAction;
@@ -60,6 +88,12 @@ export interface GamepadComponentConfig {
     poseStampedOdometryMessageType?: string;
     poseStampedUseOdometryOrientation?: boolean;
     twistStampedFrameId?: string;
+
+    // Physical gamepad specific
+    physicalGamepadProfile?: PhysicalGamepadProfile;
+    physicalGamepadIndex?: number;
+    physicalGamepadDeadzone?: number;
+    physicalGamepadBindings?: Partial<Record<PhysicalGamepadControlId, PhysicalGamepadBinding>>;
 
     // Button specific
     buttonIndex?: number;
@@ -176,5 +210,4 @@ export interface EditorState {
   cellSize: number;
   showGrid: boolean;
   snapToGrid: boolean;
-} 
-import type { RosOperation } from '../../utils/rosOperations';
+}

--- a/src/panels/ExternalPanelHost.test.tsx
+++ b/src/panels/ExternalPanelHost.test.tsx
@@ -56,7 +56,7 @@ const renderHost = (overrides: Partial<React.ComponentProps<typeof ExternalPanel
     ros: {} as never,
     connectionStatus: 'connected',
     connectionGeneration: 1,
-    runtime: { target: 'web', endpoints: { videoStream: 'https://robot.test/stream' } },
+    runtime: { target: 'web', endpoints: { webrtcWhep: 'http://robot.local:8889/', webrtcDiscovery: 'http://robot.local:9997/v3/paths/list', webrtcHls: 'http://robot.test:8888/', videoStream: 'https://robot.test/stream' } },
     isActive: true,
     state: { count: 2 },
     onStateChange,
@@ -91,6 +91,9 @@ describe('ExternalPanelHost sandbox', () => {
     expect(iframe).not.toBeNull();
     expect(iframe).toHaveAttribute('sandbox', 'allow-scripts allow-downloads allow-forms');
     expect(iframe?.getAttribute('sandbox')).not.toContain('allow-same-origin');
+    // That opaque origin makes the frame cross-origin, which withholds autoplay unless granted,
+    // leaving a panel that plays a stream unable to start one.
+    expect(iframe?.getAttribute('allow')).toContain('autoplay');
     // Loaded from its own URL rather than srcdoc, so it does not inherit the host page's CSP.
     expect(iframe?.getAttribute('srcdoc')).toBeNull();
     const sandboxSrc = new URL(iframe!.getAttribute('src')!, document.baseURI);

--- a/src/panels/ExternalPanelHost.tsx
+++ b/src/panels/ExternalPanelHost.tsx
@@ -59,6 +59,10 @@ const getInitialViewportSnapshot = (isActive: boolean): RoboBoyPanelViewportSnap
 
 const getIframeAllow = (capabilities: readonly string[]): string | undefined => {
   const permissions = [
+    // The sandbox has an opaque origin, so it counts as cross-origin and Permissions Policy
+    // withholds autoplay by default. A panel that plays a stream would then be refused playback it
+    // never asked a person for, and could only report that it was waiting to be tapped.
+    'autoplay',
     capabilities.includes('camera') ? 'camera' : '',
     capabilities.includes('microphone') ? 'microphone' : '',
     capabilities.includes('web-bluetooth') ? 'bluetooth' : '',

--- a/src/panels/PanelManagerDialog.test.tsx
+++ b/src/panels/PanelManagerDialog.test.tsx
@@ -55,7 +55,7 @@ describe('PanelManagerDialog', () => {
     api.load.mockResolvedValue({
       config: {
         schemaVersion: 2,
-        sources: [{ type: 'remote', name: 'official', catalogUrl: 'https://panels.example/catalog.json' }],
+        sources: [{ type: 'remote', name: 'roboboy-official', catalogUrl: OFFICIAL_PANEL_SOURCE.catalogUrl }],
         selection: { mode: 'include', panelIds: [panel.id] },
       },
     });
@@ -326,6 +326,32 @@ describe('PanelManagerDialog', () => {
     expect(screen.getByText(/ships with this build/)).toBeInTheDocument();
   });
 
+  it('does not offer the official catalog on a deployment that does not configure it', async () => {
+    api.load.mockResolvedValue({
+      config: {
+        schemaVersion: 2,
+        sources: [{ type: 'local', name: 'local-workspace', repositories: ['/panel-workspace/hello'] }],
+        selection: { mode: 'all' },
+      },
+    });
+    render(
+      <PanelManagerDialog
+        installedPanels={[]}
+        availablePanels={availableFrom([])}
+        onPanelEnabledChange={vi.fn()}
+        onClose={vi.fn()}
+        onApplied={vi.fn()}
+      />
+    );
+
+    await screen.findByText(/installs panels from its own configured sources/);
+
+    // Asking would fail every time, so the dialog never asks and never reports a failure.
+    expect(api.catalog).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Couldn't load the official panel catalog/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+  });
+
   it('shows a retry action when the official catalog fails to load', async () => {
     api.catalog.mockRejectedValueOnce(new Error('network down'));
     render(
@@ -396,7 +422,7 @@ describe('PanelManagerDialog', () => {
     api.load.mockResolvedValue({
       config: {
         schemaVersion: 2,
-        sources: [{ type: 'remote', name: 'official', catalogUrl: 'https://panels.example/catalog.json' }],
+        sources: [{ type: 'remote', name: 'roboboy-official', catalogUrl: OFFICIAL_PANEL_SOURCE.catalogUrl }],
         selection: { mode: 'all' },
       },
     });

--- a/src/panels/PanelManagerDialog.tsx
+++ b/src/panels/PanelManagerDialog.tsx
@@ -11,6 +11,7 @@ import {
   type CatalogPanelSummary,
   type PanelInstallPreview,
   type PanelSourceConfig,
+  type RemotePanelSourceConfig,
   type PanelSourcesConfig,
 } from './managerApi';
 import type { AvailablePanel } from './useInstalledPanels';
@@ -33,12 +34,20 @@ const splitLines = (value: string): string[] =>
     .map(item => item.trim())
     .filter(Boolean);
 
-const ensureOfficialSourcePresent = (config: PanelSourcesConfig): PanelSourceConfig[] => {
-  const alreadyPresent = config.sources.some(
-    source => source.type === 'remote' && source.catalogUrl === OFFICIAL_PANEL_SOURCE.catalogUrl
+/**
+ * The deployment's own entry for the official catalog, whatever it named it. The manager resolves a
+ * catalog by the source name its configuration gives -- the URL it fetches comes from an operator,
+ * never from the browser -- so browsing is possible only through an entry that is already there.
+ * A deployment serving its own sources, such as a workspace of local checkouts, has none.
+ */
+const findOfficialSource = (config: PanelSourcesConfig): RemotePanelSourceConfig | undefined =>
+  config.sources.find(
+    (source): source is RemotePanelSourceConfig =>
+      source.type === 'remote' && source.catalogUrl === OFFICIAL_PANEL_SOURCE.catalogUrl
   );
-  return alreadyPresent ? config.sources : [...config.sources, OFFICIAL_PANEL_SOURCE];
-};
+
+const ensureOfficialSourcePresent = (config: PanelSourcesConfig): PanelSourceConfig[] =>
+  findOfficialSource(config) ? config.sources : [...config.sources, OFFICIAL_PANEL_SOURCE];
 
 const withPanelDeselected = (
   config: PanelSourcesConfig,
@@ -140,6 +149,7 @@ const PanelManagerDialog = ({
   const [catalogError, setCatalogError] = useState('');
   const [catalogLoading, setCatalogLoading] = useState(false);
   const installedIds = useMemo(() => installedPanels.map(panel => panel.id), [installedPanels]);
+  const officialSource = useMemo(() => (config ? findOfficialSource(config) : undefined), [config]);
   const panelRows = useMemo(() => {
     const rows = new Map<string, { id: string; name: string; description: string; available?: AvailablePanel; inCatalog: boolean }>();
     for (const entry of catalog ?? []) {
@@ -163,11 +173,11 @@ const PanelManagerDialog = ({
     setNotice('');
   }, [config]);
 
-  const loadCatalog = async (currentToken: string) => {
+  const loadCatalog = async (currentToken: string, source: RemotePanelSourceConfig) => {
     setCatalogLoading(true);
     setCatalogError('');
     try {
-      const result = await backend.listCatalog(currentToken, OFFICIAL_PANEL_SOURCE);
+      const result = await backend.listCatalog(currentToken, source);
       setCatalog(result.panels);
     } catch (nextError) {
       setCatalogError(nextError instanceof Error ? nextError.message : String(nextError));
@@ -184,7 +194,8 @@ const PanelManagerDialog = ({
       setConfig(result.config);
       if (result.startupError) setNotice(`The last startup install failed: ${result.startupError}`);
       storePanelManagerToken(token);
-      void loadCatalog(token);
+      const official = findOfficialSource(result.config);
+      if (official) void loadCatalog(token, official);
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : String(nextError));
     } finally {
@@ -348,11 +359,19 @@ const PanelManagerDialog = ({
                   </p>
                 </div>
               </div>
-              {catalogLoading && <p className="panel-manager-catalog-status">Checking the official catalog…</p>}
-              {!catalogLoading && catalogError && (
+              {!officialSource && (
+                <p className="panel-manager-catalog-status">
+                  This deployment installs panels from its own configured sources, so the official catalog is
+                  not offered here.
+                </p>
+              )}
+              {officialSource && catalogLoading && (
+                <p className="panel-manager-catalog-status">Checking the official catalog…</p>
+              )}
+              {officialSource && !catalogLoading && catalogError && (
                 <div className="panel-manager-catalog-error" role="alert">
                   <span>Couldn&apos;t load the official panel catalog: {catalogError}</span>
-                  <button type="button" onClick={() => void loadCatalog(token)}>
+                  <button type="button" onClick={() => void loadCatalog(token, officialSource)}>
                     Retry
                   </button>
                 </div>

--- a/src/panels/capabilityBroker.test.ts
+++ b/src/panels/capabilityBroker.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  isGrantedHostEndpointUrl,
   connectPanelCapabilityBroker,
   getGrantedPanelEndpoints,
   normalizeRosMessage,
   resourceMatches,
 } from './capabilityBroker';
 import type { ResolvedPanelManifest } from './types';
+import { resolveRuntimeEndpoints } from '../runtime/runtimeConfig';
 
 const manifest: ResolvedPanelManifest = {
   schemaVersion: 1,
@@ -235,6 +237,82 @@ describe('panel capability broker', () => {
     fetcher.mockRestore();
   });
 
+  // The gateway is granted by naming it, not by working it out from the video server, so a panel
+  // that asks for it directly gets exactly the same reach as one written before it had a name.
+  it('grants the stream gateway to a panel that names it, and nothing beside it', () => {
+    const endpoints = {
+      videoStream: 'https://robot.example:8080',
+      webrtcWhep: 'https://gateway.example:8889/',
+      webrtcDiscovery: 'https://gateway.example:9997/v3/paths/list',
+    };
+    const gatewayManifest: ResolvedPanelManifest = {
+      ...manifest,
+      permissions: { network: { hostEndpoints: ['webrtcWhep', 'webrtcDiscovery'] } },
+    };
+    const reaches = (url: string) => isGrantedHostEndpointUrl(gatewayManifest, endpoints, new URL(url));
+
+    expect(reaches('https://gateway.example:8889/camera/whep')).toBe(true);
+    expect(reaches('https://gateway.example:9997/v3/paths/list')).toBe(true);
+    // A gateway somewhere other than the robot is the point: nothing infers it from videoStream.
+    expect(reaches('https://robot.example:8889/camera/whep')).toBe(false);
+    expect(reaches('https://gateway.example:8889/admin')).toBe(false);
+    expect(reaches('https://gateway.example:9997/v3/config')).toBe(false);
+  });
+
+  // A media segment is not text: decoding it on the way through would corrupt the bytes and put
+  // any panel that plays media outside the broker, which is the only way out a panel has.
+  it('carries bytes through the broker without decoding them', async () => {
+    const segment = new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0xff, 0xfe, 0x80, 0x01]);
+    const port = {
+      onmessage: null as ((event: MessageEvent) => void) | null,
+      postMessage: vi.fn(),
+      start: vi.fn(),
+      close: vi.fn(),
+    } as unknown as MessagePort;
+    const fetcher = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      url: 'https://robot.example:8888/camera/seg1.mp4',
+      headers: new Headers({ 'content-type': 'video/mp4' }),
+      arrayBuffer: async () => segment.buffer,
+    } as Response);
+
+    const disconnect = connectPanelCapabilityBroker(
+      port,
+      {
+        manifest: {
+          ...manifest,
+          capabilities: ['network'],
+          permissions: { network: { hostEndpoints: ['webrtcHls'] } },
+        },
+        ros: null,
+        runtime: { target: 'desktop' },
+        runtimeEndpoints: { webrtcHls: 'https://robot.example:8888/' },
+        hostElement: document.createElement('div'),
+        logger: console,
+      },
+      vi.fn()
+    );
+
+    port.onmessage?.({
+      data: {
+        type: 'request',
+        requestId: 'segment',
+        method: 'network.fetch',
+        params: { url: 'https://robot.example:8888/camera/seg1.mp4' },
+      },
+    } as MessageEvent);
+
+    await vi.waitFor(() => expect(port.postMessage).toHaveBeenCalled());
+    const calls = (port.postMessage as ReturnType<typeof vi.fn>).mock.calls;
+    const [message] = calls[calls.length - 1];
+    expect(message.error).toBeUndefined();
+    expect(new Uint8Array(message.value.body)).toEqual(segment);
+
+    disconnect();
+    fetcher.mockRestore();
+  });
+
   it('limits a host endpoint grant to its known service routes', async () => {
     const endpointOnlyManifest: ResolvedPanelManifest = {
       ...manifest,
@@ -251,7 +329,7 @@ describe('panel capability broker', () => {
       statusText: 'OK',
       url: 'https://robot.example:8889/camera/whep',
       headers: new Headers({ 'content-type': 'application/sdp', server: 'private-server' }),
-      text: async () => 'answer',
+      arrayBuffer: async () => new TextEncoder().encode('answer').buffer,
     } as Response);
     const disconnect = connectPanelCapabilityBroker(
       port,
@@ -259,7 +337,11 @@ describe('panel capability broker', () => {
         manifest: endpointOnlyManifest,
         ros: null,
         runtime: { target: 'web' },
-        runtimeEndpoints: { videoStream: 'https://robot.example:8080' },
+        runtimeEndpoints: {
+          videoStream: 'https://robot.example:8080',
+          webrtcWhep: 'https://robot.example:8889/',
+          webrtcDiscovery: 'https://robot.example:9997/v3/paths/list',
+        },
         hostElement: document.createElement('div'),
         logger: console,
       },
@@ -300,5 +382,66 @@ describe('panel capability broker', () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
     disconnect();
     fetcher.mockRestore();
+  });
+});
+
+// The whole chain the WebRTC panel depends on, in one place: what the runtime resolves for a
+// deployment, what the panel builds from it, and whether the broker lets that through. It is wired
+// across three files and two repositories, so nothing else notices when one end moves.
+describe('stream gateway endpoints reach the panel', () => {
+  const gatewayManifest: ResolvedPanelManifest = {
+    ...manifest,
+    permissions: { network: { hostEndpoints: ['webrtcWhep', 'webrtcDiscovery'] } },
+  };
+
+  // Exactly what robo-boy-webrtc-panel does with the base it is handed.
+  const panelWhepUrl = (whepBase: string, streamPath: string) =>
+    new URL(`${streamPath}/whep`, new URL(whepBase, document.baseURI)).toString();
+
+  it.each([
+    // A domain connection is what actually stays on the same origin; an empty IP falls through to
+    // a direct localhost backend, which is a different deployment entirely.
+    ['browser behind the proxy', { ros2Option: 'domain' as const, ros2Value: 10 }, false],
+    ['packaged app, direct', { ros2Option: 'ip' as const, ros2Value: 'robot.local' }, true],
+  ])('grants what the panel builds for a %s', (_label, params, desktop) => {
+    const runtime = resolveRuntimeEndpoints(params, desktop, {
+      protocol: 'https:',
+      hostname: 'roboboy.test',
+      host: 'roboboy.test',
+    });
+    const endpoints = {
+      webrtcWhep: new URL(runtime.webrtcWhepBaseUrl, document.baseURI).href,
+      webrtcDiscovery: new URL(runtime.webrtcDiscoveryUrl, document.baseURI).href,
+    };
+
+    const whep = panelWhepUrl(endpoints.webrtcWhep, 'manipulator_wrist_camera');
+    expect(isGrantedHostEndpointUrl(gatewayManifest, endpoints, new URL(whep))).toBe(true);
+    expect(isGrantedHostEndpointUrl(gatewayManifest, endpoints, new URL(endpoints.webrtcDiscovery))).toBe(true);
+
+    // The gateway's other control routes stay out of reach in every deployment.
+    const control = new URL('../v3/config/global/get', endpoints.webrtcDiscovery).toString();
+    expect(isGrantedHostEndpointUrl(gatewayManifest, endpoints, new URL(control))).toBe(false);
+
+    // The HLS fallback is granted where the gateway is addressable directly, and simply does not
+    // exist behind the proxy -- a browser has WebRTC and never reaches for it.
+    const hlsManifest: ResolvedPanelManifest = {
+      ...manifest,
+      permissions: { network: { hostEndpoints: ['webrtcHls'] } },
+    };
+    const withHls = { ...endpoints, webrtcHls: runtime.webrtcHlsBaseUrl };
+    if (desktop) {
+      expect(runtime.webrtcHlsBaseUrl).toBe('http://robot.local:8888/');
+      for (const file of ['index.m3u8', 'video1_stream.m3u8', 'abc_video1_init.mp4', 'abc_video1_seg10.mp4']) {
+        const url = new URL(`manipulator_wrist_camera/${file}`, runtime.webrtcHlsBaseUrl);
+        expect(isGrantedHostEndpointUrl(hlsManifest, withHls, url)).toBe(true);
+      }
+      // Still one stream path deep: nothing else on that port is reachable.
+      const deep = new URL('manipulator_wrist_camera/nested/secret.mp4', runtime.webrtcHlsBaseUrl);
+      expect(isGrantedHostEndpointUrl(hlsManifest, withHls, deep)).toBe(false);
+    } else {
+      expect(runtime.webrtcHlsBaseUrl).toBe('');
+      const url = new URL('https://roboboy.test:8888/manipulator_wrist_camera/index.m3u8');
+      expect(isGrantedHostEndpointUrl(hlsManifest, withHls, url)).toBe(false);
+    }
   });
 });

--- a/src/panels/capabilityBroker.ts
+++ b/src/panels/capabilityBroker.ts
@@ -27,7 +27,7 @@ interface CapabilityBrokerOptions {
   manifest: ResolvedPanelManifest;
   ros: Ros | null;
   runtime: RoboBoyPanelRuntime;
-  runtimeEndpoints: { videoStream?: string };
+  runtimeEndpoints: GrantedRuntimeEndpoints;
   hostElement: HTMLElement;
   requestRosTopicSelection?: (
     topics: Array<{ name: string; messageType: string }>,
@@ -95,6 +95,14 @@ const requireResourcePermission = (
   return resource;
 };
 
+/** The host endpoints a panel may be granted, by the id its manifest names them with. */
+export interface GrantedRuntimeEndpoints {
+  videoStream?: string;
+  webrtcWhep?: string;
+  webrtcDiscovery?: string;
+  webrtcHls?: string;
+}
+
 const normalizeHeaders = (value: unknown): Record<string, string> => {
   if (value === undefined) return {};
   if (!value || typeof value !== 'object' || Array.isArray(value))
@@ -113,35 +121,54 @@ const normalizeHeaders = (value: unknown): Record<string, string> => {
   return headers;
 };
 
-const isVideoStreamEndpointUrl = (endpoint: string, url: URL): boolean => {
+/** The only shape a WHEP request takes: one stream path directly beneath the gateway. */
+const GATEWAY_WHEP_PATH = /^[A-Za-z0-9][A-Za-z0-9_-]*\/whep(?:\/.*)?$/;
+
+/** One stream path beneath the gateway, then a single playlist or segment file inside it. */
+const GATEWAY_HLS_PATH = /^[A-Za-z0-9][A-Za-z0-9_-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * Whether a URL sits beneath a granted endpoint, matching the rest of its path.
+ *
+ * The endpoint is whatever the runtime resolved -- a same-origin route behind the proxy, the
+ * gateway's own host and port without one -- so neither shape is written down here.
+ */
+const isBeneathEndpoint = (endpoint: string, url: URL, path: RegExp): boolean => {
   const base = new URL(endpoint, document.baseURI);
-  const proxyBacked =
-    endpoint.startsWith('/') || (base.origin === window.location.origin && base.pathname === '/video_stream');
-  if (proxyBacked) {
-    return (
-      url.origin === window.location.origin &&
-      (url.pathname === '/webrtc/_discovery/paths' ||
-        /^\/webrtc\/[A-Za-z0-9][A-Za-z0-9_-]*\/whep(?:\/.*)?$/.test(url.pathname))
-    );
-  }
-  if (url.protocol !== base.protocol || url.hostname !== base.hostname) return false;
-  if (url.port === '9997') return url.pathname === '/v3/paths/list';
-  return url.port === '8889' && /^\/[A-Za-z0-9][A-Za-z0-9_-]*\/whep(?:\/.*)?$/.test(url.pathname);
+  if (url.origin !== base.origin) return false;
+  const prefix = base.pathname.endsWith('/') ? base.pathname : `${base.pathname}/`;
+  return url.pathname.startsWith(prefix) && path.test(url.pathname.slice(prefix.length));
 };
 
-const isGrantedHostEndpointUrl = (
+const isEndpoint = (endpoint: string, url: URL): boolean =>
+  url.href === new URL(endpoint, document.baseURI).href;
+
+export const isGrantedHostEndpointUrl = (
   manifest: ResolvedPanelManifest,
-  runtimeEndpoints: { videoStream?: string },
+  runtimeEndpoints: GrantedRuntimeEndpoints,
   url: URL
-): boolean =>
-  (manifest.permissions?.network?.hostEndpoints || []).some(endpoint => {
-    const value = runtimeEndpoints[endpoint];
-    return endpoint === 'videoStream' && value ? isVideoStreamEndpointUrl(value, url) : false;
+): boolean => {
+  const { webrtcWhep, webrtcDiscovery, webrtcHls } = runtimeEndpoints;
+  const reachesGateway = () =>
+    (webrtcWhep ? isBeneathEndpoint(webrtcWhep, url, GATEWAY_WHEP_PATH) : false) ||
+    (webrtcDiscovery ? isEndpoint(webrtcDiscovery, url) : false);
+
+  return (manifest.permissions?.network?.hostEndpoints || []).some(endpoint => {
+    if (endpoint === 'webrtcWhep')
+      return webrtcWhep ? isBeneathEndpoint(webrtcWhep, url, GATEWAY_WHEP_PATH) : false;
+    if (endpoint === 'webrtcDiscovery') return webrtcDiscovery ? isEndpoint(webrtcDiscovery, url) : false;
+    if (endpoint === 'webrtcHls') return webrtcHls ? isBeneathEndpoint(webrtcHls, url, GATEWAY_HLS_PATH) : false;
+    // Panels published before the gateway had endpoints of its own ask for the video server and
+    // mean the gateway. They are answered from the gateway's endpoints rather than from a second
+    // account of where it lives.
+    if (endpoint === 'videoStream') return reachesGateway();
+    return false;
   });
+};
 
 const allowedNetworkUrl = (
   manifest: ResolvedPanelManifest,
-  runtimeEndpoints: { videoStream?: string },
+  runtimeEndpoints: GrantedRuntimeEndpoints,
   value: unknown
 ) => {
   if (typeof value !== 'string' || value.length > 4096) throw new Error('Network URL is invalid.');
@@ -169,18 +196,22 @@ const requireJsonPayload = (value: unknown, label: string): RoboBoyJsonObject =>
   return value;
 };
 
-const readBoundedResponseText = async (response: Response): Promise<string> => {
+/**
+ * Reads a response as bytes, under the same cap text was read under.
+ *
+ * Bytes are what a response actually is; text and JSON are readings of them. Decoding here instead
+ * would put a panel that wants media -- a video segment, an image, a point cloud -- outside the
+ * broker, which is the one way out a panel has.
+ */
+const readBoundedResponseBytes = async (response: Response): Promise<ArrayBuffer> => {
   if (!response.body) {
-    const body = await response.text();
-    if (new TextEncoder().encode(body).byteLength > MAX_NETWORK_BYTES) {
-      throw new Error('Network response is too large.');
-    }
-    return body;
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > MAX_NETWORK_BYTES) throw new Error('Network response is too large.');
+    return buffer;
   }
   const reader = response.body.getReader();
-  const decoder = new TextDecoder();
+  const chunks: Uint8Array[] = [];
   let size = 0;
-  let body = '';
   let streamComplete = false;
   try {
     while (!streamComplete) {
@@ -192,12 +223,18 @@ const readBoundedResponseText = async (response: Response): Promise<string> => {
         await reader.cancel();
         throw new Error('Network response is too large.');
       }
-      body += decoder.decode(value, { stream: true });
+      chunks.push(value);
     }
-    return body + decoder.decode();
   } finally {
     reader.releaseLock();
   }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body.buffer;
 };
 
 const respond = (port: MessagePort, requestId: string, value?: unknown, error?: unknown) => {
@@ -381,7 +418,7 @@ const handleRequest = async (
       if (Number.isFinite(declaredLength) && declaredLength > MAX_NETWORK_BYTES) {
         throw new Error('Network response is too large.');
       }
-      const body = await readBoundedResponseText(response);
+      const body = await readBoundedResponseBytes(response);
       return {
         status: response.status,
         statusText: response.statusText,
@@ -483,7 +520,7 @@ export const connectPanelCapabilityBroker = (
 
 export const getGrantedPanelEndpoints = (
   manifest: ResolvedPanelManifest,
-  runtimeEndpoints: { videoStream?: string }
+  runtimeEndpoints: GrantedRuntimeEndpoints
 ): Record<string, string> =>
   Object.fromEntries(
     (manifest.permissions?.network?.hostEndpoints || [])

--- a/src/panels/localPanelSeed.test.ts
+++ b/src/panels/localPanelSeed.test.ts
@@ -71,6 +71,24 @@ describe('bundled panel seeding', () => {
     expect(await store.read('bundled/la.tessel.roboboy.duck/1.0.0/index.js')).not.toBeNull();
   });
 
+  // A rebuilt panel keeps its version, so the store held bytes from the previous build for the
+  // life of the install -- and served them against a manifest they no longer matched.
+  it('replaces a stale bundle left by an earlier build of the same version', async () => {
+    const id = 'la.tessel.roboboy.duck';
+    const stalePath = `bundled/${id}/1.0.0/index.js`;
+    const store = createMemoryPanelStore({ [stalePath]: "export default { id: 'stale' };\n" });
+
+    const seeded = await seedLocalPanelsFromBundle(store, await buildFetcher([id]), BASE);
+
+    expect(seeded).toEqual([id]);
+    expect(await store.read(stalePath)).toBe(sourceFor(id));
+    // What the store serves now matches the integrity the registry files it under.
+    const registry = JSON.parse((await store.read(BUNDLED_PANEL_REGISTRY_PATH))!);
+    expect(await getSha256Integrity(new TextEncoder().encode((await store.read(stalePath))!))).toBe(
+      registry.panels[0].integrity
+    );
+  });
+
   it('never touches panels installed through the manager', async () => {
     const store = createMemoryPanelStore({ [LOCAL_PANEL_REGISTRY_PATH]: JSON.stringify(userInstalled) });
 

--- a/src/panels/localPanelSeed.ts
+++ b/src/panels/localPanelSeed.ts
@@ -48,7 +48,14 @@ export const seedLocalPanelsFromBundle = async (
 
   for (const manifest of candidates) {
     const path = `${BUNDLED_PANEL_PREFIX}${manifest.id}/${manifest.version}/index.js`;
-    const existing = await store.read(path);
+    const cached = await store.read(path);
+    // Reusing what the store already holds is an optimisation, never a way past verification: a
+    // rebuilt bundle keeps its version, so bytes that no longer match the manifest they are filed
+    // under would otherwise be served for the life of the install.
+    const existing =
+      cached !== null && (await getSha256Integrity(new TextEncoder().encode(cached))) === manifest.integrity
+        ? cached
+        : null;
     const source =
       existing ??
       (await (async () => {

--- a/src/panels/registry.ts
+++ b/src/panels/registry.ts
@@ -26,7 +26,7 @@ const PANEL_CAPABILITIES = new Set<RoboBoyPanelCapability>([
   'camera',
   'microphone',
 ]);
-const HOST_ENDPOINTS = new Set(['videoStream']);
+const HOST_ENDPOINTS = new Set(['videoStream', 'webrtcWhep', 'webrtcDiscovery', 'webrtcHls']);
 const ROS_RESOURCE_PATTERN = /^\/[A-Za-z0-9_~{}*][A-Za-z0-9_~{}/*-]*$/;
 
 interface ParseRegistryOptions {

--- a/src/panels/sandboxRuntime.test.ts
+++ b/src/panels/sandboxRuntime.test.ts
@@ -95,7 +95,8 @@ describe('panel sandbox document', () => {
             status: 200,
             statusText: 'OK',
             headers: { 'content-type': 'application/json' },
-            body: '{"stream":"ready"}',
+            // The host answers in bytes now; text and JSON are readings of them.
+            body: new TextEncoder().encode('{"stream":"ready"}').buffer,
           },
         };
         queueMicrotask(() =>
@@ -246,6 +247,7 @@ describe('panel sandbox document', () => {
     expect(response.statusText).toBe('OK');
     expect(response.headers.get('Content-Type')).toBe('application/json');
     await expect(response.text()).resolves.toBe('{"stream":"ready"}');
+    expect(new TextDecoder().decode(await response.arrayBuffer())).toBe('{"stream":"ready"}');
     await expect(response.json()).resolves.toEqual({ stream: 'ready' });
 
     const alreadyAborted = new AbortController();

--- a/src/panels/sandboxRuntime.ts
+++ b/src/panels/sandboxRuntime.ts
@@ -197,7 +197,10 @@ export const panelSandboxBootstrap = (parentOrigin: string) => {
                 cache: request.cache,
               },
               request.signal
-            )) as { status: number; statusText: string; headers: Record<string, string>; body: string };
+            )) as { status: number; statusText: string; headers: Record<string, string>; body: ArrayBuffer };
+            // The body arrives as bytes and stays that way; text and JSON are readings of it, and
+            // each reader gets its own copy so one cannot hand another a consumed buffer.
+            const decode = () => new TextDecoder().decode(response.body);
             return {
               ok: response.status >= 200 && response.status < 300,
               status: response.status,
@@ -205,8 +208,9 @@ export const panelSandboxBootstrap = (parentOrigin: string) => {
               headers: Object.freeze({
                 get: (name: string) => response.headers[name.toLowerCase()] ?? null,
               }),
-              text: async () => response.body,
-              json: async () => JSON.parse(response.body),
+              text: async () => decode(),
+              json: async () => JSON.parse(decode()),
+              arrayBuffer: async () => response.body.slice(0),
             };
           },
         }

--- a/src/panels/types.ts
+++ b/src/panels/types.ts
@@ -116,6 +116,9 @@ export interface PanelHostRuntime {
   target: RoboBoyPanelRuntime['target'];
   endpoints: {
     videoStream: string;
+    webrtcWhep: string;
+    webrtcDiscovery: string;
+    webrtcHls: string;
   };
 }
 

--- a/src/runtime/runtimeConfig.test.ts
+++ b/src/runtime/runtimeConfig.test.ts
@@ -19,6 +19,9 @@ describe('resolveRuntimeEndpoints', () => {
       videoStreamBaseUrl: '/video_stream',
       meshResourcesBaseUrl: '/mesh_resources',
       ollamaBaseUrl: '/ollama',
+      webrtcWhepBaseUrl: '/webrtc/',
+      webrtcHlsBaseUrl: '',
+      webrtcDiscoveryUrl: '/webrtc/_discovery/paths',
       mode: 'web',
       host: 'robot.local',
     });
@@ -36,6 +39,9 @@ describe('resolveRuntimeEndpoints', () => {
       videoStreamBaseUrl: 'http://192.168.1.20:8080',
       meshResourcesBaseUrl: 'http://192.168.1.20:8000',
       ollamaBaseUrl: 'http://192.168.1.20:11434',
+      webrtcWhepBaseUrl: 'http://192.168.1.20:8889/',
+      webrtcHlsBaseUrl: 'http://192.168.1.20:8888/',
+      webrtcDiscoveryUrl: 'http://192.168.1.20:9997/v3/paths/list',
       mode: 'web',
       host: '192.168.1.20',
     });
@@ -66,6 +72,9 @@ describe('resolveRuntimeEndpoints', () => {
       videoStreamBaseUrl: 'http://robot.tailnet.ts.net:8080',
       meshResourcesBaseUrl: 'http://robot.tailnet.ts.net:8000',
       ollamaBaseUrl: 'http://robot.tailnet.ts.net:11434',
+      webrtcWhepBaseUrl: 'http://robot.tailnet.ts.net:8889/',
+      webrtcHlsBaseUrl: 'http://robot.tailnet.ts.net:8888/',
+      webrtcDiscoveryUrl: 'http://robot.tailnet.ts.net:9997/v3/paths/list',
       mode: 'web',
       host: 'robot.tailnet.ts.net',
     });
@@ -85,6 +94,9 @@ describe('resolveRuntimeEndpoints', () => {
         videoStreamPort: '8080',
         meshResourcesPort: '8000',
         ollamaPort: '11434',
+        webrtcPort: '8889',
+        webrtcDiscoveryPort: '9997',
+  webrtcHlsPort: '8888',
         webBackendMode: 'proxy',
       }
     );
@@ -102,6 +114,9 @@ describe('resolveRuntimeEndpoints', () => {
       videoStreamBaseUrl: 'http://192.168.1.20:8080',
       meshResourcesBaseUrl: 'http://192.168.1.20:8000',
       ollamaBaseUrl: 'http://192.168.1.20:11434',
+      webrtcWhepBaseUrl: 'http://192.168.1.20:8889/',
+      webrtcHlsBaseUrl: 'http://192.168.1.20:8888/',
+      webrtcDiscoveryUrl: 'http://192.168.1.20:9997/v3/paths/list',
       mode: 'desktop',
       host: '192.168.1.20',
     });
@@ -128,7 +143,8 @@ describe('resolveRuntimeEndpoints', () => {
       videoStreamPort: '18080',
       meshResourcesPort: '18000',
       ollamaPort: '11435',
-      webBackendMode: 'auto',
+      webrtcPort: '8889', webrtcDiscoveryPort: '9997',
+  webrtcHlsPort: '8888', webBackendMode: 'auto',
     });
 
     expect(endpoints.rosbridgeUrl).toBe('ws://robot.local:19090');

--- a/src/runtime/runtimeConfig.tsx
+++ b/src/runtime/runtimeConfig.tsx
@@ -7,6 +7,21 @@ export interface RuntimeEndpoints {
   videoStreamBaseUrl: string;
   meshResourcesBaseUrl: string;
   ollamaBaseUrl: string;
+  /**
+   * The WebRTC stream gateway, named directly rather than worked out from the video server.
+   *
+   * It is a deployment of its own: it may run beside Robo-Boy, inside a simulator, or not at all,
+   * and a ROS stack with nothing else running is a perfectly good reason to want it. Everything
+   * that reaches it reads these, so where it lives is decided once, here.
+   */
+  webrtcWhepBaseUrl: string;
+  webrtcDiscoveryUrl: string;
+  /**
+   * The same stream over HLS, for webviews that cannot speak WebRTC at all. Empty where the
+   * gateway is not addressable directly, which is every browser behind the proxy -- and no loss,
+   * since a browser has WebRTC and never needs the fallback.
+   */
+  webrtcHlsBaseUrl: string;
   mode: 'web' | 'desktop';
   host: string;
 }
@@ -16,6 +31,9 @@ export interface RuntimePortConfig {
   videoStreamPort: string;
   meshResourcesPort: string;
   ollamaPort: string;
+  webrtcPort: string;
+  webrtcDiscoveryPort: string;
+  webrtcHlsPort: string;
   webBackendMode: 'auto' | 'proxy' | 'direct';
 }
 
@@ -42,6 +60,11 @@ export const getRuntimePortConfig = (): RuntimePortConfig => ({
   videoStreamPort: normalizeRuntimePort(import.meta.env.VITE_VIDEO_STREAM_PORT, '8080'),
   meshResourcesPort: normalizeRuntimePort(import.meta.env.VITE_MESH_RESOURCES_PORT, '8000'),
   ollamaPort: normalizeRuntimePort(import.meta.env.VITE_OLLAMA_PORT, '11434'),
+  // MediaMTX serves WHEP and its read-only path list on separate ports, so a gateway that is not
+  // the stock one can be reached without either of them being written into a caller.
+  webrtcPort: normalizeRuntimePort(import.meta.env.VITE_WEBRTC_PORT, '8889'),
+  webrtcDiscoveryPort: normalizeRuntimePort(import.meta.env.VITE_WEBRTC_DISCOVERY_PORT, '9997'),
+  webrtcHlsPort: normalizeRuntimePort(import.meta.env.VITE_WEBRTC_HLS_PORT, '8888'),
   webBackendMode: readWebBackendMode(import.meta.env.VITE_WEB_BACKEND_MODE),
 });
 
@@ -121,6 +144,9 @@ const resolveDirectEndpoints = (
     videoStreamBaseUrl: `${httpScheme}://${urlHost}:${ports.videoStreamPort}`,
     meshResourcesBaseUrl: `${httpScheme}://${urlHost}:${ports.meshResourcesPort}`,
     ollamaBaseUrl: `${httpScheme}://${urlHost}:${ports.ollamaPort}`,
+    webrtcWhepBaseUrl: `${httpScheme}://${urlHost}:${ports.webrtcPort}/`,
+    webrtcDiscoveryUrl: `${httpScheme}://${urlHost}:${ports.webrtcDiscoveryPort}/v3/paths/list`,
+    webrtcHlsBaseUrl: `${httpScheme}://${urlHost}:${ports.webrtcHlsPort}/`,
     mode,
     host,
   };
@@ -157,6 +183,12 @@ export function resolveRuntimeEndpoints(
       videoStreamBaseUrl: '/video_stream',
       meshResourcesBaseUrl: '/mesh_resources',
       ollamaBaseUrl: '/ollama',
+      // Same-origin, because a browser on an HTTPS page cannot reach the gateway's own ports.
+      webrtcWhepBaseUrl: '/webrtc/',
+      webrtcDiscoveryUrl: '/webrtc/_discovery/paths',
+      // No proxy route: the fallback exists for webviews without WebRTC, and every browser that
+      // reaches this branch has it. Nothing is published that nothing would use.
+      webrtcHlsBaseUrl: '',
       mode: 'web',
       host: location.hostname,
     };


### PR DESCRIPTION
## Summary

Promote the current dev branch to main for the next Robo-Boy release.

- decouple the WebRTC stream-gateway endpoints and add desktop HLS fallback support
- add byte broker responses, sandbox autoplay, bundled-panel integrity fixes, and Panel SDK 2.1.0
- include configurable physical gamepad publishing updates

The release version will be recorded from release-please after this promotion is merged.