### PR TITLE
feat: polish external panel manager UI and responsiveness

### DIFF
--- a/src/panels/PanelManagerDialog.css
+++ b/src/panels/PanelManagerDialog.css
@@ -4,9 +4,9 @@
   z-index: 12000;
   display: grid;
   place-items: center;
-  /* The dim covers the whole screen; the dialog inside it stays clear of the system's bars. */
   padding: calc(20px + var(--safe-area-top)) 20px calc(20px + var(--safe-area-bottom));
-  background: rgb(0 0 0 / 0.66);
+  background: rgb(0 0 0 / 0.7);
+  backdrop-filter: blur(3px);
 }
 
 .panel-manager-dialog,
@@ -15,7 +15,7 @@
 }
 
 .panel-manager-dialog {
-  width: min(920px, 100%);
+  width: min(940px, 100%);
   max-height: min(860px, calc(var(--safe-height) * 0.94));
   min-width: 0;
   display: flex;
@@ -24,33 +24,24 @@
   background: var(--card-bg);
   border: 1px solid var(--border-color);
   border-radius: 14px;
-  box-shadow: 0 24px 80px rgb(0 0 0 / 0.45);
+  box-shadow: 0 24px 80px rgb(0 0 0 / 0.48);
   overflow: hidden;
-}
-
-.panel-manager-dialog > header,
-.panel-manager-section-heading,
-.panel-manager-source-title,
-.panel-manager-installed li,
-.panel-manager-catalog li {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px 16px;
-}
-
-.panel-manager-installed li,
-.panel-manager-catalog li {
-  flex-wrap: wrap;
 }
 
 .panel-manager-dialog > header {
   min-width: 0;
-  padding: 18px 22px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  background: color-mix(in srgb, var(--background-secondary) 72%, var(--card-bg));
   border-bottom: 1px solid var(--border-color);
 }
 
-.panel-manager-dialog > header > div {
+.panel-manager-dialog > header > div,
+.panel-manager-section-heading > div,
+.panel-manager-panel-copy {
   min-width: 0;
 }
 
@@ -61,80 +52,22 @@
 }
 
 .panel-manager-dialog h2 {
-  font-size: 1.25rem;
+  margin-top: 2px;
+  font-size: 1.22rem;
+  line-height: 1.2;
 }
 
 .panel-manager-dialog h3 {
-  font-size: 1rem;
+  font-size: 0.98rem;
+  line-height: 1.25;
 }
 
 .panel-manager-kicker {
-  color: var(--text-color-secondary);
-  font-size: 0.72rem;
+  color: var(--primary-color);
+  font-size: 0.68rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.panel-manager-icon-button {
-  width: 34px;
-  height: 34px;
-  display: grid;
-  place-items: center;
-  padding: 0;
-  color: inherit;
-  background: transparent;
-  border: 0;
-  border-radius: 7px;
-  cursor: pointer;
-}
-
-.panel-manager-icon-button:hover {
-  background: var(--background-secondary);
-}
-
-.panel-manager-content {
-  min-width: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  padding: 20px 22px 28px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--primary-color) transparent;
-}
-
-.panel-manager-content::-webkit-scrollbar {
-  width: 6px;
-}
-
-.panel-manager-content::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.panel-manager-content::-webkit-scrollbar-thumb {
-  background-color: color-mix(in srgb, var(--primary-color) 58%, transparent);
-  border-radius: 3px;
-}
-
-.panel-manager-content::-webkit-scrollbar-thumb:hover {
-  background-color: var(--primary-color);
-}
-
-.panel-manager-content > section + section {
-  margin-top: 26px;
-  padding-top: 24px;
-  border-top: 1px solid var(--border-color);
-}
-
-.panel-manager-section-heading p,
-.panel-manager-unlock p {
-  margin-top: 4px;
-  color: var(--text-color-secondary);
-  font-size: 0.82rem;
-}
-
-.panel-manager-add-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  letter-spacing: 0.1em;
 }
 
 .panel-manager-dialog button,
@@ -148,48 +81,538 @@
   cursor: pointer;
 }
 
+.panel-manager-dialog button:disabled,
+.panel-manager-dialog input:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.panel-manager-dialog button:focus-visible,
+.panel-manager-dialog input:focus-visible,
+.panel-manager-dialog textarea:focus-visible,
+.panel-manager-dialog select:focus-visible,
+.panel-manager-disclosure > summary:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.panel-manager-icon-button {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  color: var(--text-color-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms ease;
+}
+
+.panel-manager-icon-button:hover:not(:disabled) {
+  color: var(--text-color);
+  background: color-mix(in srgb, var(--text-color) 8%, transparent);
+}
+
+.panel-manager-icon-button:active:not(:disabled) {
+  transform: scale(0.94);
+}
+
+.panel-manager-content {
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 18px 20px 24px;
+  overscroll-behavior: contain;
+}
+
+.panel-manager-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.panel-manager-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.panel-manager-content::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--primary-color) 55%, transparent);
+  border-radius: 999px;
+}
+
+.panel-manager-content > section + section,
+.panel-manager-content > section + .panel-manager-disclosure,
+.panel-manager-content > .panel-manager-disclosure + .panel-manager-disclosure,
+.panel-manager-content > .panel-manager-disclosure + section {
+  margin-top: 16px;
+}
+
+.panel-manager-section-heading,
+.panel-manager-source-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px 16px;
+}
+
+.panel-manager-section-heading p,
+.panel-manager-unlock p,
+.panel-manager-disclosure-description {
+  margin-top: 4px;
+  color: var(--text-color-secondary);
+  font-size: 0.79rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-auth-note {
+  opacity: 0.88;
+}
+
+.panel-manager-panel-count {
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  color: var(--text-color-secondary);
+  background: var(--background-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+.panel-manager-catalog {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 360px), 1fr));
+  gap: 9px;
+  padding: 0;
+  margin: 13px 0 0;
+  list-style: none;
+}
+
+.panel-manager-panel-card {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  background: color-mix(in srgb, var(--background-secondary) 58%, var(--card-bg));
+  border: 1px solid var(--border-color);
+  border-left: 3px solid var(--border-color);
+  border-radius: 9px;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.panel-manager-panel-card:hover {
+  border-color: color-mix(in srgb, var(--primary-color) 52%, var(--border-color));
+  box-shadow: 0 5px 16px rgb(0 0 0 / 0.1);
+  transform: translateY(-1px);
+}
+
+.panel-manager-panel-card[data-state='enabled'] {
+  border-left-color: var(--primary-color);
+}
+
+.panel-manager-panel-card[data-state='disabled'] {
+  border-left-color: var(--text-color-secondary);
+}
+
+.panel-manager-panel-card[data-state='pending-install'] {
+  border-left-color: var(--primary-color);
+  background: color-mix(in srgb, var(--primary-color) 7%, var(--card-bg));
+}
+
+.panel-manager-panel-card[data-state='pending-removal'] {
+  border-left-color: var(--error-color);
+  background: color-mix(in srgb, var(--error-color) 7%, var(--card-bg));
+}
+
+.panel-manager-panel-title {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.panel-manager-panel-title strong {
+  min-width: 0;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-version {
+  flex: 0 0 auto;
+  color: var(--text-color-secondary);
+  font-size: 0.68rem;
+}
+
+.panel-manager-panel-copy > p {
+  margin-top: 5px;
+  color: var(--text-color-secondary);
+  font-size: 0.76rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-panel-id {
+  display: block;
+  max-width: 100%;
+  margin-top: 6px;
+  color: var(--text-color-secondary);
+  font-size: 0.66rem;
+  line-height: 1.3;
+  opacity: 0.76;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-panel-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.panel-manager-panel-tags > span {
+  max-width: 100%;
+  padding: 3px 6px;
+  color: var(--text-color-secondary);
+  background: color-mix(in srgb, var(--text-color-secondary) 10%, transparent);
+  border-radius: 999px;
+  font-size: 0.63rem;
+  font-weight: 650;
+  line-height: 1.25;
+  letter-spacing: 0.025em;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-panel-tags [data-kind='installed'],
+.panel-manager-panel-tags [data-kind='pending'] {
+  color: var(--primary-darker-color);
+  background: color-mix(in srgb, var(--primary-color) 14%, transparent);
+}
+
+.panel-manager-panel-tags [data-kind='available'] {
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  background: transparent;
+}
+
+.panel-manager-panel-tags [data-kind='danger'] {
+  color: var(--error-color);
+  background: color-mix(in srgb, var(--error-color) 11%, transparent);
+}
+
+.panel-manager-bundled-note {
+  display: block;
+  margin-top: 6px;
+  color: var(--text-color-secondary);
+  font-size: 0.65rem;
+}
+
+.panel-manager-panel-actions {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 10px;
+}
+
+.panel-manager-button,
 .panel-manager-add-actions button,
-.panel-manager-installed button,
-.panel-manager-catalog button,
-.panel-manager-review button {
+.panel-manager-catalog-error button {
+  min-height: 32px;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 11px;
+  justify-content: center;
+  gap: 5px;
+  padding: 6px 9px;
   color: var(--text-color);
   background: var(--background-secondary);
   border: 1px solid var(--border-color);
   border-radius: 7px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.15;
+  white-space: nowrap;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 150ms ease;
+}
+
+.panel-manager-button:hover:not(:disabled),
+.panel-manager-add-actions button:hover:not(:disabled),
+.panel-manager-catalog-error button:hover:not(:disabled) {
+  color: var(--primary-color);
+  border-color: color-mix(in srgb, var(--primary-color) 58%, var(--border-color));
+}
+
+.panel-manager-button:active:not(:disabled),
+.panel-manager-add-actions button:active:not(:disabled),
+.panel-manager-catalog-error button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.panel-manager-install-button {
+  color: var(--button-text-color);
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+.panel-manager-install-button:hover:not(:disabled) {
+  color: var(--button-text-color);
+  background: var(--primary-hover-color);
+  border-color: var(--primary-hover-color);
+}
+
+.panel-manager-remove-button {
+  color: var(--error-color);
+  background: transparent;
+  border-color: color-mix(in srgb, var(--error-color) 42%, var(--border-color));
+}
+
+.panel-manager-remove-button:hover:not(:disabled) {
+  color: var(--error-color);
+  background: color-mix(in srgb, var(--error-color) 9%, transparent);
+  border-color: var(--error-color);
+}
+
+.panel-manager-toggle {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-color-secondary);
+  font-size: 0.7rem;
+  font-weight: 650;
+  cursor: pointer;
+  user-select: none;
+}
+
+.panel-manager-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.panel-manager-toggle-track {
+  width: 32px;
+  height: 18px;
+  flex: 0 0 32px;
+  display: block;
+  padding: 2px;
+  background: color-mix(in srgb, var(--text-color-secondary) 52%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-color-secondary) 55%, var(--border-color));
+  border-radius: 999px;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.panel-manager-toggle-track > span {
+  width: 12px;
+  height: 12px;
+  display: block;
+  background: var(--card-bg);
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.28);
+  transition: transform 160ms ease;
+}
+
+.panel-manager-toggle input:checked + .panel-manager-toggle-track {
+  background: var(--primary-color);
+  border-color: var(--primary-darker-color);
+}
+
+.panel-manager-toggle input:checked + .panel-manager-toggle-track > span {
+  transform: translateX(14px);
+}
+
+.panel-manager-toggle input:focus-visible + .panel-manager-toggle-track {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.panel-manager-toggle:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.panel-manager-catalog-status,
+.panel-manager-empty-state {
+  margin-top: 12px;
+  color: var(--text-color-secondary);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-empty-state {
+  padding: 14px;
+  text-align: center;
+  background: color-mix(in srgb, var(--background-secondary) 55%, transparent);
+  border: 1px dashed var(--border-color);
+  border-radius: 9px;
+}
+
+.panel-manager-empty-state strong {
+  color: var(--text-color);
+  font-size: 0.82rem;
+}
+
+.panel-manager-empty-state p {
+  margin-top: 3px;
+}
+
+.panel-manager-catalog-error {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 12px;
+  margin-top: 12px;
+  padding: 10px 11px;
+  color: var(--error-color);
+  background: color-mix(in srgb, var(--error-color) 8%, var(--card-bg));
+  border: 1px solid color-mix(in srgb, var(--error-color) 28%, var(--border-color));
+  border-radius: 8px;
+  font-size: 0.76rem;
+}
+
+.panel-manager-catalog-error span {
+  min-width: 0;
+  flex: 1 1 260px;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-disclosure {
+  min-width: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 9px;
+  overflow: clip;
+}
+
+.panel-manager-disclosure > summary {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  background: color-mix(in srgb, var(--background-secondary) 62%, var(--card-bg));
+  cursor: pointer;
+  list-style: none;
+  transition: background-color 150ms ease;
+}
+
+.panel-manager-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.panel-manager-disclosure > summary:hover {
+  background: var(--background-secondary);
+}
+
+.panel-manager-disclosure > summary > span {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.panel-manager-disclosure > summary strong {
+  font-size: 0.8rem;
+}
+
+.panel-manager-disclosure > summary small {
+  color: var(--text-color-secondary);
+  font-size: 0.67rem;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-disclosure > summary svg {
+  flex: 0 0 auto;
+  color: var(--text-color-secondary);
+  transition: transform 160ms ease;
+}
+
+.panel-manager-disclosure[open] > summary svg {
+  transform: rotate(180deg);
+}
+
+.panel-manager-disclosure-content {
+  min-width: 0;
+  padding: 12px;
+  border-top: 1px solid var(--border-color);
+}
+
+.panel-manager-add-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .panel-manager-sources {
   display: grid;
-  gap: 12px;
-  margin-top: 14px;
+  gap: 9px;
+  margin-top: 10px;
+}
+
+.panel-manager-sources:empty::before {
+  content: 'No sources configured.';
+  padding: 12px;
+  color: var(--text-color-secondary);
+  text-align: center;
+  border: 1px dashed var(--border-color);
+  border-radius: 8px;
+  font-size: 0.75rem;
 }
 
 .panel-manager-source {
-  padding: 14px;
-  background: color-mix(in srgb, var(--background-secondary) 66%, transparent);
+  min-width: 0;
+  padding: 11px;
+  background: color-mix(in srgb, var(--background-secondary) 48%, transparent);
   border: 1px solid var(--border-color);
-  border-radius: 10px;
+  border-radius: 8px;
+}
+
+.panel-manager-source-title strong {
+  min-width: 0;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
 }
 
 .panel-manager-fields,
 .panel-manager-selection {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 12px;
+  gap: 10px;
+  margin-top: 10px;
 }
 
 .panel-manager-fields label,
 .panel-manager-selection label,
 .panel-manager-unlock label {
+  min-width: 0;
   display: grid;
-  gap: 5px;
+  gap: 4px;
   color: var(--text-color-secondary);
-  font-size: 0.76rem;
+  font-size: 0.72rem;
 }
 
 .panel-manager-fields .wide,
@@ -201,102 +624,80 @@
 .panel-manager-dialog textarea,
 .panel-manager-dialog select {
   width: 100%;
-  padding: 9px 10px;
+  min-width: 0;
+  padding: 8px 9px;
   color: var(--text-color);
   background: var(--background-color);
   border: 1px solid var(--border-color);
   border-radius: 7px;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.panel-manager-dialog input:hover:not(:disabled),
+.panel-manager-dialog textarea:hover:not(:disabled),
+.panel-manager-dialog select:hover:not(:disabled) {
+  border-color: var(--border-color-light);
+}
+
+.panel-manager-dialog input:focus,
+.panel-manager-dialog textarea:focus,
+.panel-manager-dialog select:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color) 16%, transparent);
 }
 
 .panel-manager-dialog textarea {
-  min-height: 66px;
+  min-height: 62px;
   resize: vertical;
 }
 
-.panel-manager-installed {
-  display: grid;
-  gap: 7px;
-  padding: 0;
-  margin: 14px 0 0;
-  list-style: none;
-}
-
-.panel-manager-installed li {
-  padding: 9px 11px;
-  background: var(--background-secondary);
-  border-radius: 8px;
-}
-
-.panel-manager-installed span {
-  display: grid;
-  min-width: 0;
-  overflow-wrap: break-word;
-}
-
-.panel-manager-installed small {
-  color: var(--text-color-secondary);
-}
-
-.panel-manager-catalog {
-  display: grid;
-  gap: 7px;
-  padding: 0;
-  margin: 14px 0 0;
-  list-style: none;
-}
-
-.panel-manager-catalog li {
-  padding: 9px 11px;
-  background: var(--background-secondary);
-  border-radius: 8px;
-}
-
-.panel-manager-catalog span {
-  display: grid;
-  min-width: 0;
-  overflow-wrap: break-word;
-}
-
-.panel-manager-catalog small {
-  color: var(--text-color-secondary);
-}
-
-.panel-manager-catalog-status {
-  margin: 14px 0 0;
-  color: var(--text-color-secondary);
-  font-size: 0.82rem;
-  overflow-wrap: break-word;
+.panel-manager-review {
+  padding: 13px;
+  background: color-mix(in srgb, var(--background-secondary) 50%, transparent);
+  border: 1px solid var(--border-color);
+  border-radius: 9px;
 }
 
 .panel-manager-change-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: 7px;
-  margin-top: 14px;
+  gap: 6px;
+  margin-top: 12px;
+  color: var(--text-color-secondary);
+  font-size: 0.76rem;
 }
 
 .panel-manager-change-summary span {
-  padding: 6px 9px;
+  max-width: 100%;
+  padding: 5px 8px;
+  color: var(--primary-darker-color);
+  background: color-mix(in srgb, var(--primary-color) 13%, transparent);
   border-radius: 999px;
-  background: var(--background-secondary);
-  font-size: 0.78rem;
+  text-transform: capitalize;
+  overflow-wrap: anywhere;
 }
 
 .panel-manager-change-summary [data-change='remove'] {
   color: var(--error-color);
+  background: color-mix(in srgb, var(--error-color) 10%, transparent);
 }
 
 .panel-manager-permissions {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 10px;
-  margin-top: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 8px;
+  margin-top: 10px;
 }
 
 .panel-manager-permissions article {
-  padding: 12px;
+  min-width: 0;
+  padding: 10px;
+  background: var(--card-bg);
   border: 1px solid var(--border-color);
-  border-radius: 9px;
+  border-radius: 8px;
+  overflow-wrap: anywhere;
 }
 
 .panel-manager-permissions small {
@@ -304,39 +705,21 @@
 }
 
 .panel-manager-permissions ul {
-  padding-left: 18px;
-  margin: 8px 0 0;
+  padding-left: 17px;
+  margin: 7px 0 0;
   color: var(--text-color-secondary);
-  font-size: 0.78rem;
-}
-
-.panel-manager-unlock {
-  width: min(460px, 100%);
-  display: grid;
-  gap: 14px;
-  align-self: center;
-  padding: 34px 22px;
-}
-
-.panel-manager-primary {
-  justify-content: center;
-  padding: 10px 14px !important;
-  color: white !important;
-  background: var(--primary-color) !important;
-  border-color: transparent !important;
-}
-
-.panel-manager-apply {
-  width: 100%;
-  margin-top: 14px;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .panel-manager-confirmation {
   display: flex;
   align-items: flex-start;
-  gap: 0.55rem;
-  font-size: 0.82rem;
-  line-height: 1.35;
+  gap: 8px;
+  margin-top: 12px;
+  font-size: 0.76rem;
+  line-height: 1.4;
   cursor: pointer;
 }
 
@@ -344,62 +727,143 @@
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
-  margin: 0.15rem 0 0;
+  margin: 2px 0 0;
+  padding: 0;
   accent-color: var(--primary-color);
 }
 
 .panel-manager-confirmation span {
   min-width: 0;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.panel-manager-unlock {
+  width: min(460px, 100%);
+  display: grid;
+  gap: 13px;
+  align-self: center;
+  padding: 34px 22px;
+}
+
+.panel-manager-load-error {
+  justify-items: start;
+}
+
+.panel-manager-load-error strong {
+  color: var(--error-color);
+  font-size: 0.9rem;
+}
+
+.panel-manager-inline-error {
+  padding: 8px 9px;
+  color: var(--error-color) !important;
+  background: color-mix(in srgb, var(--error-color) 8%, var(--card-bg));
+  border: 1px solid color-mix(in srgb, var(--error-color) 28%, var(--border-color));
+  border-radius: 7px;
+}
+
+.panel-manager-loading {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+}
+
+.panel-manager-loading strong {
+  font-size: 0.9rem;
+}
+
+.panel-manager-spinner {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--primary-color);
+  border-radius: 50%;
+  animation: panel-manager-spin 700ms linear infinite;
+}
+
+@keyframes panel-manager-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.panel-manager-primary {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  color: var(--button-text-color);
+  background: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  border-radius: 7px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 150ms ease;
+}
+
+.panel-manager-primary:hover:not(:disabled) {
+  background: var(--primary-hover-color);
+  border-color: var(--primary-hover-color);
+}
+
+.panel-manager-primary:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.panel-manager-apply {
+  width: 100%;
+  margin-top: 11px;
 }
 
 .panel-manager-message {
-  padding: 10px 22px;
+  padding: 10px 20px;
   color: var(--text-color);
   background: var(--background-secondary);
   border-top: 1px solid var(--border-color);
-  font-size: 0.82rem;
-  overflow-wrap: break-word;
+  font-size: 0.76rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .panel-manager-message.error {
   color: var(--error-color);
+  background: color-mix(in srgb, var(--error-color) 8%, var(--card-bg));
 }
 
-.panel-manager-catalog-error {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px 12px;
-  margin: 14px 0 0;
-  padding: 9px 11px;
-  color: var(--error-color);
-  background: var(--background-secondary);
-  border-radius: 8px;
-  font-size: 0.82rem;
-}
-
-.panel-manager-catalog-error span {
-  min-width: 0;
-  overflow-wrap: break-word;
-}
-
-@media (max-width: 768px) {
+@media (max-width: 720px) {
   .panel-manager-backdrop {
     padding: var(--safe-area-top) 0 var(--safe-area-bottom);
   }
 
   .panel-manager-dialog {
     width: 100%;
-    max-height: var(--safe-height);
     height: var(--safe-height);
+    max-height: var(--safe-height);
+    border-right: 0;
+    border-left: 0;
     border-radius: 0;
   }
 
+  .panel-manager-dialog > header {
+    padding: 13px 15px;
+  }
+
+  .panel-manager-content {
+    padding: 14px 15px 20px;
+  }
+}
+
+@media (max-width: 560px) {
   .panel-manager-section-heading {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .panel-manager-panel-count {
+    align-self: flex-start;
   }
 
   .panel-manager-fields,
@@ -412,22 +876,49 @@
     grid-column: auto;
   }
 
-  .panel-manager-permissions {
-    grid-template-columns: 1fr;
+  .panel-manager-review .panel-manager-button {
+    width: 100%;
+  }
+
+  .panel-manager-disclosure-content {
+    padding: 10px;
   }
 }
 
-/* Origin and state for one panel: secondary to its name, but always visible. */
-.panel-manager-catalog-tags {
-  margin-top: 2px;
-  color: var(--text-muted-color, #6c757d);
-  font-variant: all-small-caps;
-  letter-spacing: 0.04em;
+@media (max-width: 360px) {
+  .panel-manager-dialog > header,
+  .panel-manager-content,
+  .panel-manager-message {
+    padding-right: 11px;
+    padding-left: 11px;
+  }
+
+  .panel-manager-panel-card {
+    padding: 10px;
+  }
+
+  .panel-manager-panel-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .panel-manager-toggle {
+    min-height: 32px;
+    justify-content: space-between;
+  }
+
+  .panel-manager-panel-actions .panel-manager-button {
+    width: 100%;
+  }
 }
 
-/* Who can install panels here: stated where the installing happens. */
-.panel-manager-auth-note {
-  margin-top: 6px;
-  color: var(--text-muted-color, #6c757d);
-  font-size: 0.85em;
+@media (prefers-reduced-motion: reduce) {
+  .panel-manager-dialog *,
+  .panel-manager-dialog *::before,
+  .panel-manager-dialog *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }

--- a/src/panels/PanelManagerDialog.test.tsx
+++ b/src/panels/PanelManagerDialog.test.tsx
@@ -89,10 +89,7 @@ describe('PanelManagerDialog', () => {
     // Removing from the panel list previews the change straight away.
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
     await screen.findByText('remove Telemetry@2.0.0');
-    expect(api.preview).toHaveBeenCalledWith(
-      '',
-      expect.objectContaining({ selection: { mode: 'none' } })
-    );
+    expect(api.preview).toHaveBeenCalledWith('', expect.objectContaining({ selection: { mode: 'none' } }));
     expect(api.apply).not.toHaveBeenCalled();
 
     const applyButton = screen.getByRole('button', { name: 'Apply this exact plan' });
@@ -153,7 +150,7 @@ describe('PanelManagerDialog', () => {
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0]);
     await waitFor(() => expect(api.preview).toHaveBeenCalledTimes(1));
-    // The first panel now reads "Keep", so this is the second one.
+    // The first panel now reads "Keep installed", so this is the second one.
     fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0]);
 
     await waitFor(() =>
@@ -300,7 +297,9 @@ describe('PanelManagerDialog', () => {
     expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Install' })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Disable' }));
+    const toggle = screen.getByRole('switch', { name: 'Telemetry enabled' });
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
 
     expect(onPanelEnabledChange).toHaveBeenCalledWith('com.example.telemetry', false);
   });
@@ -323,7 +322,78 @@ describe('PanelManagerDialog', () => {
 
     expect(screen.queryByRole('button', { name: 'Install' })).not.toBeInTheDocument();
     expect(screen.queryByText(/Not installed/)).not.toBeInTheDocument();
-    expect(screen.getByText(/ships with this build/)).toBeInTheDocument();
+    expect(screen.getByText(/Ships with this build/)).toBeInTheDocument();
+  });
+
+  it('makes disabled and available states explicit', async () => {
+    api.catalog.mockResolvedValue({
+      panels: [
+        {
+          id: secondPanel.id,
+          name: secondPanel.name,
+          description: secondPanel.description,
+          version: secondPanel.version,
+        },
+      ],
+    });
+    render(
+      <PanelManagerDialog
+        installedPanels={[panel]}
+        availablePanels={[{ manifest: panel, origin: 'installed', isEnabled: false } as AvailablePanel]}
+        onPanelEnabledChange={vi.fn()}
+        onClose={vi.fn()}
+        onApplied={vi.fn()}
+      />
+    );
+
+    await screen.findByText('Camera');
+
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Telemetry enabled' })).not.toBeChecked();
+    expect(screen.getByText('Installed')).toBeInTheDocument();
+    expect(screen.getByText('Available')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Install' })).toBeEnabled();
+  });
+
+  it('shows pending install and removal states after verification', async () => {
+    const officialSummary = {
+      id: secondPanel.id,
+      name: secondPanel.name,
+      description: secondPanel.description,
+      version: secondPanel.version,
+    };
+    api.catalog.mockResolvedValue({ panels: [officialSummary] });
+    api.preview
+      .mockResolvedValueOnce({
+        planId: 'install-plan',
+        expiresInSeconds: 600,
+        panels: [secondPanel],
+        changes: [{ type: 'add', panel: secondPanel }],
+      })
+      .mockResolvedValueOnce({
+        planId: 'remove-plan',
+        expiresInSeconds: 600,
+        panels: [secondPanel],
+        changes: [{ type: 'remove', panel }],
+      });
+    render(
+      <PanelManagerDialog
+        installedPanels={[panel]}
+        availablePanels={availableFrom([panel])}
+        onPanelEnabledChange={vi.fn()}
+        onClose={vi.fn()}
+        onApplied={vi.fn()}
+      />
+    );
+
+    await screen.findByText('Camera');
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }));
+    expect(await screen.findByText('Pending install')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel install' })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(await screen.findByText('Pending removal')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Keep installed' })).toBeEnabled();
   });
 
   it('does not offer the official catalog on a deployment that does not configure it', async () => {
@@ -364,13 +434,34 @@ describe('PanelManagerDialog', () => {
       />
     );
 
-
     await screen.findByText("Couldn't load the official panel catalog: network down");
 
     api.catalog.mockResolvedValueOnce({ panels: [] });
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 
     await waitFor(() => expect(api.catalog).toHaveBeenCalledTimes(2));
+  });
+
+  it('replaces the startup loading state with a recoverable error', async () => {
+    api.load.mockRejectedValueOnce(new Error('deployment offline'));
+    render(
+      <PanelManagerDialog
+        installedPanels={[]}
+        availablePanels={availableFrom([])}
+        onPanelEnabledChange={vi.fn()}
+        onClose={vi.fn()}
+        onApplied={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText("Couldn't load panels")).toBeInTheDocument();
+    expect(screen.getByText('deployment offline')).toBeInTheDocument();
+    expect(screen.queryByText('Loading panels')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await screen.findByText('Panel sources');
+    expect(api.load).toHaveBeenCalledTimes(2);
   });
 
   it('does not duplicate the official source when it is already configured under a custom name', async () => {

--- a/src/panels/PanelManagerDialog.tsx
+++ b/src/panels/PanelManagerDialog.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { FiPlus, FiTrash2, FiX } from 'react-icons/fi';
+import { FiChevronDown, FiPlus, FiTrash2, FiX } from 'react-icons/fi';
 import { useRuntimeConfig } from '../runtime/runtimeConfig';
 import { createLocalPanelManagerBackend, remotePanelManagerBackend } from './managerBackend';
 import { OFFICIAL_PANEL_SOURCE } from './constants';
 import {
-  applyPanelManagerPlan,
-  listPanelCatalog,
-  loadPanelManagerConfig,
-  previewPanelManagerConfig,
   type CatalogPanelSummary,
   type PanelInstallPreview,
   type PanelSourceConfig,
@@ -122,6 +118,30 @@ const storePanelManagerToken = (value: string) => {
   }
 };
 
+interface PanelToggleProps {
+  panelName: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+const PanelToggle = ({ panelName, checked, disabled, onChange }: PanelToggleProps) => (
+  <label className="panel-manager-toggle">
+    <span className="panel-manager-toggle-label">{checked ? 'Enabled' : 'Disabled'}</span>
+    <input
+      type="checkbox"
+      role="switch"
+      aria-label={`${panelName} enabled`}
+      checked={checked}
+      disabled={disabled}
+      onChange={event => onChange(event.target.checked)}
+    />
+    <span className="panel-manager-toggle-track" aria-hidden="true">
+      <span />
+    </span>
+  </label>
+);
+
 const PanelManagerDialog = ({
   installedPanels,
   availablePanels,
@@ -151,17 +171,43 @@ const PanelManagerDialog = ({
   const installedIds = useMemo(() => installedPanels.map(panel => panel.id), [installedPanels]);
   const officialSource = useMemo(() => (config ? findOfficialSource(config) : undefined), [config]);
   const panelRows = useMemo(() => {
-    const rows = new Map<string, { id: string; name: string; description: string; available?: AvailablePanel; inCatalog: boolean }>();
+    const rows = new Map<
+      string,
+      {
+        id: string;
+        name: string;
+        description: string;
+        version: string;
+        available?: AvailablePanel;
+        inCatalog: boolean;
+      }
+    >();
     for (const entry of catalog ?? []) {
-      rows.set(entry.id, { id: entry.id, name: entry.name, description: entry.description, inCatalog: true });
+      rows.set(entry.id, {
+        id: entry.id,
+        name: entry.name,
+        description: entry.description,
+        version: entry.version,
+        inCatalog: true,
+      });
     }
     for (const panel of availablePanels) {
-      const { id, name, description } = panel.manifest;
-      rows.set(id, { id, name, description, available: panel, inCatalog: rows.get(id)?.inCatalog ?? false });
+      const { id, name, description, version } = panel.manifest;
+      rows.set(id, {
+        id,
+        name,
+        description,
+        version,
+        available: panel,
+        inCatalog: rows.get(id)?.inCatalog ?? false,
+      });
     }
     return [...rows.values()];
   }, [availablePanels, catalog]);
+  const installedCount = panelRows.filter(row => row.available).length;
+  const availableCount = panelRows.length - installedCount;
   const skipNextResetRef = useRef(false);
+  const [pendingPanelId, setPendingPanelId] = useState<string | null>(null);
 
   useEffect(() => {
     if (skipNextResetRef.current) {
@@ -240,10 +286,11 @@ const PanelManagerDialog = ({
     setConfig({ ...config, sources: [...config.sources, source] });
   };
 
-  const requestPreview = async (overrideConfig?: PanelSourcesConfig) => {
+  const requestPreview = async (overrideConfig?: PanelSourcesConfig, panelId?: string) => {
     const target = overrideConfig ?? config;
     if (!target) return;
     setBusy(true);
+    setPendingPanelId(panelId ?? null);
     setError('');
     setNotice('');
     try {
@@ -256,17 +303,18 @@ const PanelManagerDialog = ({
       setError(nextError instanceof Error ? nextError.message : String(nextError));
     } finally {
       setBusy(false);
+      setPendingPanelId(null);
     }
   };
 
   const installCatalogPanel = (panelId: string) => {
     if (!config) return;
-    void requestPreview(withCatalogPanelSelected(config, installedIds, panelId));
+    void requestPreview(withCatalogPanelSelected(config, installedIds, panelId), panelId);
   };
 
   const removeCatalogPanel = (panelId: string) => {
     if (!config) return;
-    void requestPreview(withPanelDeselected(config, installedIds, panelId));
+    void requestPreview(withPanelDeselected(config, installedIds, panelId), panelId);
   };
 
   const applyPreview = async () => {
@@ -310,16 +358,17 @@ const PanelManagerDialog = ({
         </header>
 
         {!config ? (
-          requiresToken !== true ? (
-            <div className="panel-manager-unlock">
-              <p>Loading installed panels…</p>
-            </div>
-          ) : (
+          requiresToken === true ? (
             <div className="panel-manager-unlock">
               <p>
                 Enter the deployment token. It's remembered in this browser so you won't need to re-enter it here next
                 time.
               </p>
+              {error && (
+                <p className="panel-manager-inline-error" role="alert">
+                  {error}
+                </p>
+              )}
               <label>
                 Panel manager token
                 <input
@@ -339,17 +388,30 @@ const PanelManagerDialog = ({
                 {busy ? 'Checking…' : 'Unlock'}
               </button>
             </div>
+          ) : error ? (
+            <div className="panel-manager-unlock panel-manager-load-error" role="alert">
+              <strong>Couldn&apos;t load panels</strong>
+              <p>{error}</p>
+              <button type="button" className="panel-manager-button" onClick={() => void unlock()} disabled={busy}>
+                {busy ? 'Retrying…' : 'Retry'}
+              </button>
+            </div>
+          ) : (
+            <div className="panel-manager-unlock panel-manager-loading" role="status">
+              <span className="panel-manager-spinner" aria-hidden="true" />
+              <div>
+                <strong>Loading panels</strong>
+                <p>Checking this deployment and its configured sources…</p>
+              </div>
+            </div>
           )
         ) : (
           <div className="panel-manager-content">
-            <section>
+            <section className="panel-manager-panels-section">
               <div className="panel-manager-section-heading">
                 <div>
                   <h3>Panels</h3>
-                  <p>
-                    Everything this app can run, with where it came from. Official and custom panels can be
-                    installed or removed; panels that ship with the build can be switched off but not removed.
-                  </p>
+                  <p>Install panels for this deployment, then switch installed panels on or off for this browser.</p>
                   <p className="panel-manager-auth-note">
                     {isDesktopRuntime
                       ? 'Panels install into this app only; nothing is sent to the robot.'
@@ -358,15 +420,26 @@ const PanelManagerDialog = ({
                         : 'Installing needs no token: anyone who can reach this deployment can add a panel. Set ROBOBOY_PANEL_MANAGER_TOKEN on it to require one.'}
                   </p>
                 </div>
+                {panelRows.length > 0 && (
+                  <span
+                    className="panel-manager-panel-count"
+                    aria-label={`${installedCount} installed, ${availableCount} available`}
+                  >
+                    {installedCount} installed
+                    {availableCount > 0 ? ` · ${availableCount} available` : ''}
+                  </span>
+                )}
               </div>
               {!officialSource && (
-                <p className="panel-manager-catalog-status">
-                  This deployment installs panels from its own configured sources, so the official catalog is
-                  not offered here.
+                <p className="panel-manager-catalog-status panel-manager-empty-state">
+                  This deployment installs panels from its own configured sources, so the official catalog is not
+                  offered here.
                 </p>
               )}
               {officialSource && catalogLoading && (
-                <p className="panel-manager-catalog-status">Checking the official catalog…</p>
+                <p className="panel-manager-catalog-status" role="status">
+                  Checking the official catalog…
+                </p>
               )}
               {officialSource && !catalogLoading && catalogError && (
                 <div className="panel-manager-catalog-error" role="alert">
@@ -377,7 +450,10 @@ const PanelManagerDialog = ({
                 </div>
               )}
               {!catalogLoading && panelRows.length === 0 && (
-                <p className="panel-manager-catalog-status">No panels are available right now.</p>
+                <div className="panel-manager-empty-state">
+                  <strong>No panels available</strong>
+                  <p>There are no installed panels or panels offered by the configured catalog right now.</p>
+                </div>
               )}
               {panelRows.length > 0 && (
                 <ul className="panel-manager-catalog">
@@ -387,41 +463,96 @@ const PanelManagerDialog = ({
                     const isManaged = installedIds.includes(row.id);
                     const selected = isManaged && isEffectivelySelected(config, row.id);
                     const origin = isBundled ? 'Bundled' : row.inCatalog ? 'Official' : 'Custom';
-                    const state = !available ? 'Not installed' : available.isEnabled ? 'Enabled' : 'Disabled';
+                    const plannedChange = preview?.changes.find(change => change.panel.id === row.id)?.type;
+                    const isPendingInstall = plannedChange === 'add';
+                    const isPendingRemoval = plannedChange === 'remove';
+                    const isPendingUpdate = plannedChange === 'update';
                     return (
-                      <li key={row.id}>
-                        <span>
-                          <strong>{row.name}</strong>
-                          <small>{row.description}</small>
-                          <small className="panel-manager-catalog-tags">
-                            {origin} · {state}
-                            {isBundled ? ' · ships with this build' : ''}
-                          </small>
-                        </span>
-                        {available && (
-                          <button
-                            type="button"
-                            onClick={() => onPanelEnabledChange(row.id, !available.isEnabled)}
-                            disabled={busy}
-                          >
-                            {available.isEnabled ? 'Disable' : 'Enable'}
-                          </button>
-                        )}
-                        {!available && row.inCatalog && (
-                          <button type="button" onClick={() => installCatalogPanel(row.id)} disabled={busy}>
-                            Install
-                          </button>
-                        )}
-                        {available && !isBundled && isManaged && selected && (
-                          <button type="button" onClick={() => removeCatalogPanel(row.id)} disabled={busy}>
-                            Remove
-                          </button>
-                        )}
-                        {available && !isBundled && isManaged && !selected && (
-                          <button type="button" onClick={() => installCatalogPanel(row.id)} disabled={busy}>
-                            Keep
-                          </button>
-                        )}
+                      <li
+                        key={row.id}
+                        className="panel-manager-panel-card"
+                        data-state={
+                          isPendingRemoval
+                            ? 'pending-removal'
+                            : isPendingInstall || isPendingUpdate
+                              ? 'pending-install'
+                              : available?.isEnabled
+                                ? 'enabled'
+                                : available
+                                  ? 'disabled'
+                                  : 'available'
+                        }
+                      >
+                        <div className="panel-manager-panel-copy">
+                          <div className="panel-manager-panel-title">
+                            <strong>{row.name}</strong>
+                            <span className="panel-manager-version">v{row.version}</span>
+                          </div>
+                          <p>{row.description || 'No description provided.'}</p>
+                          <span className="panel-manager-panel-id" title={row.id}>
+                            {row.id}
+                          </span>
+                          <div className="panel-manager-panel-tags" aria-label="Panel status">
+                            <span data-kind="origin">{origin}</span>
+                            <span data-kind={available ? 'installed' : 'available'}>
+                              {available ? 'Installed' : 'Available'}
+                            </span>
+                            {isPendingInstall && <span data-kind="pending">Pending install</span>}
+                            {isPendingRemoval && <span data-kind="danger">Pending removal</span>}
+                            {isPendingUpdate && <span data-kind="pending">Update ready</span>}
+                          </div>
+                          {isBundled && <small className="panel-manager-bundled-note">Ships with this build</small>}
+                        </div>
+                        <div className="panel-manager-panel-actions">
+                          {available && (
+                            <PanelToggle
+                              panelName={row.name}
+                              checked={available.isEnabled}
+                              disabled={busy}
+                              onChange={isEnabled => onPanelEnabledChange(row.id, isEnabled)}
+                            />
+                          )}
+                          {!available && row.inCatalog && !isPendingInstall && (
+                            <button
+                              type="button"
+                              className="panel-manager-button panel-manager-install-button"
+                              onClick={() => installCatalogPanel(row.id)}
+                              disabled={busy}
+                            >
+                              {busy && pendingPanelId === row.id ? 'Preparing…' : 'Install'}
+                            </button>
+                          )}
+                          {!available && row.inCatalog && isPendingInstall && (
+                            <button
+                              type="button"
+                              className="panel-manager-button"
+                              onClick={() => removeCatalogPanel(row.id)}
+                              disabled={busy}
+                            >
+                              {busy && pendingPanelId === row.id ? 'Preparing…' : 'Cancel install'}
+                            </button>
+                          )}
+                          {available && !isBundled && isManaged && selected && !isPendingRemoval && (
+                            <button
+                              type="button"
+                              className="panel-manager-button panel-manager-remove-button"
+                              onClick={() => removeCatalogPanel(row.id)}
+                              disabled={busy}
+                            >
+                              {busy && pendingPanelId === row.id ? 'Preparing…' : 'Remove'}
+                            </button>
+                          )}
+                          {available && !isBundled && isManaged && (!selected || isPendingRemoval) && (
+                            <button
+                              type="button"
+                              className="panel-manager-button"
+                              onClick={() => installCatalogPanel(row.id)}
+                              disabled={busy}
+                            >
+                              {busy && pendingPanelId === row.id ? 'Preparing…' : 'Keep installed'}
+                            </button>
+                          )}
+                        </div>
                       </li>
                     );
                   })}
@@ -429,175 +560,192 @@ const PanelManagerDialog = ({
               )}
             </section>
 
-            <section>
-              <div className="panel-manager-section-heading">
-                <div>
-                  <h3>Sources</h3>
+            <details className="panel-manager-disclosure">
+              <summary>
+                <span>
+                  <strong>Panel sources</strong>
+                  <small>{config.sources.length} configured · Advanced</small>
+                </span>
+                <FiChevronDown aria-hidden="true" />
+              </summary>
+              <div className="panel-manager-disclosure-content">
+                <div className="panel-manager-section-heading">
                   <p>Credentials stay in server environment variables; this form stores only their names.</p>
+                  <div className="panel-manager-add-actions">
+                    <button type="button" onClick={() => addSource('remote')}>
+                      <FiPlus /> Remote
+                    </button>
+                    <button type="button" onClick={() => addSource('local')}>
+                      <FiPlus /> Local
+                    </button>
+                  </div>
                 </div>
-                <div className="panel-manager-add-actions">
-                  <button type="button" onClick={() => addSource('remote')}>
-                    <FiPlus /> Remote
-                  </button>
-                  <button type="button" onClick={() => addSource('local')}>
-                    <FiPlus /> Local
-                  </button>
+                <div className="panel-manager-sources">
+                  {config.sources.map((source, index) => (
+                    <article key={`${source.type}-${index}`} className="panel-manager-source">
+                      <div className="panel-manager-source-title">
+                        <strong>{source.type === 'remote' ? 'Remote catalog' : 'Mounted workspace'}</strong>
+                        <button
+                          type="button"
+                          className="panel-manager-icon-button"
+                          onClick={() => removeSource(index)}
+                          aria-label={`Remove source ${source.name}`}
+                        >
+                          <FiTrash2 />
+                        </button>
+                      </div>
+                      <div className="panel-manager-fields">
+                        <label>
+                          Name
+                          <input
+                            value={source.name}
+                            onChange={event => updateSource(index, { ...source, name: event.target.value })}
+                          />
+                        </label>
+                        {source.type === 'remote' ? (
+                          <>
+                            <label className="wide">
+                              Catalog URL
+                              <input
+                                value={source.catalogUrl}
+                                onChange={event => updateSource(index, { ...source, catalogUrl: event.target.value })}
+                              />
+                            </label>
+                            <label className="wide">
+                              Allowed release origins
+                              <textarea
+                                value={(source.allowedOrigins || []).join('\n')}
+                                onChange={event =>
+                                  updateSource(index, { ...source, allowedOrigins: splitLines(event.target.value) })
+                                }
+                                placeholder="https://releases.example.com"
+                              />
+                            </label>
+                            <label>
+                              Authorization environment
+                              <input
+                                value={source.authorizationEnv || ''}
+                                onChange={event =>
+                                  updateSource(index, { ...source, authorizationEnv: event.target.value || undefined })
+                                }
+                                placeholder="ROBOBOY_PANEL_SOURCE_PRIVATE_AUTHORIZATION"
+                              />
+                            </label>
+                            <label className="wide">
+                              Credentialed origins
+                              <textarea
+                                value={(source.authenticatedOrigins || []).join('\n')}
+                                onChange={event =>
+                                  updateSource(index, {
+                                    ...source,
+                                    authenticatedOrigins: splitLines(event.target.value),
+                                  })
+                                }
+                                placeholder="Defaults to the catalog origin"
+                              />
+                            </label>
+                          </>
+                        ) : (
+                          <>
+                            <label>
+                              Mounted root
+                              <input
+                                value={source.root || ''}
+                                onChange={event =>
+                                  updateSource(index, { ...source, root: event.target.value || undefined })
+                                }
+                              />
+                            </label>
+                            <label>
+                              Root environment
+                              <input
+                                value={source.rootEnv || ''}
+                                onChange={event =>
+                                  updateSource(index, { ...source, rootEnv: event.target.value || undefined })
+                                }
+                                placeholder="ROBOBOY_PANEL_WORKSPACE"
+                              />
+                            </label>
+                            <label className="wide">
+                              Repository directories
+                              <textarea
+                                value={source.repositories.join('\n')}
+                                onChange={event =>
+                                  updateSource(index, { ...source, repositories: splitLines(event.target.value) })
+                                }
+                                placeholder="my-panel"
+                              />
+                            </label>
+                          </>
+                        )}
+                      </div>
+                    </article>
+                  ))}
                 </div>
               </div>
-              <div className="panel-manager-sources">
-                {config.sources.map((source, index) => (
-                  <article key={`${source.type}-${index}`} className="panel-manager-source">
-                    <div className="panel-manager-source-title">
-                      <strong>{source.type === 'remote' ? 'Remote catalog' : 'Mounted workspace'}</strong>
-                      <button
-                        type="button"
-                        className="panel-manager-icon-button"
-                        onClick={() => removeSource(index)}
-                        aria-label={`Remove source ${source.name}`}
-                      >
-                        <FiTrash2 />
-                      </button>
-                    </div>
-                    <div className="panel-manager-fields">
-                      <label>
-                        Name
-                        <input
-                          value={source.name}
-                          onChange={event => updateSource(index, { ...source, name: event.target.value })}
-                        />
-                      </label>
-                      {source.type === 'remote' ? (
-                        <>
-                          <label className="wide">
-                            Catalog URL
-                            <input
-                              value={source.catalogUrl}
-                              onChange={event => updateSource(index, { ...source, catalogUrl: event.target.value })}
-                            />
-                          </label>
-                          <label className="wide">
-                            Allowed release origins
-                            <textarea
-                              value={(source.allowedOrigins || []).join('\n')}
-                              onChange={event =>
-                                updateSource(index, { ...source, allowedOrigins: splitLines(event.target.value) })
-                              }
-                              placeholder="https://releases.example.com"
-                            />
-                          </label>
-                          <label>
-                            Authorization environment
-                            <input
-                              value={source.authorizationEnv || ''}
-                              onChange={event =>
-                                updateSource(index, { ...source, authorizationEnv: event.target.value || undefined })
-                              }
-                              placeholder="ROBOBOY_PANEL_SOURCE_PRIVATE_AUTHORIZATION"
-                            />
-                          </label>
-                          <label className="wide">
-                            Credentialed origins
-                            <textarea
-                              value={(source.authenticatedOrigins || []).join('\n')}
-                              onChange={event =>
-                                updateSource(index, {
-                                  ...source,
-                                  authenticatedOrigins: splitLines(event.target.value),
-                                })
-                              }
-                              placeholder="Defaults to the catalog origin"
-                            />
-                          </label>
-                        </>
-                      ) : (
-                        <>
-                          <label>
-                            Mounted root
-                            <input
-                              value={source.root || ''}
-                              onChange={event =>
-                                updateSource(index, { ...source, root: event.target.value || undefined })
-                              }
-                            />
-                          </label>
-                          <label>
-                            Root environment
-                            <input
-                              value={source.rootEnv || ''}
-                              onChange={event =>
-                                updateSource(index, { ...source, rootEnv: event.target.value || undefined })
-                              }
-                              placeholder="ROBOBOY_PANEL_WORKSPACE"
-                            />
-                          </label>
-                          <label className="wide">
-                            Repository directories
-                            <textarea
-                              value={source.repositories.join('\n')}
-                              onChange={event =>
-                                updateSource(index, { ...source, repositories: splitLines(event.target.value) })
-                              }
-                              placeholder="my-panel"
-                            />
-                          </label>
-                        </>
-                      )}
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </section>
+            </details>
 
-            <section>
-              <div className="panel-manager-section-heading">
-                <div>
-                  <h3>Advanced selection</h3>
-                  <p>The desired state the manager resolves. Panels above are the view of what it produced.</p>
-                </div>
-              </div>
-              <div className="panel-manager-selection">
-                <label>
-                  Mode
-                  <select
-                    value={config.selection.mode}
-                    onChange={event => {
-                      const mode = event.target.value as 'all' | 'include' | 'none';
-                      setConfig({
-                        ...config,
-                        selection: mode === 'include' ? { mode, panelIds: installedIds } : { mode },
-                      });
-                    }}
-                  >
-                    <option value="all">All discovered panels</option>
-                    <option value="include">Only listed panel IDs</option>
-                    <option value="none">No external panels</option>
-                  </select>
-                </label>
-                {config.selection.mode === 'include' && (
-                  <label className="wide">
-                    Panel IDs
-                    <textarea
-                      value={config.selection.panelIds.join('\n')}
-                      onChange={event =>
+            <details className="panel-manager-disclosure">
+              <summary>
+                <span>
+                  <strong>Selection rules</strong>
+                  <small>Mode: {config.selection.mode === 'include' ? 'listed panels' : config.selection.mode}</small>
+                </span>
+                <FiChevronDown aria-hidden="true" />
+              </summary>
+              <div className="panel-manager-disclosure-content">
+                <p className="panel-manager-disclosure-description">
+                  The desired state the manager resolves. Panels above are the view of what it produced.
+                </p>
+                <div className="panel-manager-selection">
+                  <label>
+                    Mode
+                    <select
+                      value={config.selection.mode}
+                      onChange={event => {
+                        const mode = event.target.value as 'all' | 'include' | 'none';
                         setConfig({
                           ...config,
-                          selection: { mode: 'include', panelIds: splitLines(event.target.value) },
-                        })
-                      }
-                    />
+                          selection: mode === 'include' ? { mode, panelIds: installedIds } : { mode },
+                        });
+                      }}
+                    >
+                      <option value="all">All discovered panels</option>
+                      <option value="include">Only listed panel IDs</option>
+                      <option value="none">No external panels</option>
+                    </select>
                   </label>
-                )}
+                  {config.selection.mode === 'include' && (
+                    <label className="wide">
+                      Panel IDs
+                      <textarea
+                        value={config.selection.panelIds.join('\n')}
+                        onChange={event =>
+                          setConfig({
+                            ...config,
+                            selection: { mode: 'include', panelIds: splitLines(event.target.value) },
+                          })
+                        }
+                      />
+                    </label>
+                  )}
+                </div>
               </div>
-            </section>
+            </details>
 
             <section className="panel-manager-review">
               <div className="panel-manager-section-heading">
                 <div>
-                  <h3>Review</h3>
-                  <p>Preview verifies manifests and bundle hashes without changing the active registry.</p>
+                  <h3>{preview ? 'Ready to apply' : 'Review changes'}</h3>
+                  <p>
+                    {preview
+                      ? 'Verified against the selected sources. Review access before applying this exact plan.'
+                      : 'Preview verifies manifests and bundle hashes without changing the active registry.'}
+                  </p>
                 </div>
                 <button
                   type="button"
+                  className="panel-manager-button"
                   onClick={() => void requestPreview()}
                   disabled={busy || config.sources.length === 0}
                 >
@@ -606,7 +754,7 @@ const PanelManagerDialog = ({
               </div>
               {preview && (
                 <>
-                  <div className="panel-manager-change-summary">
+                  <div className="panel-manager-change-summary" role="status">
                     {preview.changes.length === 0
                       ? 'No installed-panel changes.'
                       : preview.changes.map(change => (
@@ -652,7 +800,7 @@ const PanelManagerDialog = ({
             </section>
           </div>
         )}
-        {error && (
+        {config && error && (
           <div className="panel-manager-message error" role="alert">
             {error}
           </div>


### PR DESCRIPTION
## Summary
- replace enable and disable actions with accessible compact switches
- clarify installed, available, bundled, disabled, and pending plan states
- make panel cards and advanced controls compact and responsive down to narrow mobile widths
- polish loading, empty, catalog error, review, and retry feedback states
- preserve the existing verified preview, trust confirmation, and exact-plan apply workflow

## Verification
- npm test -- --run
- npm run lint
- npm run build
- responsive browser QA at 1280px, 390px, and 320px